### PR TITLE
feat: add coinGeckoId to a bunch of new warp routes

### DIFF
--- a/.changeset/ninety-lizards-lay.md
+++ b/.changeset/ninety-lizards-lay.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add coinGeckoId to a bunch of new warp routes

--- a/.changeset/ninety-lizards-lay.md
+++ b/.changeset/ninety-lizards-lay.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': minor
 ---
 
-Add coinGeckoId to a bunch of new warp routes
+Add coinGeckoId to a bunch of new warp routes, set Endurance USDC token to EvmHypCollateral

--- a/deployments/warp_routes/CBBTC/base-zeronetwork-config.yaml
+++ b/deployments/warp_routes/CBBTC/base-zeronetwork-config.yaml
@@ -3,6 +3,7 @@ tokens:
   - addressOrDenom: "0x2A872Ae01375A5ca7e044cb0e75cb97621Ca954A"
     chainName: base
     collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    coinGeckoId: coinbase-wrapped-btc
     connections:
       - token: ethereum|zeronetwork|0x3f7F02453518A55C0c6F89F0A6A8ab6c22Da01Df
     decimals: 8

--- a/deployments/warp_routes/CBBTC/base-zeronetwork-config.yaml
+++ b/deployments/warp_routes/CBBTC/base-zeronetwork-config.yaml
@@ -2,8 +2,8 @@
 tokens:
   - addressOrDenom: "0x2A872Ae01375A5ca7e044cb0e75cb97621Ca954A"
     chainName: base
-    collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
     coinGeckoId: coinbase-wrapped-btc
+    collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
     connections:
       - token: ethereum|zeronetwork|0x3f7F02453518A55C0c6F89F0A6A8ab6c22Da01Df
     decimals: 8

--- a/deployments/warp_routes/CBBTC/ethereum-flowmainnet-config.yaml
+++ b/deployments/warp_routes/CBBTC/ethereum-flowmainnet-config.yaml
@@ -3,6 +3,7 @@ tokens:
   - addressOrDenom: "0xfF5C22ea202258143557f6cc3bDe174dde6E8fE1"
     chainName: ethereum
     collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
+    coinGeckoId: coinbase-wrapped-btc
     connections:
       - token: ethereum|flowmainnet|0xA0197b2044D28b08Be34d98b23c9312158Ea9A18
     decimals: 8

--- a/deployments/warp_routes/CBBTC/ethereum-flowmainnet-config.yaml
+++ b/deployments/warp_routes/CBBTC/ethereum-flowmainnet-config.yaml
@@ -2,8 +2,8 @@
 tokens:
   - addressOrDenom: "0xfF5C22ea202258143557f6cc3bDe174dde6E8fE1"
     chainName: ethereum
-    collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
     coinGeckoId: coinbase-wrapped-btc
+    collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
     connections:
       - token: ethereum|flowmainnet|0xA0197b2044D28b08Be34d98b23c9312158Ea9A18
     decimals: 8

--- a/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88"
     chainName: arbitrum
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
       - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
@@ -22,6 +23,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0x885598858b68562FE5001F8eE022522313257C7a"
     chainName: base
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
@@ -42,6 +44,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0xA900858116D7605a01AfC7595450d8D78555Bc83"
     chainName: blast
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
@@ -62,6 +65,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0xFc9F3387eb4385785420f661CE7A9E486f404b8F"
     chainName: bsc
+    coinGeckoId: ethereum
     collateralAddressOrDenom: "0x2170Ed0880ac9A755fd29B2688956BD959F933F8"
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
@@ -82,6 +86,7 @@ tokens:
     standard: EvmHypCollateral
     symbol: ETH
   - addressOrDenom: "0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0"
+    coinGeckoId: ethereum
     chainName: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
@@ -103,6 +108,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c"
     chainName: gnosis
+    coinGeckoId: ethereum
     collateralAddressOrDenom: "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1"
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
@@ -124,6 +130,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0xA92D6084709469A2B2339919FfC568b7C5D7888D"
     chainName: mantle
+    coinGeckoId: ethereum
     collateralAddressOrDenom: "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
@@ -145,6 +152,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0xef043d913b196dc87CB1256850894AA72DAD5933"
     chainName: mode
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
@@ -165,6 +173,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539"
     chainName: optimism
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
@@ -185,6 +194,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779"
     chainName: polygon
+    coinGeckoId: ethereum
     collateralAddressOrDenom: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
@@ -206,6 +216,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0xF85379CF296f84871dee84826153d6F5ccA9de3B"
     chainName: scroll
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
@@ -226,6 +237,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0x2E2c9BeE342398E26156Da12769262087de6EdDC"
     chainName: zeronetwork
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
@@ -246,6 +258,7 @@ tokens:
     symbol: ETH
   - addressOrDenom: "0xA900858116D7605a01AfC7595450d8D78555Bc83"
     chainName: zoramainnet
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a

--- a/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
@@ -86,8 +86,8 @@ tokens:
     standard: EvmHypCollateral
     symbol: ETH
   - addressOrDenom: "0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0"
-    coinGeckoId: ethereum
     chainName: ethereum
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
       - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a

--- a/deployments/warp_routes/POL/polygon-zeronetwork-config.yaml
+++ b/deployments/warp_routes/POL/polygon-zeronetwork-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x76Af114f7Ebe96C02a3e4AB10f1511a7A66057A1"
     chainName: polygon
+    coinGeckoId: polygon-ecosystem-token
     connections:
       - token: ethereum|zeronetwork|0x3d7dBc3dab88C0e3c3Dcb6901a6163bb02417e6B
     decimals: 18

--- a/deployments/warp_routes/USDB/blast-zeronetwork-config.yaml
+++ b/deployments/warp_routes/USDB/blast-zeronetwork-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x1CF975C9bF2DF76c43a14405066007f8393142E9"
     chainName: blast
+    coinGeckoId: usdb
     collateralAddressOrDenom: "0x4300000000000000000000000000000000000003"
     connections:
       - token: ethereum|zeronetwork|0xB11a9606f3e470abD00b1bbB28AffAC3126c2Acb

--- a/deployments/warp_routes/USDC/arbitrum-base-endurance-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-base-endurance-config.yaml
@@ -30,5 +30,5 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
-    standard: EvmHypCollateral
+    standard: EvmHypCollateralFiat
     symbol: USDC

--- a/deployments/warp_routes/USDC/arbitrum-base-endurance-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-base-endurance-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
     chainName: arbitrum
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|endurance|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
@@ -12,6 +13,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
     chainName: base
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|endurance|0xa66a9C0112a428d407388Db87659E9C66F3eF29c

--- a/deployments/warp_routes/USDC/arbitrum-base-ethereum-lisk-optimism-polygon-zeronetwork-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-base-ethereum-lisk-optimism-polygon-zeronetwork-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x14adE09354a20ed23E690afc803E64E60a84e7D3"
     chainName: arbitrum
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|base|0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D
@@ -16,6 +17,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D"
     chainName: base
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
@@ -30,6 +32,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xa6826c7Dd74c4e1B400AEF4a362692f99872F5F5"
     chainName: ethereum
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
@@ -57,6 +60,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xcA11d580faaE3E6993aA230f437079ac21f3078a"
     chainName: optimism
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
     connections:
       - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
@@ -71,6 +75,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xb805ee88eE76EcE03ba503A2634344804a0Ea59A"
     chainName: polygon
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
     connections:
       - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
@@ -85,6 +90,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
     chainName: zeronetwork
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0x6a6394F47DD0BAF794808F2749C09bd4Ee874E70"
     connections:
       - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3

--- a/deployments/warp_routes/WBTC/ethereum-mode-scroll-zeronetwork-config.yaml
+++ b/deployments/warp_routes/WBTC/ethereum-mode-scroll-zeronetwork-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x745C75868237F3635c486fe166639Cc4706512A9"
     chainName: ethereum
+    coinGeckoId: wrapped-bitcoin
     collateralAddressOrDenom: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
     connections:
       - token: ethereum|mode|0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1
@@ -14,6 +15,7 @@ tokens:
     symbol: WBTC
   - addressOrDenom: "0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1"
     chainName: mode
+    coinGeckoId: wrapped-bitcoin
     collateralAddressOrDenom: "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF"
     connections:
       - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9
@@ -26,6 +28,7 @@ tokens:
     symbol: WBTC
   - addressOrDenom: "0x10a5263ACED246fCD0977f1a3C6A238a14183096"
     chainName: scroll
+    coinGeckoId: wrapped-bitcoin
     collateralAddressOrDenom: "0x3C1BCa5a656e69edCD0D4E36BEbb3FcDAcA60Cf1"
     connections:
       - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9


### PR DESCRIPTION
### Description

- Adds coinGeckoId to recent warp routes, incl zeronetwork warp routes. Used for warp monitor purposes
- Sets the endurance USDC to a EvmHypCollateralFiat instead of EvmHypCollateral

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
