### PR TITLE
feat:switch toplevel keys to chainNames

### DIFF
--- a/deployments/warp-deployments.yaml
+++ b/deployments/warp-deployments.yaml
@@ -4,39 +4,27 @@
 ---
 description: Hyperlane Warp Route artifacts
 timestamp: 2023-09-23T16:00:00.000Z
+deployer: Abacus Works (Hyperlane)
 version:
   major: 1
   minor: 0
   patch: 0
 data:
   # Example deployment config and artifacts:
-  - timestamp: 2023-08-01T12:00:00.000Z
-    deployer: Abacus Works (Hyperlane)
-    config:
-      base:
-        chainName: anvil1
-        type: collateral 
-        address: 0x1234567890123456789012345678901234567890 # Required for collateral types
-        # isNft: true # If the token is an NFT (ERC721) set to true
-        # owner: 0x123 # Optional owner address for synthetic token
-        # mailbox: 0x123 # Optional mailbox address route
-        # interchainGasPaymaster: 0x123 # Optional interchainGasPaymaster address
-      synthetics:
-        - chainName: anvil2
-        # You can optionally set the token metadata otherwise the base tokens will be used
-        # name: "MySyntheticToken"
-        # symbol: "MST"
-        # totalSupply: 10000000
-    artifacts:
-      base:
-        type: collateral
-        chainName: anvil1
-        address: 0x1234567890123456789012345678901234567890
-        routerAddress: 0x1234567890123456789012345678901234567890
-        symbol: MYTOK
-        name: MyToken
-        decimals: 18
-      synthetics:
-        - chainName: anvil2
-          type: synthetic
-          routerAddress: 0x1234567890123456789012345678901234567890
+  config:
+    anvil1:
+      protocolType: cosmos
+      type: collateral
+      hypAddress: "anvil1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa"
+      tokenAddress: "ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7"
+      name: "CollateralInu"
+      symbol: "COLL"
+      decimals: 18
+      ibcDenom: "ibc/1234567890123456789012345678901234567890"
+    anvil2:
+      protocolType: ethereum
+      type: synthetic
+      hypAddress: "0x1234567890123456789012345678901234567890"
+      name: "WrappedCollateralInu"
+      symbol: "WCOLL"
+      decimals: 18


### PR DESCRIPTION
the monorepo has chainName as the toplevel keys so to maintain consistency adjusted the warp route config to match it.