### PR TITLE
fix: add missing coigecko id to form usdt and usdc routes

### DIFF
--- a/.changeset/kind-shrimps-begin.md
+++ b/.changeset/kind-shrimps-begin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+add missing coingecko id to form usdt and usdc routes

--- a/deployments/warp_routes/USDC/ethereum-form-config.yaml
+++ b/deployments/warp_routes/USDC/ethereum-form-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x3551011EA5F210981E9C2a8659444011370f41e2"
     chainName: ethereum
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|form|0xC316C8252B5F2176d0135Ebb0999E99296998F2e
@@ -12,6 +13,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xC316C8252B5F2176d0135Ebb0999E99296998F2e"
     chainName: form
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xFBf489bb4783D4B1B2e7D07ba39873Fb8068507D"
     connections:
       - token: ethereum|ethereum|0x3551011EA5F210981E9C2a8659444011370f41e2

--- a/deployments/warp_routes/USDT/ethereum-form-config.yaml
+++ b/deployments/warp_routes/USDT/ethereum-form-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x6435821A260B6A8EcB4ab723B84e1Bc3BC8b5304"
     chainName: ethereum
+    coinGeckoId: tether
     collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
     connections:
       - token: ethereum|form|0xFA3198ecF05303a6d96E57a45E6c815055D255b1


### PR DESCRIPTION
### Description

add missing coingecko id to usdc and usdc routes on form

### Backward compatibility

- YES

### Testing

- Manual
- CLI
