### PR TITLE
fix: incorrect reference to the variable

### DIFF
--- a/scripts/check-mailbox-hooks.sh
+++ b/scripts/check-mailbox-hooks.sh
@@ -43,7 +43,7 @@ for chain_dir in chains/*/; do
 
     # Check if addresses.yaml has a fallbackRoutingHook entry
     fallback_routing_hook=$(yq e '.fallbackRoutingHook' "$addresses_file")
-    if [ "$merkle_tree_hook" = "null" ]; then
+    if [ "$fallback_routing_hook" = "null" ]; then
         echo "$chain_name: No address for fallbackRoutingHook, skipping."
         continue
     fi


### PR DESCRIPTION
### Description
In this block, the variable `fallback_routing_hook` obtained from the file should be checked, not the previously read variable `merkle_tree_hook`.

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
