### PR TITLE
fix: Update toYamlString to not use aliasDuplicateObjects

### DIFF
--- a/.changeset/itchy-paws-tan.md
+++ b/.changeset/itchy-paws-tan.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update toYamlString to not use aliasDuplicateObjects due to alias errors.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { ABACUS_WORKS_DEPLOYER_NAME } from './consts.js';
 import { ChainMetadata } from '@hyperlane-xyz/sdk';
 
 export function toYamlString(data: any, prefix?: string): string {
-  const yamlString = stringify(data, { indent: 2, sortMapEntries: true });
+  const yamlString = stringify(data, { indent: 2, sortMapEntries: true, aliasDuplicateObjects: false });
   return prefix ? `${prefix}\n${yamlString}` : yamlString;
 }
 


### PR DESCRIPTION
### Description
This fixes the error that has been hard to debug:
```
Error: Error: Unresolved alias (the anchor must be set before the alias): a1
    at Alias.toString (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/nodes/Alias.js:72:23)
    at Object.stringify (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/stringify/stringify.js:93:25)
    at Object.stringifyPair (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/stringify/stringifyPair.js:97:32)
    at Pair.toString (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/nodes/Pair.js:33:29)
    at Object.stringify (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/stringify/stringify.js:90:21)
    at stringifyBlockCollection (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/stringify/stringifyCollection.js:36:29)
    at Object.stringifyCollection (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/stringify/stringifyCollection.js:10:12)
    at YAMLMap.toString (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/nodes/YAMLMap.js:136:36)
    at Object.stringify (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/stringify/stringify.js:118:20)
    at Object.stringifyPair (/Users/leyu/Desktop/Code/hyperlane/hyperlane-monorepo/node_modules/yaml/dist/stringify/stringifyPair.js:97:32)
```

### Backward compatibility
Yes

### Testing
Tested with `yarn link`
