### PR TITLE
feat(warp-route): added the USDT warp route from ethereum to superseed

### DIFF
--- a/.changeset/gorgeous-rivers-shake.md
+++ b/.changeset/gorgeous-rivers-shake.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+add the USDT warp route from ethereum to superseed

--- a/deployments/warp_routes/USDT/ethereum-superseed-addresses.yaml
+++ b/deployments/warp_routes/USDT/ethereum-superseed-addresses.yaml
@@ -1,0 +1,4 @@
+ethereum:
+  collateral: "0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3"
+superseed:
+  synthetic: "0xc5068BB6803ADbe5600DE5189fe27A4dAcE31170"

--- a/deployments/warp_routes/USDT/ethereum-superseed-config.yaml
+++ b/deployments/warp_routes/USDT/ethereum-superseed-config.yaml
@@ -16,6 +16,7 @@ tokens:
     connections:
       - token: ethereum|ethereum|0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3
     decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
     standard: EvmHypSynthetic
     symbol: USDT

--- a/deployments/warp_routes/USDT/ethereum-superseed-config.yaml
+++ b/deployments/warp_routes/USDT/ethereum-superseed-config.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3"
+    chainName: ethereum
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+    connections:
+      - token: ethereum|superseed|0xc5068BB6803ADbe5600DE5189fe27A4dAcE31170
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    standard: EvmHypCollateral
+    symbol: USDT
+  - addressOrDenom: "0xc5068BB6803ADbe5600DE5189fe27A4dAcE31170"
+    chainName: superseed
+    connections:
+      - token: ethereum|ethereum|0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3
+    decimals: 6
+    name: Tether USD
+    standard: EvmHypSynthetic
+    symbol: USDT


### PR DESCRIPTION
### Description

Adds the USDT warp route artifacts for connecting ethereum and superseed

### Backward compatibility

- YES

### Testing

- CLI
- Ran UI locally
