### PR TITLE
fix: sort entries in YAML as required by CI

### DIFF
--- a/.changeset/kind-olives-change.md
+++ b/.changeset/kind-olives-change.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Sort entries in YAML as required by CI

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { stringify } from 'yaml';
 
 export function toYamlString(data: any, prefix?: string): string {
-  const yamlString = stringify(data);
+  const yamlString = stringify(data, { indent: 2, sortMapEntries: true });
   return prefix ? `${prefix}\n${yamlString}` : yamlString;
 }
 


### PR DESCRIPTION
### Description

#### Type: Fix

#### Other notes

fixes #84 

### Backward compatibility

Yes
It's only sorting in YAML strings generated.

### Testing

I've tested with success the unit test below by just adding the logging of the metadata added from mock:
```
yarn mocha --config .mocharc.json './test/unit/registry.test.ts' -f 'Adds a new chain' --exit


  Registry utilities
Chain mockchain not found in registry, adding it now
Added chain {
  blockExplorers: [
    {
      apiUrl: 'https://api.etherscan.io/api',
      family: 'etherscan',
      name: 'Etherscan',
      url: 'https://etherscan.io'
    },
    {
      apiUrl: 'https://eth.blockscout.com/api',
      family: 'blockscout',
      name: 'Blockscout',
      url: 'https://blockscout.com/eth/mainnet'
    }
  ],
  blocks: { confirmations: 7, estimateBlockTime: 13, reorgPeriod: 14 },
  chainId: 1,
  displayName: 'Ethereum',
  domainId: 1,
  gnosisSafeTransactionServiceUrl: 'https://safe-transaction-mainnet.safe.global/',
  name: 'mockchain',
  nativeToken: { decimals: 18, name: 'Ether', symbol: 'ETH' },
  protocol: 'ethereum',
  rpcUrls: [
    { http: 'https://ethereum.publicnode.com' },
    { http: 'https://cloudflare-eth.com' }
  ]
}
```