### PR TITLE
feat: add Solana to SMOL warp route

### DIFF
--- a/.changeset/spotty-points-tell.md
+++ b/.changeset/spotty-points-tell.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': minor
 ---
 
-Add SMOL warp route config
+Add solanamainnet to SMOL warp route config

--- a/.changeset/spotty-points-tell.md
+++ b/.changeset/spotty-points-tell.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add SMOL warp route config

--- a/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-addresses.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-addresses.yaml
@@ -2,5 +2,7 @@ arbitrum:
   collateral: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
 ethereum:
   synthetic: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
+solanamainnet:
+  synthetic: 7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
 treasure:
   synthetic: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"

--- a/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-config.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-config.yaml
@@ -15,15 +15,27 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
       - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
+      - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
     decimals: 18
     name: SMOL
     standard: EvmHypSynthetic
+    symbol: SMOL
+  - addressOrDenom: 7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
+    chainName: solanamainnet
+    collateralAddressOrDenom: 5KHQeeQvM4qBtmX3WnaCMGpM3Th7jYpqcHf3c6qzPodM
+    connections:
+      - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
+      - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
+    decimals: 9
+    name: SMOL
+    standard: SealevelHypSynthetic
     symbol: SMOL
   - addressOrDenom: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
     chainName: treasure
     connections:
       - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
       - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
+      - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
     decimals: 18
     name: SMOL
     standard: EvmHypSynthetic


### PR DESCRIPTION
### Description

- Adds `solanamainnet` to the SMOL warp route
- Only connects solana to ethereum and treasure (not arbitrum) at the request of the team

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
