### PR TITLE
feat: add pndr bsc-ethereum-lumiaprism logo

### DIFF
--- a/.changeset/popular-ducks-thank.md
+++ b/.changeset/popular-ducks-thank.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add PNDR/bsc-ethereum-lumiaprism logoURI field"

--- a/deployments/warp_routes/PNDR/bsc-ethereum-lumiaprism-config.yaml
+++ b/deployments/warp_routes/PNDR/bsc-ethereum-lumiaprism-config.yaml
@@ -27,8 +27,8 @@ tokens:
     connections:
       - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
       - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
-    logoURI: /deployments/warp_routes/PNDR/logo.jpeg
     decimals: 18
+    logoURI: /deployments/warp_routes/PNDR/logo.jpeg
     name: Ponder
     standard: EvmHypSynthetic
     symbol: PNDR

--- a/deployments/warp_routes/PNDR/bsc-ethereum-lumiaprism-config.yaml
+++ b/deployments/warp_routes/PNDR/bsc-ethereum-lumiaprism-config.yaml
@@ -8,6 +8,7 @@ tokens:
       - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
       - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
     decimals: 18
+    logoURI: /deployments/warp_routes/PNDR/logo.jpeg
     name: Ponder
     standard: EvmHypCollateral
     symbol: PNDR
@@ -17,6 +18,7 @@ tokens:
       - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
       - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
     decimals: 18
+    logoURI: /deployments/warp_routes/PNDR/logo.jpeg
     name: Ponder
     standard: EvmHypSynthetic
     symbol: PNDR
@@ -25,6 +27,7 @@ tokens:
     connections:
       - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
       - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
+    logoURI: /deployments/warp_routes/PNDR/logo.jpeg
     decimals: 18
     name: Ponder
     standard: EvmHypSynthetic


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

Add PNDR/bsc-ethereum-lumiaprism logoURI field

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
Local Warp UI