### PR TITLE
chore: add deployer name for AW testnets

### DIFF
--- a/.changeset/two-boxes-compete.md
+++ b/.changeset/two-boxes-compete.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Set deployer names for known AW testnets

--- a/chains/camptestnet/metadata.yaml
+++ b/chains/camptestnet/metadata.yaml
@@ -9,6 +9,9 @@ blocks:
   estimateBlockTime: 2
   reorgPeriod: 1
 chainId: 325000
+deployer:
+  name: Abacus Works
+  url: https://www.hyperlane.xyz
 displayName: Camp Network Testnet V2
 domainId: 325000
 gasCurrencyCoinGeckoId: ethereum

--- a/chains/formtestnet/metadata.yaml
+++ b/chains/formtestnet/metadata.yaml
@@ -9,6 +9,9 @@ blocks:
   estimateBlockTime: 2
   reorgPeriod: 1
 chainId: 132902
+deployer:
+  name: Abacus Works
+  url: https://www.hyperlane.xyz
 displayName: Form Testnet
 domainId: 132902
 gasCurrencyCoinGeckoId: ethereum

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -567,6 +567,9 @@ camptestnet:
     estimateBlockTime: 2
     reorgPeriod: 1
   chainId: 325000
+  deployer:
+    name: Abacus Works
+    url: https://www.hyperlane.xyz
   displayName: Camp Network Testnet V2
   domainId: 325000
   gasCurrencyCoinGeckoId: ethereum
@@ -1254,6 +1257,9 @@ formtestnet:
     estimateBlockTime: 2
     reorgPeriod: 1
   chainId: 132902
+  deployer:
+    name: Abacus Works
+    url: https://www.hyperlane.xyz
   displayName: Form Testnet
   domainId: 132902
   gasCurrencyCoinGeckoId: ethereum
@@ -3031,6 +3037,9 @@ soneiumtestnet:
     estimateBlockTime: 2
     reorgPeriod: 1
   chainId: 1946
+  deployer:
+    name: Abacus Works
+    url: https://www.hyperlane.xyz
   displayName: Soneium Minato Testnet
   domainId: 1946
   gasCurrencyCoinGeckoId: ethereum
@@ -3124,6 +3133,9 @@ suavetoliman:
     estimateBlockTime: 4
     reorgPeriod: 1
   chainId: 33626250
+  deployer:
+    name: Abacus Works
+    url: https://www.hyperlane.xyz
   displayName: SUAVE Toliman Testnet
   domainId: 33626250
   gasCurrencyCoinGeckoId: ethereum
@@ -3147,6 +3159,9 @@ superpositiontestnet:
     estimateBlockTime: 1
     reorgPeriod: 1
   chainId: 98985
+  deployer:
+    name: Abacus Works
+    url: https://www.hyperlane.xyz
   displayName: Superposition Testnet
   domainId: 98985
   gasCurrencyCoinGeckoId: superposition

--- a/chains/soneiumtestnet/metadata.yaml
+++ b/chains/soneiumtestnet/metadata.yaml
@@ -9,6 +9,9 @@ blocks:
   estimateBlockTime: 2
   reorgPeriod: 1
 chainId: 1946
+deployer:
+  name: Abacus Works
+  url: https://www.hyperlane.xyz
 displayName: Soneium Minato Testnet
 domainId: 1946
 gasCurrencyCoinGeckoId: ethereum

--- a/chains/suavetoliman/metadata.yaml
+++ b/chains/suavetoliman/metadata.yaml
@@ -9,6 +9,9 @@ blocks:
   estimateBlockTime: 4
   reorgPeriod: 1
 chainId: 33626250
+deployer:
+  name: Abacus Works
+  url: https://www.hyperlane.xyz
 displayName: SUAVE Toliman Testnet
 domainId: 33626250
 gasCurrencyCoinGeckoId: ethereum

--- a/chains/superpositiontestnet/metadata.yaml
+++ b/chains/superpositiontestnet/metadata.yaml
@@ -9,6 +9,9 @@ blocks:
   estimateBlockTime: 1
   reorgPeriod: 1
 chainId: 98985
+deployer:
+  name: Abacus Works
+  url: https://www.hyperlane.xyz
 displayName: Superposition Testnet
 domainId: 98985
 gasCurrencyCoinGeckoId: superposition

--- a/test/unit/chains.test.ts
+++ b/test/unit/chains.test.ts
@@ -10,9 +10,11 @@ describe('Chain metadata', () => {
       ChainMetadataSchema.parse(metadata);
     });
 
-    // it(`${chain} metadata contains deployer details`, () => {
-    //   expect(metadata.deployer).not.to.be.undefined;
-    // });
+    it(`${chain} metadata contains deployer details if mailbox address is defined`, () => {
+      if (chainAddresses[chain] && chainAddresses[chain].mailboxAddress) {
+        expect(metadata.deployer).not.to.be.undefined;
+      }
+    });
 
     it(`${chain} metadata has 'index.from' defined if technicalStack is arbitrumnitro`, () => {
       if (metadata.technicalStack === ChainTechnicalStack.ArbitrumNitro) {


### PR DESCRIPTION
chore: add deployer name for AW testnets

did a pass on all chains, seems only recent testnets were affected