### PR TITLE
Add LINEA mainnet route for DAI

### DIFF
--- a/.changeset/stupid-avocados-give.md
+++ b/.changeset/stupid-avocados-give.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Added LINEA mainnet route for DAI, accessible from Arbitrum, BSC, Polygon

--- a/deployments/warp_routes/DAI/arbitrum-bsc-linea-polygon-addresses.yaml
+++ b/deployments/warp_routes/DAI/arbitrum-bsc-linea-polygon-addresses.yaml
@@ -1,0 +1,8 @@
+arbitrum:
+  collateral: "0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552"
+bsc:
+  collateral: "0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552"
+linea:
+  synthetic: "0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b"
+polygon:
+  collateral: "0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552"

--- a/deployments/warp_routes/DAI/arbitrum-bsc-linea-polygon-config.yaml
+++ b/deployments/warp_routes/DAI/arbitrum-bsc-linea-polygon-config.yaml
@@ -8,6 +8,7 @@ tokens:
       - token: ethereum|linea|0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b
       - token: ethereum|polygon|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
     decimals: 18
+    logoURI: /deployments/warp_routes/DAI/logo.svg
     name: Dai Stablecoin
     standard: EvmHypCollateral
     symbol: DAI
@@ -19,6 +20,7 @@ tokens:
       - token: ethereum|linea|0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b
       - token: ethereum|polygon|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
     decimals: 18
+    logoURI: /deployments/warp_routes/DAI/logo.svg
     name: Dai Stablecoin
     standard: EvmHypCollateral
     symbol: DAI
@@ -29,6 +31,7 @@ tokens:
       - token: ethereum|bsc|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
       - token: ethereum|polygon|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
     decimals: 18
+    logoURI: /deployments/warp_routes/DAI/logo.svg
     name: Dai Stablecoin
     standard: EvmHypSynthetic
     symbol: DAI
@@ -40,6 +43,7 @@ tokens:
       - token: ethereum|bsc|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
       - token: ethereum|linea|0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b
     decimals: 18
+    logoURI: /deployments/warp_routes/DAI/logo.svg
     name: Dai Stablecoin
     standard: EvmHypCollateral
     symbol: DAI

--- a/deployments/warp_routes/DAI/arbitrum-bsc-linea-polygon-config.yaml
+++ b/deployments/warp_routes/DAI/arbitrum-bsc-linea-polygon-config.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552"
+    chainName: arbitrum
+    collateralAddressOrDenom: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+    connections:
+      - token: ethereum|bsc|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+      - token: ethereum|linea|0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b
+      - token: ethereum|polygon|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+    decimals: 18
+    name: Dai Stablecoin
+    standard: EvmHypCollateral
+    symbol: DAI
+  - addressOrDenom: "0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552"
+    chainName: bsc
+    collateralAddressOrDenom: "0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3"
+    connections:
+      - token: ethereum|arbitrum|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+      - token: ethereum|linea|0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b
+      - token: ethereum|polygon|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+    decimals: 18
+    name: Dai Stablecoin
+    standard: EvmHypCollateral
+    symbol: DAI
+  - addressOrDenom: "0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b"
+    chainName: linea
+    connections:
+      - token: ethereum|arbitrum|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+      - token: ethereum|bsc|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+      - token: ethereum|polygon|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+    decimals: 18
+    name: Dai Stablecoin
+    standard: EvmHypSynthetic
+    symbol: DAI
+  - addressOrDenom: "0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552"
+    chainName: polygon
+    collateralAddressOrDenom: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+    connections:
+      - token: ethereum|arbitrum|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+      - token: ethereum|bsc|0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552
+      - token: ethereum|linea|0xdF17853b7a56499d7d6CAe0cEa3003EfC8257B5b
+    decimals: 18
+    name: Dai Stablecoin
+    standard: EvmHypCollateral
+    symbol: DAI


### PR DESCRIPTION
### Description

Added LINEA mainnet route for DAI, accessible from Arbitrum, BSC, Polygon
New routes for DAI: 
1) Arbitrum - Linea
2) BSC - Linea
3) Polygon - Linea

### Backward compatibility

Yes

### Testing

All routes Linea - Arbitrum/BSC/Polygon successfully tested here https://hyperlane.superbridge.app/?hyperlaneWarpRoutes=172c7756-8e8c-4672-814b-9c01d9b48cd6