### PR TITLE
chore: remove remaining -addresses.yaml files

### DIFF
--- a/.changeset/tame-jeans-decide.md
+++ b/.changeset/tame-jeans-decide.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': major
+---
+
+Remove more addresses-yaml files

--- a/deployments/warp_routes/LOGX/arbitrum-solanamainnet-addresses.yaml
+++ b/deployments/warp_routes/LOGX/arbitrum-solanamainnet-addresses.yaml
@@ -1,4 +1,0 @@
-arbitrum:
-  collateral: "0x79EdA6DAfB2B9531930CbD9240A73B5eF0e8c9E2"
-solanamainnet:
-  synthetic: 975wpF9KmWTVnh398Qs6VcnDtYZsXVWtKiSkXfWH22GP

--- a/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-addresses.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-addresses.yaml
@@ -1,8 +1,0 @@
-arbitrum:
-  collateral: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
-ethereum:
-  synthetic: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
-solanamainnet:
-  synthetic: 7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
-treasure:
-  synthetic: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"

--- a/deployments/warp_routes/SOL/solanamainnet-sonicsvm-addresses.yaml
+++ b/deployments/warp_routes/SOL/solanamainnet-sonicsvm-addresses.yaml
@@ -1,4 +1,0 @@
-solanamainnet:
-  native: BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
-sonicsvm:
-  native: 7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY

--- a/deployments/warp_routes/SONIC/solanamainnet-sonicsvm-addresses.yaml
+++ b/deployments/warp_routes/SONIC/solanamainnet-sonicsvm-addresses.yaml
@@ -1,4 +1,0 @@
-solanamainnet:
-  collateral: 2e6hyJbUpbhqbJzorDZ1m4QVTj5oPhsn2H3KBaMFVXAz
-sonicsvm:
-  synthetic: 5sPRiRLfmohVmtkgiGV6scrzy2C6qEZRGRUiePZf1Fs2

--- a/deployments/warp_routes/USDC/solanamainnet-sonicsvm-addresses.yaml
+++ b/deployments/warp_routes/USDC/solanamainnet-sonicsvm-addresses.yaml
@@ -1,4 +1,0 @@
-solanamainnet:
-  collateral: 996EsR8a7MC6odE6j7sjsArmDQVqB96qWu84wHdthahm
-sonicsvm:
-  synthetic: BvTEYSqCcfMwpAriC1vDpNhzR1JWzasRFfCPCdgsYaCd

--- a/deployments/warp_routes/USDStar/solanamainnet-sonicsvm-addresses.yaml
+++ b/deployments/warp_routes/USDStar/solanamainnet-sonicsvm-addresses.yaml
@@ -1,4 +1,0 @@
-solanamainnet:
-  collateral: FRPTWpmnNPm4LS2a5NUL1QenUrzGDAuifZBUi1mTWTdt
-sonicsvm:
-  synthetic: 68g96Cq16vKAqyG79BFVeJCgitjK9fQ1NRCRmcPkJtDB

--- a/deployments/warp_routes/USDT/solanamainnet-sonicsvm-addresses.yaml
+++ b/deployments/warp_routes/USDT/solanamainnet-sonicsvm-addresses.yaml
@@ -1,4 +1,0 @@
-solanamainnet:
-  collateral: CKrNt2y1e2H9728mHRVYyF2owy9eKreepRKpTMj2j8JG
-sonicsvm:
-  synthetic: BGW8geBw12Yyp4rW7Fp97a3CQRA4Czi8PdtuV2Ec3Vdy

--- a/deployments/warp_routes/sSOL/solanamainnet-sonicsvm-addresses.yaml
+++ b/deployments/warp_routes/sSOL/solanamainnet-sonicsvm-addresses.yaml
@@ -1,4 +1,0 @@
-solanamainnet:
-  collateral: 9PHKQFEDzedHuigSm1ZBojEX4DVF3cincGZwy3k7VHTN
-sonicsvm:
-  synthetic: XYbsJQGzZgPDbt9Swd2ao54nhGSq8Wjq23MoogHvEq6


### PR DESCRIPTION
### Description

chore: remove remaining -addresses.yaml files

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
