### PR TITLE
fix: check changeset only on non-release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
         run: yarn run test:health
 
   changeset:
+    if: ${{ github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main' }}
     runs-on: ubuntu-latest
     needs: [install]
     steps:
@@ -126,13 +127,5 @@ jobs:
             **/node_modules
             .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-      - name: Check branch prefix and run changeset status
-        run: |
-          if [[ "${{ github.head_ref }}" == changeset-release/main || "$(gh pr view ${{ github.event.pull_request.number }} --json mergeStateStatus --jq '.mergeStateStatus')" == "MERGE_QUEUE" ]]; then
-            echo "Branch is 'changeset-release/main' or PR is in the merge queue. Passing automatically."
-            exit 0
-          else
-            yarn changeset status --since origin/main
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: changeset
+        run: yarn changeset status --since origin/main


### PR DESCRIPTION
- fix: check changeset only on non-release PRs
- will be skipped if branch is `changeset-release/main` or running in the merge queue