### PR TITLE
fix: remove gasLimit overrides for rootstock/rootstocktestnet

### DIFF
--- a/.changeset/honest-points-smoke.md
+++ b/.changeset/honest-points-smoke.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Remove gasLimit override for rootstock and roostocktestnet

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -2826,8 +2826,6 @@ rootstock:
     - http: https://rpc.mainnet.rootstock.io/kXhXHf6TnnfW1POvr4UT0YUvujmuju-M
     - http: https://public-node.rsk.co
     - http: https://mycrypto.rsk.co
-  transactionOverrides:
-    gasLimit: 6800000
 rootstocktestnet:
   blockExplorers:
     - apiUrl: https://rootstock-testnet.blockscout.com/api
@@ -2853,8 +2851,6 @@ rootstocktestnet:
   protocol: ethereum
   rpcUrls:
     - http: https://rpc.testnet.rootstock.io/YZIZHxGCQAryubOWH7LjdtjNkSDb5J-T
-  transactionOverrides:
-    gasLimit: 6800000
 saakuru:
   blockExplorers:
     - apiUrl: https://explorer.saakuru.network/api

--- a/chains/rootstock/metadata.yaml
+++ b/chains/rootstock/metadata.yaml
@@ -29,7 +29,3 @@ rpcUrls:
   - http: https://rpc.mainnet.rootstock.io/kXhXHf6TnnfW1POvr4UT0YUvujmuju-M
   - http: https://public-node.rsk.co
   - http: https://mycrypto.rsk.co
-transactionOverrides:
-  # Maximum gas the operation can afford. It's an upper limit the user sets to prevent losing gas.
-  # Reference: https://dev.rootstock.io/concepts/rbtc/gas/
-  gasLimit: 6800000

--- a/chains/rootstocktestnet/metadata.yaml
+++ b/chains/rootstocktestnet/metadata.yaml
@@ -26,5 +26,3 @@ rpcUrls:
   # Recommended way is to get a new APIKEY whoever wants to run Hyperlane on Rootstock.
   # RPC API Dashboard: https://dashboard.rpc.rootstock.io
   - http: https://rpc.testnet.rootstock.io/YZIZHxGCQAryubOWH7LjdtjNkSDb5J-T
-transactionOverrides:
-  gasLimit: 6800000


### PR DESCRIPTION
### Description

fix: remove gasLimit overrides for rootstock/rootstocktestnet

hardcoding the gaslimit this high causes problems in the relayer, as it will want the IGP payment to cover this limit. if the gas limit is set to the block gas limit, this is likely never going to happen. so we remove the overrides.

note, the overrides have been removed in the recently deployed agent configs. this is to update the default registry metadata to match our deployed agent setup.

### Backward compatibility

y

### Testing

manual