### PR TITLE
fix: specify coinGeckoId for Solana warp route under the collateral token

### DIFF
--- a/.changeset/sweet-trees-perform.md
+++ b/.changeset/sweet-trees-perform.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Specify coinGeckoId for Solana warp route under collateral

--- a/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-config.yaml
+++ b/deployments/warp_routes/SOL/eclipsemainnet-solanamainnet-config.yaml
@@ -2,7 +2,6 @@
 tokens:
   - addressOrDenom: FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
     chainName: eclipsemainnet
-    coinGeckoId: solana
     collateralAddressOrDenom: BeRUj3h7BqkbdfFU7FBNYbodgf8GCHodzKvF9aVjNNfL
     connections:
       - token: sealevel|solanamainnet|8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
@@ -13,6 +12,7 @@ tokens:
     symbol: SOL
   - addressOrDenom: 8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
     chainName: solanamainnet
+    coinGeckoId: solana
     connections:
       - token: sealevel|eclipsemainnet|FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
     decimals: 9


### PR DESCRIPTION
### Description

Made a small mistake - probably should add a CI check for stuff like this

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
