### PR TITLE
chore: validate logoURI path

### DIFF
--- a/scripts/validate-file-data.js
+++ b/scripts/validate-file-data.js
@@ -12,6 +12,7 @@ const noLogoFileError = [];
 // warp route warnings / errors
 const noConfigFileWarning = [];
 const unorderedChainNamesError = [];
+const invalidLogoURIPathError = [];
 
 function validateChains() {
   if (!fs.existsSync(chainsDir)) {
@@ -71,6 +72,27 @@ function validateConfigFiles(entryPath) {
     noConfigFileWarning.push(entryPath);
     return;
   }
+
+  configFiles.forEach((configFile) => {
+    const configFilePath = path.join(entryPath, configFile);
+    const configData = readYaml(configFilePath);
+
+    if (Object.keys(configData).includes('tokens')) {
+      const tokens = configData.tokens;
+      tokens.forEach((token) => {
+        if (Object.keys(token).includes('logoURI')) {
+          const logoURI = token.logoURI;
+          const filePath = path.join('./', logoURI);
+          if (!fs.existsSync(filePath)) {
+            invalidLogoURIPathError.push({
+              chain: token.chainName,
+              path: configFilePath,
+            });
+          }
+        }
+      });
+    }
+  });
 }
 
 function validateWarpRoutes() {
@@ -105,7 +127,8 @@ function validateErrors() {
   const errorCount =
     missingDeployerField.length +
     noLogoFileError.length +
-    unorderedChainNamesError.length;
+    unorderedChainNamesError.length +
+    invalidLogoURIPathError.length;
 
   if (errorCount === 0) return;
 
@@ -124,6 +147,13 @@ function validateErrors() {
       'Error: Chain names not ordered alphabetically at paths:',
       unorderedChainNamesError,
     );
+
+  if (invalidLogoURIPathError.length > 0) {
+    console.error(
+      'Error: Invalid logoURI path at, verify this file exists:',
+      invalidLogoURIPathError,
+    );
+  }
 
   process.exit(1);
 }

--- a/scripts/validate-file-data.js
+++ b/scripts/validate-file-data.js
@@ -150,7 +150,7 @@ function validateErrors() {
 
   if (invalidLogoURIPathError.length > 0) {
     console.error(
-      'Error: Invalid logoURI path at, verify this file exists:',
+      'Error: Invalid logoURI paths, verify that files exist:',
       invalidLogoURIPathError,
     );
   }


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
fixes #496 

Now validates that the path in logoURI for warp deployments actually exists, if it doesn't it will throw an error in the CI

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
Manual
![image](https://github.com/user-attachments/assets/e926cb98-7dc5-476d-a874-128e611f4a17)

