### PR TITLE
Add TIA token to new Stride deploys to work in warp UI

### DIFF
--- a/.changeset/neat-adults-march.md
+++ b/.changeset/neat-adults-march.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add TIA token for IGP support in UI

--- a/deployments/warp_routes/TIA/eclipse-stride-config.yaml
+++ b/deployments/warp_routes/TIA/eclipse-stride-config.yaml
@@ -28,3 +28,11 @@ tokens:
     name: Celestia
     standard: SealevelHypSynthetic
     symbol: TIA
+  # TIA, required for the IGP payment but not connected to any other chain
+  - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+    chainName: stride
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: Celstia
+    standard: CosmosIbc
+    symbol: TIA

--- a/deployments/warp_routes/TIA/eclipse-stride-config.yaml
+++ b/deployments/warp_routes/TIA/eclipse-stride-config.yaml
@@ -33,6 +33,6 @@ tokens:
     chainName: stride
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: Celstia
+    name: Celestia
     standard: CosmosIbc
     symbol: TIA

--- a/deployments/warp_routes/stTIA/eclipse-stride-config.yaml
+++ b/deployments/warp_routes/stTIA/eclipse-stride-config.yaml
@@ -33,6 +33,6 @@ tokens:
     chainName: stride
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: Celstia
+    name: Celestia
     standard: CosmosIbc
     symbol: TIA

--- a/deployments/warp_routes/stTIA/eclipse-stride-config.yaml
+++ b/deployments/warp_routes/stTIA/eclipse-stride-config.yaml
@@ -28,3 +28,11 @@ tokens:
     name: Stride Staked TIA
     standard: SealevelHypSynthetic
     symbol: stTIA
+  # TIA, required for the IGP payment but not connected to any other chain
+  - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+    chainName: stride
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: Celstia
+    standard: CosmosIbc
+    symbol: TIA


### PR DESCRIPTION
### Description

- The TIA token itself must be present if it's used as the IGP token
- Tested locally

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
