### PR TITLE
Add missing neutron token definitions to warp configs

### DIFF
--- a/.changeset/real-peaches-sneeze.md
+++ b/.changeset/real-peaches-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add missing neutron token definitions to warp route configs

--- a/deployments/warp_routes/ECLIP/arbitrum-neutron-config.yaml
+++ b/deployments/warp_routes/ECLIP/arbitrum-neutron-config.yaml
@@ -20,3 +20,10 @@ tokens:
     name: Eclipse Fi
     standard: EvmHypSynthetic
     symbol: ECLIP
+  - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+    chainName: neutron
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA.n
+    standard: CosmosIbc
+    symbol: TIA.n

--- a/deployments/warp_routes/TIA/arbitrum-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/arbitrum-neutron-config.yaml
@@ -25,3 +25,10 @@ tokens:
     name: TIA.n
     standard: EvmHypSynthetic
     symbol: TIA.n
+  - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+    chainName: neutron
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA.n
+    standard: CosmosIbc
+    symbol: TIA.n

--- a/deployments/warp_routes/TIA/manta-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/manta-neutron-config.yaml
@@ -25,3 +25,10 @@ tokens:
     name: TIA.n
     standard: EvmHypSynthetic
     symbol: TIA.n
+  - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+    chainName: neutron
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA.n
+    standard: CosmosIbc
+    symbol: TIA.n


### PR DESCRIPTION
### Description

Add missing neutron token definitions to warp configs. Required for use with WarpCore which will look for these tokens when they're used for IGP fees.

#### Other notes

### Backward compatibility

Yes

### Testing

Tested in UI
