### PR TITLE
feat(warp): Update FastUSD ethereum sei collateral address

### DIFF
--- a/.changeset/rotten-rice-refuse.md
+++ b/.changeset/rotten-rice-refuse.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Update FastUSD ethereum sei collateral address to stake deUSD

--- a/deployments/warp_routes/FASTUSD/ethereum-sei-config.yaml
+++ b/deployments/warp_routes/FASTUSD/ethereum-sei-config.yaml
@@ -12,9 +12,9 @@ tokens:
     symbol: fastUSD
   - addressOrDenom: "0x9AD81058c6C3Bf552C9014CB30E824717A0ee21b"
     chainName: ethereum
-    # Unique setup where deUSD is deposited as collateral on Ethereum and fastUSD is minted as a synthetic on Sei
+    # Unique setup where staked deUSD is deposited as collateral on Ethereum and fastUSD is minted as a synthetic on Sei
     coinGeckoId: elixir-deusd
-    collateralAddressOrDenom: "0x15700B564Ca08D9439C58cA5053166E8317aa138"
+    collateralAddressOrDenom: "0x5C5b196aBE0d54485975D1Ec29617D42D9198326"
     connections:
       - token: ethereum|sei|0xeA895A7Ff45d8d3857A04c1E38A362f3bd9a076f
     decimals: 18


### PR DESCRIPTION
### Description

- Update FastUSD ethereum sei collateral address to stake deUSD, this is in response to an upgrade made by elixir to the warp route 
