### PR TITLE
feat: Add configuration for currencies supported on particular chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 # build artifacts
 dist
 tmp
+
+# ides
+.idea

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -2435,6 +2435,17 @@ neutron:
     - http: https://rpc-arch.mainnet.neutron.tm.p2p.org
     - http: https://rpc-kralum.neutron-1.neutron.org
   slip44: 118
+  supportedCurrencies:
+    - description: It is not TIA on Celestia chain. It is TIA bridged to Neutron chain.
+      identifier: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+      symbol: TIA
+      uuid: 0b03525c-ec50-4176-9318-b70636e0c054
+    - identifier: ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
+      symbol: ATOM
+      uuid: 5b606c8a-795b-4d82-ad8e-4181943a2ef9
+    - identifier: ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349
+      symbol: USDC.AXL
+      uuid: 3315c687-7e20-4a43-a9f2-3f118da7f77b
   transactionOverrides:
     gasPrice: "0.0075"
 ngmi:

--- a/chains/neutron/metadata.yaml
+++ b/chains/neutron/metadata.yaml
@@ -34,3 +34,14 @@ rpcUrls:
 slip44: 118
 transactionOverrides:
   gasPrice: "0.0075"
+supportedCurrencies:
+  - symbol: TIA
+    description: "It is not TIA on Celestia chain. It is TIA bridged to Neutron chain."
+    identifier: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+    uuid: 0b03525c-ec50-4176-9318-b70636e0c054
+  - symbol: ATOM
+    identifier: ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
+    uuid: 5b606c8a-795b-4d82-ad8e-4181943a2ef9
+  - symbol: USDC.AXL
+    identifier: ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349
+    uuid: 3315c687-7e20-4a43-a9f2-3f118da7f77b

--- a/chains/schema.json
+++ b/chains/schema.json
@@ -293,32 +293,6 @@
           "type": "object",
           "additionalProperties": {},
           "description": "Properties to include when forming transaction requests."
-        },
-        "supportedCurrencies": {
-          "type": "array",
-          "description": "Contains an array of crypto currencies which can be used to express transaction fees in this particular chain as well as being transferred on this chain.",
-          "items": {
-            "type": "object",
-            "description": "Mapping from identifier of a crypto currency used in chain transaction to UUID specifically generated for this crypto currency.",
-            "properties": {
-              "symbol": {
-                "type": "string",
-                "description": "The symbol of the crypto currency so that human can understand what crypto currency is it."
-              },
-              "description": {
-                "type": "string",
-                "description": "Free form field for any additional information about the crypto currency for human users in the case when symbol is not enough."
-              },
-              "identifier": {
-                "type": "string",
-                "description": "The identifier from chain transaction. It can be any string. Scraper should be able to generate the identifier using the data available on a transaction."
-              },
-              "uuid": {
-                "type": "string",
-                "description": "UUID generated specifically to represent this crypto currency on this chain."
-              }
-            }
-          }
         }
       },
       "required": [

--- a/chains/schema.json
+++ b/chains/schema.json
@@ -293,6 +293,32 @@
           "type": "object",
           "additionalProperties": {},
           "description": "Properties to include when forming transaction requests."
+        },
+        "supportedCurrencies": {
+          "type": "array",
+          "description": "Contains an array of crypto currencies which can be used to express transaction fees in this particular chain as well as being transferred on this chain.",
+          "items": {
+            "type": "object",
+            "description": "Mapping from identifier of a crypto currency used in chain transaction to UUID specifically generated for this crypto currency.",
+            "properties": {
+              "symbol": {
+                "type": "string",
+                "description": "The symbol of the crypto currency so that human can understand what crypto currency is it."
+              },
+              "description": {
+                "type": "string",
+                "description": "Free form field for any additional information about the crypto currency for human users in the case when symbol is not enough."
+              },
+              "identifier": {
+                "type": "string",
+                "description": "The identifier from chain transaction. It can be any string. Scraper should be able to generate the identifier using the data available on a transaction."
+              },
+              "uuid": {
+                "type": "string",
+                "description": "UUID generated specifically to represent this crypto currency on this chain."
+              }
+            }
+          }
         }
       },
       "required": [


### PR DESCRIPTION
### Description

Add configuration for currencies supported on particular chain. The configuration allows to specify mapping from the identifier of crypto currency which is used in transaction object to UUID which uniquely identify this crypto currency for Hyperlane agent.

### Related issues

- Contributes to https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4641

### Backward compatibility

Yes

### Testing

Generated agent config (`mainnet-config.json`) and started Scraper with it just to check that new field does not break it.
