### PR TITLE
fix: remove skip ci from workflow

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -58,7 +58,7 @@ jobs:
           CHANGES=$(git status -s)
           if [[ ! -z $CHANGES ]]; then
             git add .
-            git commit -m "Update chain metadata and address files [skip ci]"
+            git commit -m "Update chain metadata and address files"
             git push
           else
             echo "No changes to commit."

--- a/.github/workflows/optimize-svg.yml
+++ b/.github/workflows/optimize-svg.yml
@@ -54,7 +54,7 @@ jobs:
           CHANGES=$(git status -s)
           if [[ ! -z $CHANGES ]]; then
             git add .
-            git commit -m "Optimize SVG files [skip ci]" 
+            git commit -m "Optimize SVG files" 
             git push
           else
             echo "No changes to commit."


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

When both combine or optimize-svg have changes, whoever finishes last would not be able to push because the other one already commited changes. I removed [skip ci] because it is not necessary and the initial thought was that it would loop but that should not be the case. Once one of the workflow updates it will trigger another check and if the other workflow has changes it will check again and do the proper changes.

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
Manual
