### PR TITLE
feat: add SMOL config and metadata.json

### DIFF
--- a/.changeset/grumpy-maps-tan.md
+++ b/.changeset/grumpy-maps-tan.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add SMOL config and metadata

--- a/deployments/warp_routes/SMOL/arbitrum-ethereum-treasure-addresses.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-ethereum-treasure-addresses.yaml
@@ -1,0 +1,6 @@
+arbitrum:
+  collateral: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
+ethereum:
+  synthetic: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
+treasure:
+  synthetic: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"

--- a/deployments/warp_routes/SMOL/arbitrum-ethereum-treasure-config.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-ethereum-treasure-config.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
+    chainName: arbitrum
+    collateralAddressOrDenom: "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5"
+    connections:
+      - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
+      - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
+    decimals: 18
+    # logoURI: /deployments/warp_routes/SMOL/logo.svg
+    name: SMOL
+    standard: EvmHypCollateral
+    symbol: SMOL
+  - addressOrDenom: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
+    chainName: ethereum
+    connections:
+      - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
+      - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
+    decimals: 18
+    # logoURI: /deployments/warp_routes/SMOL/logo.svg
+    name: SMOL
+    standard: EvmHypSynthetic
+    symbol: SMOL
+  - addressOrDenom: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
+    chainName: treasure
+    connections:
+      - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
+      - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
+    decimals: 18
+    # logoURI: /deployments/warp_routes/SMOL/logo.svg
+    name: SMOL
+    standard: EvmHypSynthetic
+    symbol: SMOL

--- a/deployments/warp_routes/SMOL/arbitrum-ethereum-treasure-config.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-ethereum-treasure-config.yaml
@@ -7,7 +7,6 @@ tokens:
       - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
       - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
     decimals: 18
-    # logoURI: /deployments/warp_routes/SMOL/logo.svg
     name: SMOL
     standard: EvmHypCollateral
     symbol: SMOL
@@ -17,7 +16,6 @@ tokens:
       - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
       - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
     decimals: 18
-    # logoURI: /deployments/warp_routes/SMOL/logo.svg
     name: SMOL
     standard: EvmHypSynthetic
     symbol: SMOL
@@ -27,7 +25,6 @@ tokens:
       - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
       - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
     decimals: 18
-    # logoURI: /deployments/warp_routes/SMOL/logo.svg
     name: SMOL
     standard: EvmHypSynthetic
     symbol: SMOL

--- a/deployments/warp_routes/SMOL/metadata.json
+++ b/deployments/warp_routes/SMOL/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "SMOL",
+  "symbol": "SMOL",
+  "description": "SMOL, Warp Route bridged via Hyperlane.",
+  "attributes": []
+}


### PR DESCRIPTION
### Description

- Adds the existing SMOL token deployed by the treasure team
- Adds a metadata.json in preparation for a Solana token deploy. There is no image yet as the design is still being finalized, this will be updated later.

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
