### PR TITLE
[WIP] feat(registry): expose getWarpArtifactsPaths

### DIFF
--- a/src/registry/BaseRegistry.ts
+++ b/src/registry/BaseRegistry.ts
@@ -28,7 +28,7 @@ export abstract class BaseRegistry implements IRegistry {
     return 'chains';
   }
 
-  protected getWarpArtifactsPaths({ tokens }: WarpCoreConfig) {
+  getWarpArtifactsPaths({ tokens }: WarpCoreConfig) {
     if (!tokens.length) throw new Error('No tokens provided in config');
     const symbols = new Set<string>(tokens.map((token) => token.symbol.toUpperCase()));
     if (symbols.size !== 1)

--- a/src/registry/IRegistry.ts
+++ b/src/registry/IRegistry.ts
@@ -43,4 +43,5 @@ export interface IRegistry {
 
   addWarpRoute(config: WarpCoreConfig): MaybePromise<void>;
   // TODO define more deployment artifact related methods
+  getWarpArtifactsPaths(config: WarpCoreConfig): MaybePromise<{ configPath: string; addressesPath: string }>;
 }


### PR DESCRIPTION
### Description

#### Type: <New | Updated> <Network | Warp Route>

#### Network(s): <Network Name(s)>

#### Other notes

### Backward compatibility

<!--
Are these changes backward compatible? Note, additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
