### PR TITLE
Update pulsechain metadata

### DIFF
--- a/.changeset/hot-flies-speak.md
+++ b/.changeset/hot-flies-speak.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/registry": patch
+---
+
+Update pulsechain metadata

--- a/chains/pulsechain/metadata.yaml
+++ b/chains/pulsechain/metadata.yaml
@@ -15,7 +15,7 @@ chainId: 369
 deployer:
   name: Abacus Works
   url: https://www.hyperlane.xyz
-displayName: Pulsechain
+displayName: PulseChain
 domainId: 369
 gasCurrencyCoinGeckoId: pulsechain
 isTestnet: false

--- a/chains/pulsechain/metadata.yaml
+++ b/chains/pulsechain/metadata.yaml
@@ -1,19 +1,24 @@
 blockExplorers:
   - apiUrl: https://api.scan.pulsechain.com/api
     family: blockscout
-    name: PulseChain Explorer
-    url: https://scan.pulsechainfoundation.org
+    name: Pulsechain Explorer
+    url: https://oldscan.gopulse.com/#/
+  - apiUrl: https://api.scan.pulsechain.com/api
+    family: blockscout
+    name: Otterscan
+    url: https://otter.pulsechain.com
 blocks:
   confirmations: 1
-  estimateBlockTime: 2
+  estimateBlockTime: 10
   reorgPeriod: 0
 chainId: 369
 deployer:
   name: Abacus Works
   url: https://www.hyperlane.xyz
-displayName: PulseChain
+displayName: Pulsechain
 domainId: 369
 gasCurrencyCoinGeckoId: pulsechain
+isTestnet: false
 name: pulsechain
 nativeToken:
   decimals: 18
@@ -21,4 +26,5 @@ nativeToken:
   symbol: PLS
 protocol: ethereum
 rpcUrls:
+  - http: https://pulsechain-rpc.publicnode.com
   - http: https://rpc.pulsechain.com

--- a/chains/pulsechain/metadata.yaml
+++ b/chains/pulsechain/metadata.yaml
@@ -4,7 +4,7 @@ blockExplorers:
     name: Pulsechain Explorer
     url: https://oldscan.gopulse.com/#/
   - apiUrl: https://api.scan.pulsechain.com/api
-    family: blockscout
+    family: other
     name: Otterscan
     url: https://otter.pulsechain.com
 blocks:


### PR DESCRIPTION
### Description

This PR adds the additional configurations for PulseChain to the Hyperlane registry. 
The changes include:

**Block explorers:** 
- Explorer 1
apiUrl: https://api.scan.pulsechain.com/api
family: blockscout
name: Pulsechain Explorer
url: https://oldscan.gopulse.com/#/

- Explorer 2
apiUrl: https://api.scan.pulsechain.com/api
family: other
name: Otterscan
url: https://otter.pulsechain.com

**Increased estimateBlockTime**
estimateBlockTime: 10

**Additional RPC URL:** 
https://pulsechain-rpc.publicnode.com

### Backward compatibility
Yes

### Testing
Yes

I have tested the PulseChain configurations locally and successfully deployed the core contracts to PulseChain with the configurations I have updated. But, while trying to deploy the contracts with the chain configurations in the registry, the transaction is not going through, and showing a pending status.

