### PR TITLE
refactor: Update WarpRouteDeployConfig type to WarpRouteDeployConfigW…

### DIFF
--- a/src/registry/BaseRegistry.ts
+++ b/src/registry/BaseRegistry.ts
@@ -1,6 +1,6 @@
 import type { Logger } from 'pino';
 
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 import type { ChainAddresses, MaybePromise, WarpDeployConfigMap } from '../types.js';
 import { WarpRouteConfigMap } from '../types.js';
 import { stripLeadingSlash } from '../utils.js';
@@ -87,7 +87,7 @@ export abstract class BaseRegistry implements IRegistry {
   abstract getWarpRoutes(filter?: WarpRouteFilterParams): MaybePromise<WarpRouteConfigMap>;
   abstract addWarpRoute(config: WarpCoreConfig): MaybePromise<void>;
 
-  abstract getWarpDeployConfig(routeId: string): MaybePromise<WarpRouteDeployConfig | null>;
+  abstract getWarpDeployConfig(routeId: string): MaybePromise<WarpRouteDeployConfigWithoutMailbox | null>;
   abstract getWarpDeployConfigs(filter?: WarpRouteFilterParams): MaybePromise<WarpDeployConfigMap>;
 
   merge(otherRegistry: IRegistry): IRegistry {

--- a/src/registry/FileSystemRegistry.ts
+++ b/src/registry/FileSystemRegistry.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import type { Logger } from 'pino';
 import { parse as yamlParse } from 'yaml';
 
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 
 import { CHAIN_FILE_REGEX, SCHEMA_REF, WARP_ROUTE_CONFIG_FILE_REGEX, WARP_ROUTE_DEPLOY_FILE_REGEX, } from '../consts.js';
 import { ChainAddresses, ChainAddressesSchema, WarpRouteId } from '../types.js';
@@ -118,7 +118,7 @@ export class FileSystemRegistry extends SynchronousRegistry implements IRegistry
     this.createFile({ filePath: addressesPath, data: toYamlString(addresses) });
   }
 
-  addWarpRouteConfig(warpConfig: WarpRouteDeployConfig, fileName: string): void {
+  addWarpRouteConfig(warpConfig: WarpRouteDeployConfigWithoutMailbox, fileName: string): void {
     const filePath = path.join(this.uri, this.getWarpRoutesPath(), fileName);
     this.createFile({ filePath, data: toYamlString(warpConfig)})
   }
@@ -197,7 +197,7 @@ export class FileSystemRegistry extends SynchronousRegistry implements IRegistry
     return this.readConfigsForIds(ids, warpRoutes);
   }
 
-  protected getWarpDeployConfigForIds(ids: WarpRouteId[]): WarpRouteDeployConfig[] {
+  protected getWarpDeployConfigForIds(ids: WarpRouteId[]): WarpRouteDeployConfigWithoutMailbox[] {
     const warpDeployConfig = this.listRegistryContent().deployments.warpDeployConfig;
     return this.readConfigsForIds(ids, warpDeployConfig);
   }

--- a/src/registry/GithubRegistry.ts
+++ b/src/registry/GithubRegistry.ts
@@ -1,7 +1,7 @@
 import type { Logger } from 'pino';
 import { parse as yamlParse } from 'yaml';
 
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 
 import {
   CHAIN_FILE_REGEX,
@@ -172,7 +172,7 @@ export class GithubRegistry extends BaseRegistry implements IRegistry {
     return this.fetchYamlFile(routeConfigUrl);
   }
 
-  async getWarpDeployConfig(routeId: string): Promise<WarpRouteDeployConfig | null> {
+  async getWarpDeployConfig(routeId: string): Promise<WarpRouteDeployConfigWithoutMailbox | null> {
     const repoContents = await this.listRegistryContent();
     const routeConfigUrl = repoContents.deployments.warpDeployConfig[routeId];
     if (!routeConfigUrl) return null;

--- a/src/registry/IRegistry.ts
+++ b/src/registry/IRegistry.ts
@@ -1,4 +1,4 @@
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 import { ChainAddresses, MaybePromise, WarpDeployConfigMap, WarpRouteConfigMap, WarpRouteId } from '../types.js';
 
 export interface ChainFiles {
@@ -67,7 +67,7 @@ export interface IRegistry {
   getWarpRoutes(filter?: WarpRouteFilterParams): MaybePromise<WarpRouteConfigMap>;
   addWarpRoute(config: WarpCoreConfig, options?: AddWarpRouteOptions): MaybePromise<void>;
 
-  getWarpDeployConfig(routeId: string): MaybePromise<WarpRouteDeployConfig | null>;
+  getWarpDeployConfig(routeId: string): MaybePromise<WarpRouteDeployConfigWithoutMailbox | null>;
   getWarpDeployConfigs(filter?: WarpRouteFilterParams): MaybePromise<WarpDeployConfigMap>;
 
   // TODO define more deployment artifact related methods

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -1,6 +1,6 @@
 import type { Logger } from 'pino';
 
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 import { ChainAddresses, WarpDeployConfigMap, WarpRouteConfigMap, WarpRouteId } from '../types.js';
 import { objMerge } from '../utils.js';
 import {
@@ -104,7 +104,7 @@ export class MergedRegistry implements IRegistry {
     return results.find((r) => !!r) || null;
   }
 
-  async getWarpDeployConfig(id: WarpRouteId): Promise<WarpRouteDeployConfig | null> {
+  async getWarpDeployConfig(id: WarpRouteId): Promise<WarpRouteDeployConfigWithoutMailbox | null> {
     const results = await this.multiRegistryRead((r) => r.getWarpDeployConfig(id));
     return results.find((r) => !!r) || null;
   }

--- a/src/registry/PartialRegistry.ts
+++ b/src/registry/PartialRegistry.ts
@@ -1,6 +1,6 @@
 import type { Logger } from 'pino';
 
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 import { ChainAddresses, DeepPartial, WarpRouteId } from '../types.js';
 import { ChainFiles, IRegistry, RegistryContent, RegistryType } from './IRegistry.js';
 import { SynchronousRegistry } from './SynchronousRegistry.js';
@@ -16,7 +16,7 @@ export interface PartialRegistryOptions {
   chainMetadata?: ChainMap<DeepPartial<ChainMetadata>>;
   chainAddresses?: ChainMap<DeepPartial<ChainAddresses>>;
   warpRoutes?: Array<DeepPartial<WarpCoreConfig>>;
-  warpDeployConfigs?: Array<DeepPartial<WarpRouteDeployConfig>>;
+  warpDeployConfigs?: Array<DeepPartial<WarpRouteDeployConfigWithoutMailbox>>;
   // TODO add more fields here as needed
   logger?: Logger;
 }
@@ -26,7 +26,7 @@ export class PartialRegistry extends SynchronousRegistry implements IRegistry {
   public chainMetadata: ChainMap<DeepPartial<ChainMetadata>>;
   public chainAddresses: ChainMap<DeepPartial<ChainAddresses>>;
   public warpRoutes: Array<DeepPartial<WarpCoreConfig>>;
-  public warpDeployConfigs: Array<DeepPartial<WarpRouteDeployConfig>>;
+  public warpDeployConfigs: Array<DeepPartial<WarpRouteDeployConfigWithoutMailbox>>;
 
   constructor({ chainMetadata, chainAddresses, warpRoutes, warpDeployConfigs, logger }: PartialRegistryOptions) {
     super({ uri: PARTIAL_URI_PLACEHOLDER, logger });
@@ -91,11 +91,11 @@ export class PartialRegistry extends SynchronousRegistry implements IRegistry {
     }) as WarpCoreConfig[];
   }
 
-  protected getWarpDeployConfigForIds(_ids: WarpRouteId[]): WarpRouteDeployConfig[] {
+  protected getWarpDeployConfigForIds(_ids: WarpRouteId[]): WarpRouteDeployConfigWithoutMailbox[] {
     // TODO: Right now this returns an empty array
     // This cannot be implemented without deriving the token symbol from config.token
     // We will revisit once we merge the configs
-    return this.warpDeployConfigs as WarpRouteDeployConfig[];
+    return this.warpDeployConfigs as WarpRouteDeployConfigWithoutMailbox[];
   }
 
   protected createOrUpdateChain(chain: {

--- a/src/registry/SynchronousRegistry.ts
+++ b/src/registry/SynchronousRegistry.ts
@@ -1,4 +1,4 @@
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 
 import { ChainAddresses, WarpDeployConfigMap, WarpRouteConfigMap, WarpRouteId } from '../types.js';
 import { BaseRegistry } from './BaseRegistry.js';
@@ -64,7 +64,7 @@ export abstract class SynchronousRegistry extends BaseRegistry implements IRegis
     return this.getWarpRoutesForIds([routeId])[0] || null;
   }
 
-  getWarpDeployConfig(routeId: string): WarpRouteDeployConfig | null {
+  getWarpDeployConfig(routeId: string): WarpRouteDeployConfigWithoutMailbox | null {
     return this.getWarpDeployConfigForIds([routeId])[0] || null;
   }
 
@@ -86,7 +86,7 @@ export abstract class SynchronousRegistry extends BaseRegistry implements IRegis
     const warpDeployConfig = this.listRegistryContent().deployments.warpDeployConfig;
     const { ids: routeIds } = filterWarpRoutesIds(warpDeployConfig, filter);
     const configs = this.getWarpDeployConfigForIds(routeIds);
-    const idsWithConfigs = routeIds.map((id, i): [WarpRouteId, WarpRouteDeployConfig] => [id, configs[i]])
+    const idsWithConfigs = routeIds.map((id, i): [WarpRouteId, WarpRouteDeployConfigWithoutMailbox] => [id, configs[i]])
     return Object.fromEntries(idsWithConfigs);
   }
 
@@ -95,5 +95,5 @@ export abstract class SynchronousRegistry extends BaseRegistry implements IRegis
   protected abstract createOrUpdateChain(chain: UpdateChainParams): void;
 
   protected abstract getWarpRoutesForIds(ids: WarpRouteId[]): WarpCoreConfig[];
-  protected abstract getWarpDeployConfigForIds(ids: WarpRouteId[]): WarpRouteDeployConfig[];
+  protected abstract getWarpDeployConfigForIds(ids: WarpRouteId[]): WarpRouteDeployConfigWithoutMailbox[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type { WarpCoreConfig, WarpRouteDeployConfigWithoutMailbox } from '@hyperlane-xyz/sdk';
 import { z } from 'zod';
 
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements
@@ -9,7 +9,7 @@ export type ChainAddresses = z.infer<typeof ChainAddressesSchema>;
 
 export type WarpRouteId = string;
 export type WarpRouteConfigMap = Record<WarpRouteId, WarpCoreConfig>;
-export type WarpDeployConfigMap = Record<WarpRouteId, WarpRouteDeployConfig>;
+export type WarpDeployConfigMap = Record<WarpRouteId, WarpRouteDeployConfigWithoutMailbox>;
 
 export type DeepPartial<T> = T extends object
   ? {


### PR DESCRIPTION
### Description
Updates all references of `WarpRouteDeployConfig` type to `WarpRouteDeployConfigWithoutMailbox` across the codebase. This change reflects that the warp route deploy configuration no longer includes mailbox-specific configuration, making the type name more accurate and explicit.

### Backward compatibility
Yes - This is a type rename that better reflects the actual structure of the configuration. No functional changes are made to the underlying data structure.

### Related issues
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5258
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5259

### Testing
No additional testing required as this is a type-level change only. Existing tests should continue to pass without modification.