### PR TITLE
chore: lower the polygon confirmations

### DIFF
--- a/.changeset/brave-gorillas-refuse.md
+++ b/.changeset/brave-gorillas-refuse.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Changed Polygon confirmations 200 -> 3

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -1513,7 +1513,7 @@ polygon:
       name: PolygonScan
       url: https://polygonscan.com
   blocks:
-    confirmations: 200
+    confirmations: 3
     estimateBlockTime: 2
     reorgPeriod: 256
   chainId: 137

--- a/chains/polygon/metadata.yaml
+++ b/chains/polygon/metadata.yaml
@@ -5,7 +5,7 @@ blockExplorers:
     name: PolygonScan
     url: https://polygonscan.com
 blocks:
-  confirmations: 1
+  confirmations: 3
   estimateBlockTime: 2
   reorgPeriod: 256
 chainId: 137

--- a/chains/polygon/metadata.yaml
+++ b/chains/polygon/metadata.yaml
@@ -5,7 +5,7 @@ blockExplorers:
     name: PolygonScan
     url: https://polygonscan.com
 blocks:
-  confirmations: 200
+  confirmations: 1
   estimateBlockTime: 2
   reorgPeriod: 256
 chainId: 137


### PR DESCRIPTION
### Description

- Makes it 3, matching what we use internally in infra deployments https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/mainnet3/chains.ts#L23
- A response to https://discord.com/channels/935678348330434570/961710804011458621/1276321809872191572
- waiting 200 blocks for each transaction is unreasonable and results in timeouts in the CLI

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
