### PR TITLE
feat: add an archive RPC node for Neutron

### DIFF
--- a/.changeset/witty-zoos-doubt.md
+++ b/.changeset/witty-zoos-doubt.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added an archive node RPC for Neutron

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -1943,6 +1943,7 @@ neutron:
   restUrls:
     - http: https://rest-lb.neutron.org
   rpcUrls:
+    - http: https://rpc-arch.mainnet.neutron.tm.p2p.org
     - http: https://rpc-kralum.neutron-1.neutron.org
   slip44: 118
   transactionOverrides:

--- a/chains/neutron/metadata.yaml
+++ b/chains/neutron/metadata.yaml
@@ -29,6 +29,7 @@ protocol: cosmos
 restUrls:
   - http: https://rest-lb.neutron.org
 rpcUrls:
+  - http: https://rpc-arch.mainnet.neutron.tm.p2p.org
   - http: https://rpc-kralum.neutron-1.neutron.org
 slip44: 118
 transactionOverrides:


### PR DESCRIPTION
### Description

As Cosmos indexing requires an archive node, adding a public one

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
