### PR TITLE
fix: changeset ci check is no-op on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,5 +126,8 @@ jobs:
             **/node_modules
             .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-      - name: changeset
-        run: yarn changeset status --since origin/main
+      - name: Check branch prefix and run changeset status
+        run: |
+          if [[ "${{ github.head_ref }}" != changeset-release/main ]]; then
+            yarn changeset status --since origin/main
+          fi


### PR DESCRIPTION
**problem**
the changeset release PRs get errors saying "Some packages have been changed but no changesets were found", because part of the process is moving the changeset contents to the readme and cleaning up all changesets. This is now a problem because the CI check expects there to be a changeset.

- fix: changeset ci check is no-op on release PRs