### PR TITLE
feat: add rstETH warp route from ethereum to zircuit

### DIFF
--- a/.changeset/early-olives-appear.md
+++ b/.changeset/early-olives-appear.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add rstETH/ethereum-zircuit Warp Route

--- a/deployments/warp_routes/rstETH/ethereum-zircuit-addresses.yaml
+++ b/deployments/warp_routes/rstETH/ethereum-zircuit-addresses.yaml
@@ -1,0 +1,4 @@
+ethereum:
+  collateral: "0x18E5D2ae4fb6F5Cf4e6C5D493C4d0F027FAe5054"
+zircuit:
+  synthetic: "0xc701aE35d83c812822c992aB293E4e3fAF6E9D3B"

--- a/deployments/warp_routes/rstETH/ethereum-zircuit-config.yaml
+++ b/deployments/warp_routes/rstETH/ethereum-zircuit-config.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x18E5D2ae4fb6F5Cf4e6C5D493C4d0F027FAe5054"
+    chainName: ethereum
+    collateralAddressOrDenom: "0x7a4EffD87C2f3C55CA251080b1343b605f327E3a"
+    connections:
+      - token: ethereum|zircuit|0xc701aE35d83c812822c992aB293E4e3fAF6E9D3B
+    decimals: 18
+    name: Restaking Vault ETH
+    standard: EvmHypCollateral
+    symbol: rstETH
+  - addressOrDenom: "0xc701aE35d83c812822c992aB293E4e3fAF6E9D3B"
+    chainName: zircuit
+    connections:
+      - token: ethereum|ethereum|0x18E5D2ae4fb6F5Cf4e6C5D493C4d0F027FAe5054
+    decimals: 18
+    name: Restaking Vault ETH
+    standard: EvmHypSynthetic
+    symbol: rstETH


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

Adds the rstETH warp route artifacts to connect ethereum and zircuit

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
CLI
