### PR TITLE
fix: Set correct redstone gnosisSafeTransactionServiceUrl in metadata

### DIFF
--- a/.changeset/large-pans-obey.md
+++ b/.changeset/large-pans-obey.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Fix Redstone Safe transaction service URL

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -1143,7 +1143,7 @@ redstone:
   displayName: Redstone
   domainId: 690
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://transaction-zora.safe.optimism.io
+  gnosisSafeTransactionServiceUrl: https://transaction-redstone.safe.optimism.io
   name: redstone
   nativeToken:
     decimals: 18

--- a/chains/redstone/metadata.yaml
+++ b/chains/redstone/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: Redstone
 domainId: 690
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://transaction-zora.safe.optimism.io
+gnosisSafeTransactionServiceUrl: https://transaction-redstone.safe.optimism.io
 name: redstone
 nativeToken:
   decimals: 18


### PR DESCRIPTION
### Description
- Fix redstone gnosisSafeTransactionServiceUrl 

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
