### PR TITLE
chore: update `gnosisSafeTransactionServiceUrl` for scroll

### DIFF
--- a/chains/scroll/metadata.yaml
+++ b/chains/scroll/metadata.yaml
@@ -12,7 +12,7 @@ chainId: 534352
 displayName: Scroll
 domainId: 534352
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://transaction.safe.scroll.xyz
+gnosisSafeTransactionServiceUrl: https://safe-transaction-scroll.safe.global
 name: scroll
 nativeToken:
   decimals: 18


### PR DESCRIPTION
update scroll safe url, taken from https://docs.safe.global/core-api/transaction-service-supported-networks