### PR TITLE
fix: update warp route addresses

### DIFF
--- a/.changeset/smooth-ducks-wave.md
+++ b/.changeset/smooth-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+update sol/eclipse warp route addresses

--- a/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-addresses.yaml
+++ b/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-addresses.yaml
@@ -1,4 +1,4 @@
 eclipsemainnet:
-  synthetic: TBD
+  synthetic: FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
 solanamainnet:
-  native: TBD
+  native: 8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc

--- a/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-addresses.yaml
+++ b/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-addresses.yaml
@@ -1,4 +1,4 @@
 eclipsemainnet:
-  synthetic: GLpdg3jt6w4eVYiCMhokVZ4mX6hmRvPhcL5RoCjzGr5k
+  synthetic: TBD
 solanamainnet:
-  native: 4UMNyNWW75zo69hxoJaRX5iXNUa5FdRPZZa9vDVCiESg
+  native: TBD

--- a/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-config.yaml
+++ b/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-config.yaml
@@ -1,19 +1,19 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: TBD
+  - addressOrDenom: FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
     chainName: eclipsemainnet
-    collateralAddressOrDenom: TBD
+    collateralAddressOrDenom: BeRUj3h7BqkbdfFU7FBNYbodgf8GCHodzKvF9aVjNNfL
     connections:
-      - token: sealevel|solanamainnet|TBD
+      - token: sealevel|solanamainnet|8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
     decimals: 9
     logoURI: /deployments/warp_routes/SOL/logo.svg
     name: Solana
     standard: SealevelHypSynthetic
     symbol: SOL
-  - addressOrDenom: TBD
+  - addressOrDenom: 8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
     chainName: solanamainnet
     connections:
-      - token: sealevel|eclipsemainnet|TBD
+      - token: sealevel|eclipsemainnet|FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
     decimals: 9
     logoURI: /deployments/warp_routes/SOL/logo.svg
     name: Solana

--- a/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-config.yaml
+++ b/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-config.yaml
@@ -1,19 +1,19 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: GLpdg3jt6w4eVYiCMhokVZ4mX6hmRvPhcL5RoCjzGr5k
+  - addressOrDenom: TBD
     chainName: eclipsemainnet
-    collateralAddressOrDenom: 8SuhHnSEogAN2udZsoychjTafnaGgM9MCidYZEP8vuVY
+    collateralAddressOrDenom: TBD
     connections:
-      - token: sealevel|solanamainnet|4UMNyNWW75zo69hxoJaRX5iXNUa5FdRPZZa9vDVCiESg
+      - token: sealevel|solanamainnet|TBD
     decimals: 9
     logoURI: /deployments/warp_routes/SOL/logo.svg
     name: Solana
     standard: SealevelHypSynthetic
     symbol: SOL
-  - addressOrDenom: 4UMNyNWW75zo69hxoJaRX5iXNUa5FdRPZZa9vDVCiESg
+  - addressOrDenom: TBD
     chainName: solanamainnet
     connections:
-      - token: sealevel|eclipsemainnet|GLpdg3jt6w4eVYiCMhokVZ4mX6hmRvPhcL5RoCjzGr5k
+      - token: sealevel|eclipsemainnet|TBD
     decimals: 9
     logoURI: /deployments/warp_routes/SOL/logo.svg
     name: Solana


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
