### PR TITLE
feat: replace old TONY/base-solanamainnet deploy with a new one

### DIFF
--- a/.changeset/dry-ears-agree.md
+++ b/.changeset/dry-ears-agree.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': major
+---
+
+Replace old TONY with the new TONY deploy

--- a/deployments/warp_routes/TONY/base-solanamainnet-addresses.yaml
+++ b/deployments/warp_routes/TONY/base-solanamainnet-addresses.yaml
@@ -1,4 +1,4 @@
 base:
-  collateral: "0x54624CA8ABEa68645b3B39211F90B804D53dB680"
+  collateral: "0xcc9EcE816641c8350Db06af375811107B1Aa0b9d"
 solanamainnet:
-  synthetic: 4AQVPTCAeLswnjksQdutxUDuxEJxUBwoWmVimGuPtGSt
+  synthetic: Fa4zQJCH7id5KL1eFJt2mHyFpUNfCCSkHgtMrLvrRJBN

--- a/deployments/warp_routes/TONY/base-solanamainnet-config.yaml
+++ b/deployments/warp_routes/TONY/base-solanamainnet-config.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x54624CA8ABEa68645b3B39211F90B804D53dB680"
+  - addressOrDenom: "0xcc9EcE816641c8350Db06af375811107B1Aa0b9d"
     chainName: base
     # TONY is not on Coingecko has a price with a (somewhat) similar magnitude to Bonk.
     # TONY: 0.00006 - https://cryptorank.io/price/big-tony
@@ -8,17 +8,17 @@ tokens:
     coinGeckoId: bonk
     collateralAddressOrDenom: "0xb22a793a81ff5b6ad37f40d5fe1e0ac4184d52f3"
     connections:
-      - token: sealevel|solanamainnet|4AQVPTCAeLswnjksQdutxUDuxEJxUBwoWmVimGuPtGSt
+      - token: sealevel|solanamainnet|Fa4zQJCH7id5KL1eFJt2mHyFpUNfCCSkHgtMrLvrRJBN
     decimals: 18
     logoURI: /deployments/warp_routes/TONY/logo.png
     name: Big Tony
     standard: EvmHypCollateral
     symbol: TONY
-  - addressOrDenom: 4AQVPTCAeLswnjksQdutxUDuxEJxUBwoWmVimGuPtGSt
+  - addressOrDenom: Fa4zQJCH7id5KL1eFJt2mHyFpUNfCCSkHgtMrLvrRJBN
     chainName: solanamainnet
-    collateralAddressOrDenom: 82TZR2cJmbQ3zvA2CGvoJfCMVD8WRawJGriQeGTELWQ5
+    collateralAddressOrDenom: 3SboFTm5xF3VGcduCP6CPue3ZTh8qKXNcNSXR74YDaw1
     connections:
-      - token: ethereum|base|0x54624CA8ABEa68645b3B39211F90B804D53dB680
+      - token: ethereum|base|0xcc9EcE816641c8350Db06af375811107B1Aa0b9d
     decimals: 9
     logoURI: /deployments/warp_routes/TONY/logo.png
     name: Big Tony


### PR DESCRIPTION
### Description

- A UI here https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/393 is available for anyone remaining who needs to unwind

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
