### PR TITLE
feat: add holesky addresses

### DIFF
--- a/.changeset/nice-bottles-unite.md
+++ b/.changeset/nice-bottles-unite.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add Holesky AVS deployment addresses

--- a/.changeset/nice-bottles-unite.md
+++ b/.changeset/nice-bottles-unite.md
@@ -1,5 +1,0 @@
----
-'@hyperlane-xyz/registry': patch
----
-
-Add Holesky AVS deployment addresses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperlane-xyz/registry
 
+## 1.1.1
+
+### Patch Changes
+
+- 0d3d6ea: Add Holesky AVS deployment addresses
+
 ## 1.1.0
 
 ### Minor Changes

--- a/deployments/avs/README.md
+++ b/deployments/avs/README.md
@@ -1,0 +1,13 @@
+# Hyperlane AVS
+
+This directory contains the core AVS deployment addressES like the `HyperlaneServiceManager` and the `ECDSAStakeRegistry`. In the future, it'll also house the different `IRemoteChallenger` configuration which will be used to verify the remote fraud attestation from different Hyperlane applications.
+
+## Structure
+
+## Schema
+
+Coming soon.
+
+## Contributing
+
+New challenegers can be added manually.

--- a/deployments/avs/ethereum.yaml
+++ b/deployments/avs/ethereum.yaml
@@ -1,0 +1,3 @@
+contracts:
+  avsDirectory: "0x135DDa560e946695d6f155dACaFC6f1F25C1F5AF"
+  proxyAdmin: "0x75EE15Ee1B4A75Fa3e2fDF5DF3253c25599cc659"

--- a/deployments/avs/holesky.yaml
+++ b/deployments/avs/holesky.yaml
@@ -1,4 +1,5 @@
 contracts:
+  avsDirectory: "0x055733000064333CaDDbC92763c58BF0192fFeBf"
   proxyAdmin: "0x6e7b29cb2a7617405b4d30c6f84bbd51b4bb4be8"
   ecdsaStakeRegistry: "0x275aCcCa81cAD931dC6fB6E49ED233Bc99Bed4A7"
   hyperlaneServiceManager: "0x16B710b86CAd07E6F1C531861a16F5feC29dba37"

--- a/deployments/avs/holesky.yaml
+++ b/deployments/avs/holesky.yaml
@@ -1,0 +1,4 @@
+contracts:
+  proxyAdmin: "0x6e7b29cb2a7617405b4d30c6f84bbd51b4bb4be8"
+  ecdsaStakeRegistry: "0x275aCcCa81cAD931dC6fB6E49ED233Bc99Bed4A7"
+  hyperlaneServiceManager: "0x16B710b86CAd07E6F1C531861a16F5feC29dba37"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperlane-xyz/registry",
   "description": "A collection of configs, artifacts, and schemas for Hyperlane",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "yaml": "^2",
     "zod": "^3.21.2"


### PR DESCRIPTION
### Description

#### Type: New AVS Deployment

#### Network(s): Holesky

#### Other notes

ProxyAdmin with owner: 0xfaD1C94469700833717Fa8a3017278BC1cA8031C

### Backward compatibility

Yes

### Testing


Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?

No
