### PR TITLE
Update combined data

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.head_ref || github.sha }}
           # This action secret contains a fine-grained personal access token with permissions to read/write repo content
           # It is necessary because the default GITHUB_TOKEN cannot re-trigger workflows after pushing
-          token: ${{ secrets.COMBINE_CI_TOKEN }}
+          token: ${{ secrets.COMBINE_CI_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/cache@v4
         with:

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -600,6 +600,49 @@ linea:
   protocol: ethereum
   rpcUrls:
     - http: https://rpc.linea.build
+lukso:
+  blockExplorers:
+    - apiUrl: https://explorer.execution.mainnet.lukso.network/api
+      family: blockscout
+      name: LUKSO Mainnet Explorer
+      url: https://explorer.execution.mainnet.lukso.network
+  blocks:
+    confirmations: 1
+    estimateBlockTime: 12
+    reorgPeriod: 14
+  chainId: 42
+  displayName: LUKSO
+  domainId: 42
+  name: lukso
+  nativeToken:
+    decimals: 18
+    name: LYX
+    symbol: LYX
+  protocol: ethereum
+  rpcUrls:
+    - http: https://42.rpc.thirdweb.com
+luksotestnet:
+  blockExplorers:
+    - apiUrl: https://api.explorer.execution.testnet.lukso.network/api
+      family: blockscout
+      name: LUKSO Testnet Explorer
+      url: https://explorer.execution.testnet.lukso.network
+  blocks:
+    confirmations: 1
+    estimateBlockTime: 12
+    reorgPeriod: 14
+  chainId: 4201
+  displayName: LUKSO Testnet
+  domainId: 4201
+  isTestnet: true
+  name: luksotestnet
+  nativeToken:
+    decimals: 18
+    name: LYXt
+    symbol: LYXt
+  protocol: ethereum
+  rpcUrls:
+    - http: https://rpc.testnet.lukso.network
 mantapacific:
   blockExplorers:
     - apiUrl: https://pacific-explorer.manta.network/api


### PR DESCRIPTION
An issue I didn't consider: PRs from 3rd parties don't have the secret token required for the combine job to commit. Running the update manually and adding a fallback to the default github secret token, which has the downside of not re-triggering CIs but should still be able to commit if their repo settings allow it.