### PR TITLE
fix(deployments): Fix TIA-mantapacific-neutron warp config

### DIFF
--- a/.changeset/three-socks-prove.md
+++ b/.changeset/three-socks-prove.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Fix TIA-mantapacific-neutron warp config by removing reference to the TIA arbitrum neutron HypCollateral router

--- a/deployments/warp_routes/TIA/mantapacific-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/mantapacific-neutron-config.yaml
@@ -25,14 +25,6 @@ tokens:
     name: TIA.n
     standard: EvmHypSynthetic
     symbol: TIA.n
-  - addressOrDenom: neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
-    chainName: neutron
-    collateralAddressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-    decimals: 6
-    logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: TIA.
-    standard: CwHypCollateral
-    symbol: TIA.n
   - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
     chainName: neutron
     decimals: 6

--- a/deployments/warp_routes/TIA/mantapacific-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/mantapacific-neutron-config.yaml
@@ -19,7 +19,7 @@ tokens:
   - addressOrDenom: "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa"
     chainName: mantapacific
     connections:
-      - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
+      - token: cosmos|neutron|neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA.n


### PR DESCRIPTION
### Description

- Fix TIA-mantapacific-neutron warp config by removing reference to the Tia arbitrum neutron HypCollateral router 