### PR TITLE
fix: replace incorrect zetachain rpcUrl, add sepolia Safe transaction service URL

### DIFF
--- a/.changeset/great-crews-draw.md
+++ b/.changeset/great-crews-draw.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added the Safe transaction service URL for sepolia

--- a/.changeset/tough-parrots-suffer.md
+++ b/.changeset/tough-parrots-suffer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Replace a testnet Zetachain URL from the mainnet metadata

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -1319,6 +1319,7 @@ sepolia:
     url: https://www.hyperlane.xyz
   displayName: Sepolia
   domainId: 11155111
+  gnosisSafeTransactionServiceUrl: https://safe-transaction-sepolia.safe.global
   isTestnet: true
   name: sepolia
   nativeToken:

--- a/chains/sepolia/metadata.yaml
+++ b/chains/sepolia/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Sepolia
 domainId: 11155111
+gnosisSafeTransactionServiceUrl: https://safe-transaction-sepolia.safe.global
 isTestnet: true
 name: sepolia
 nativeToken:

--- a/chains/zetachain/metadata.yaml
+++ b/chains/zetachain/metadata.yaml
@@ -24,4 +24,4 @@ nativeToken:
 protocol: ethereum
 rpcUrls:
   - http: https://zetachain-evm.blockpi.network/v1/rpc/public
-  - http: https://zetachain-athens-evm.blockpi.network/v1/rpc/public
+  - http: https://zetachain-mainnet.g.allthatnode.com/archive/evm


### PR DESCRIPTION
### Description

- This "athens" zetachain rpcUrl is actually a testnet URL - oops! Replaced with another URL from https://www.zetachain.com/docs/reference/network/api/#public-endpoints. This should fix some scripts that were falling back to this URL
- Added the Sepolia Safe transaction service URL - I used this for some testing recently

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
