### PR TITLE
fix(warp): Update solana eclipse USDC warp route addresses

### DIFF
--- a/.changeset/breezy-poets-suffer.md
+++ b/.changeset/breezy-poets-suffer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update Solana/Eclipse/Ethereum USDC warp route addresses

--- a/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-addresses.yaml
+++ b/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-addresses.yaml
@@ -1,6 +1,6 @@
 eclipsemainnet:
-  synthetic: D6k6T3G74ij6atCtBiWBs5TbFa1hFVcrFUSGZHuV7q3Z
+  synthetic: EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
 ethereum:
   collateral: "0xFc8F5272d690cf19732a7eD6f246aDF5fB8708dB"
 solanamainnet:
-  collateral: Fefw54S6NDdwNbPngPePvW4tiFTFQDT7gBPvFoDFeGqg
+  collateral: 3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm

--- a/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-addresses.yaml
+++ b/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-addresses.yaml
@@ -1,6 +1,6 @@
 eclipsemainnet:
   synthetic: EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
 ethereum:
-  collateral: "0xFc8F5272d690cf19732a7eD6f246aDF5fB8708dB"
+  collateral: "0xe1De9910fe71cC216490AC7FCF019e13a34481D7"
 solanamainnet:
   collateral: 3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm

--- a/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-config.yaml
+++ b/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-config.yaml
@@ -4,28 +4,28 @@ tokens:
     chainName: ethereum
     collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
     connections:
-      - token: sealevel|eclipsemainnet|D6k6T3G74ij6atCtBiWBs5TbFa1hFVcrFUSGZHuV7q3Z
+      - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
-  - addressOrDenom: D6k6T3G74ij6atCtBiWBs5TbFa1hFVcrFUSGZHuV7q3Z
+  - addressOrDenom: EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
     chainName: eclipsemainnet
-    collateralAddressOrDenom: AvieFG3iLSaETVWyd1Urov5fZHy888aATC2QtGTAEhf8
+    collateralAddressOrDenom: AKEWE7Bgh87GPp171b4cJPSSZfmZwQ3KaqYqXoKLNAEE
     connections:
       - token: ethereum|ethereum|0xFc8F5272d690cf19732a7eD6f246aDF5fB8708dB
-      - token: sealevel|solanamainnet|Fefw54S6NDdwNbPngPePvW4tiFTFQDT7gBPvFoDFeGqg
+      - token: sealevel|solanamainnet|3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: SealevelHypSynthetic
     symbol: USDC
-  - addressOrDenom: Fefw54S6NDdwNbPngPePvW4tiFTFQDT7gBPvFoDFeGqg
+  - addressOrDenom: 3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
     chainName: solanamainnet
     collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
     connections:
-      - token: sealevel|eclipsemainnet|D6k6T3G74ij6atCtBiWBs5TbFa1hFVcrFUSGZHuV7q3Z
+      - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC

--- a/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-config.yaml
+++ b/deployments/warp_routes/USDC/ethereum-eclipsemainnet-solanamainnet-config.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0xFc8F5272d690cf19732a7eD6f246aDF5fB8708dB"
+  - addressOrDenom: "0xe1De9910fe71cC216490AC7FCF019e13a34481D7"
     chainName: ethereum
     collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
     connections:
@@ -14,7 +14,7 @@ tokens:
     chainName: eclipsemainnet
     collateralAddressOrDenom: AKEWE7Bgh87GPp171b4cJPSSZfmZwQ3KaqYqXoKLNAEE
     connections:
-      - token: ethereum|ethereum|0xFc8F5272d690cf19732a7eD6f246aDF5fB8708dB
+      - token: ethereum|ethereum|0xe1De9910fe71cC216490AC7FCF019e13a34481D7
       - token: sealevel|solanamainnet|3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg


### PR DESCRIPTION
### Description
- update USDC solana, ethereum, eclipse warp config
<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
