### PR TITLE
feat: add apxETH and ezSOL deploys to Eclipse

### DIFF
--- a/.changeset/serious-beers-sleep.md
+++ b/.changeset/serious-beers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add apxETH and ezSOL deploys to Eclipse

--- a/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-addresses.yaml
+++ b/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-addresses.yaml
@@ -1,0 +1,4 @@
+eclipsemainnet:
+  synthetic: 9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
+ethereum:
+  collateral: "0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c"

--- a/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-config.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c"
+    chainName: ethereum
+    # Not directly listed on Coingecko, but Ethereum is a close approximation
+    coinGeckoId: ethereum
+    collateralAddressOrDenom: "0x9ba021b0a9b958b5e75ce9f6dff97c7ee52cb3e6"
+    connections:
+      - token: sealevel|eclipsemainnet|9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
+    decimals: 18
+    logoURI: /deployments/warp_routes/EZSOL/logo.svg
+    name: Autocompounding Pirex Ether
+    standard: EvmHypCollateral
+    symbol: apxETH
+  - addressOrDenom: 9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: 6AjQBsySS1FtQmA7a4oYc6GYpHBTDqtSswptsVSTz3Tv
+    connections:
+      - token: ethereum|ethereum|0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c
+    decimals: 9
+    logoURI: /deployments/warp_routes/APXETH/logo.svg
+    name: Autocompounding Pirex Ether
+    standard: SealevelHypSynthetic
+    symbol: apxETH

--- a/deployments/warp_routes/EZSOL/eclipsemainnet-solanamainnet-addresses.yaml
+++ b/deployments/warp_routes/EZSOL/eclipsemainnet-solanamainnet-addresses.yaml
@@ -1,0 +1,4 @@
+eclipsemainnet:
+  synthetic: CshTfxXWMvnRAwBTCjQ4577bkP5po5ZuNG1QTuQxA5Au
+solanamainnet:
+  collateral: b5pMgizA9vrGRt3hVqnU7vUVGBQUnLpwPzcJhG1ucyQ

--- a/deployments/warp_routes/EZSOL/eclipsemainnet-solanamainnet-config.yaml
+++ b/deployments/warp_routes/EZSOL/eclipsemainnet-solanamainnet-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: CshTfxXWMvnRAwBTCjQ4577bkP5po5ZuNG1QTuQxA5Au
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: Fu5P5ikrnQ8BKZECJ1XeeDAaTgWJUrcjw8JmFrNA8TJk
+    connections:
+      - token: sealevel|solanamainnet|b5pMgizA9vrGRt3hVqnU7vUVGBQUnLpwPzcJhG1ucyQ
+    decimals: 9
+    logoURI: /deployments/warp_routes/EZSOL/logo.svg
+    name: Renzo Restaked SOL
+    standard: SealevelHypSynthetic
+    symbol: ezSOL
+  - addressOrDenom: b5pMgizA9vrGRt3hVqnU7vUVGBQUnLpwPzcJhG1ucyQ
+    chainName: solanamainnet
+    coinGeckoId: renzo-restaked-sol
+    collateralAddressOrDenom: ezSoL6fY1PVdJcJsUpe5CM3xkfmy3zoVCABybm5WtiC
+    connections:
+      - token: sealevel|eclipsemainnet|CshTfxXWMvnRAwBTCjQ4577bkP5po5ZuNG1QTuQxA5Au
+    decimals: 9
+    logoURI: /deployments/warp_routes/EZSOL/logo.svg
+    name: Renzo Restaked SOL
+    standard: SealevelHypCollateral
+    symbol: ezSOL

--- a/deployments/warp_routes/tETH/ethereum-eclipsemainnet-config.yaml
+++ b/deployments/warp_routes/tETH/ethereum-eclipsemainnet-config.yaml
@@ -18,7 +18,6 @@ tokens:
     connections:
       - token: ethereum|ethereum|0xc2495f3183F043627CAECD56dAaa726e3B2D9c09
     decimals: 9
-    foreignDecimals: 18
     logoURI: /deployments/warp_routes/tETH/logo.svg
     name: tETH
     standard: SealevelHypSynthetic


### PR DESCRIPTION
### Description

- Deploys apxETH between Ethereum and Eclipse, and ezSOL between Solana and Eclipse

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
