### PR TITLE
feat: set gnosisSafeTransactionServiceUrl for zksync-stack mainnets

### DIFF
--- a/.changeset/nervous-elephants-flash.md
+++ b/.changeset/nervous-elephants-flash.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add gnosisSafeTransactionServiceUrl for zksync-stack mainnets.

--- a/chains/abstract/metadata.yaml
+++ b/chains/abstract/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
 displayName: Abstract
 domainId: 2741
 gasCurrencyCoinGeckoId: ethereum
+gnosisSafeTransactionServiceUrl: https://transaction.abstract-safe.protofire.io/
 index:
   from: 201749
 name: abstract

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -16,6 +16,7 @@ abstract:
   displayName: Abstract
   domainId: 2741
   gasCurrencyCoinGeckoId: ethereum
+  gnosisSafeTransactionServiceUrl: https://transaction.abstract-safe.protofire.io/
   index:
     from: 201749
   name: abstract
@@ -5893,6 +5894,7 @@ treasure:
   displayName: Treasure
   domainId: 61166
   gasCurrencyCoinGeckoId: magic
+  gnosisSafeTransactionServiceUrl: https://prod.treasure.keypersafe.xyz/
   name: treasure
   nativeToken:
     decimals: 18
@@ -6340,6 +6342,7 @@ zklink:
   displayNameShort: zkLink
   domainId: 810180
   gasCurrencyCoinGeckoId: ethereum
+  gnosisSafeTransactionServiceUrl: https://transaction.safe.zklink.io/
   name: zklink
   nativeToken:
     decimals: 18
@@ -6367,6 +6370,7 @@ zksync:
   displayName: zkSync
   domainId: 324
   gasCurrencyCoinGeckoId: ethereum
+  gnosisSafeTransactionServiceUrl: https://safe-transaction-zksync.safe.global/
   name: zksync
   nativeToken:
     decimals: 18

--- a/chains/treasure/metadata.yaml
+++ b/chains/treasure/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
 displayName: Treasure
 domainId: 61166
 gasCurrencyCoinGeckoId: magic
+gnosisSafeTransactionServiceUrl: https://prod.treasure.keypersafe.xyz/
 name: treasure
 nativeToken:
   decimals: 18

--- a/chains/zklink/metadata.yaml
+++ b/chains/zklink/metadata.yaml
@@ -16,6 +16,7 @@ displayName: zkLink Nova
 displayNameShort: zkLink
 domainId: 810180
 gasCurrencyCoinGeckoId: ethereum
+gnosisSafeTransactionServiceUrl: https://transaction.safe.zklink.io/
 name: zklink
 nativeToken:
   decimals: 18

--- a/chains/zksync/metadata.yaml
+++ b/chains/zksync/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
 displayName: zkSync
 domainId: 324
 gasCurrencyCoinGeckoId: ethereum
+gnosisSafeTransactionServiceUrl: https://safe-transaction-zksync.safe.global/
 name: zksync
 nativeToken:
   decimals: 18


### PR DESCRIPTION
### Description

feat: set gnosisSafeTransactionServiceUrl for zksync-stack mainnets

found api urls by looking at per-chain metadata returned by each UI:
- zksync https://app.safe.global/home
- treasure https://app.palmeradao.xyz/welcome
- zklink https://safe.zklink.io/welcome
- abstract https://abstract-safe.protofire.io/welcome

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
