### PR TITLE
Add mantapacific gnosisSafeTransactionServiceUrl

### DIFF
--- a/.changeset/clean-carrots-report.md
+++ b/.changeset/clean-carrots-report.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add more arbitrum rpcUrls

--- a/.changeset/shaggy-chicken-hunt.md
+++ b/.changeset/shaggy-chicken-hunt.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added mantapacific gnosisSafeTransactionServiceUrl

--- a/chains/arbitrum/metadata.yaml
+++ b/chains/arbitrum/metadata.yaml
@@ -26,5 +26,7 @@ nativeToken:
   symbol: ETH
 protocol: ethereum
 rpcUrls:
+  - http: https://arbitrum.llamarpc.com
+  - http: https://rpc.ankr.com/arbitrum
   - http: https://arb1.arbitrum.io/rpc
 technicalStack: arbitrumnitro

--- a/chains/mantapacific/metadata.yaml
+++ b/chains/mantapacific/metadata.yaml
@@ -13,7 +13,7 @@ displayName: Manta Pacific
 displayNameShort: Manta
 domainId: 169
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://transaction.safe.manta.network/
+gnosisSafeTransactionServiceUrl: https://transaction.safe.manta.network
 isTestnet: false
 name: mantapacific
 nativeToken:

--- a/chains/mantapacific/metadata.yaml
+++ b/chains/mantapacific/metadata.yaml
@@ -13,6 +13,7 @@ displayName: Manta Pacific
 displayNameShort: Manta
 domainId: 169
 gasCurrencyCoinGeckoId: ethereum
+gnosisSafeTransactionServiceUrl: https://transaction.safe.manta.network/
 isTestnet: false
 name: mantapacific
 nativeToken:


### PR DESCRIPTION
### Description

#### Type: Updated Network

#### Network(s): mantapacific

Added the gnosisSafeTransactionServiceUrl

#### Type: Updated Network

#### Network(s): arbitrum

Added more RPC URLs for arbitrum, the one before was unusable with very frequent RPCs being made. E.g. when using the CLI's `ism read`, a bunch of these ultimately resulting in a throw:
```
Slow response from provider #0.
Slow response from provider #0.
All providers timed out for method call
All providers timed out for method call
```

#### Other notes

### Backward compatibility

<!--
Are these changes backward compatible? Note, additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
