### PR TITLE
fix(registry): schema conformance

### DIFF
--- a/chains/schema.json
+++ b/chains/schema.json
@@ -1,5 +1,5 @@
 {
-  "$ref": "#/definitions/hyperlaneChainMetadata",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "hyperlaneChainMetadata": {
       "type": "object",
@@ -63,7 +63,8 @@
               "anyOf": [
                 {
                   "type": "integer",
-                  "minimum": 0
+                  "minimum": 0,
+                  "description": "A number of blocks before a transaction has a near-zero chance of reverting or block tag."
                 },
                 {
                   "type": "string"
@@ -73,7 +74,8 @@
             },
             "estimateBlockTime": {
               "type": "number",
-              "exclusiveMinimum": 0,
+              "minimum": 0,
+              "exclusiveMinimum": true,
               "description": "Rough estimate of time per block in seconds."
             }
           },
@@ -87,7 +89,9 @@
           "anyOf": [
             {
               "type": "integer",
-              "exclusiveMinimum": 0
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "description": "Integer chainId must be greater than 0."
             },
             {
               "type": "string"
@@ -133,7 +137,8 @@
         },
         "domainId": {
           "type": "integer",
-          "exclusiveMinimum": 0,
+          "minimum": 0,
+          "exclusiveMinimum": true,
           "description": "The domainId of the chain, should generally default to `chainId`. Consumer of `ChainMetadata` should use this value or `name` as a unique identifier."
         },
         "gasCurrencyCoinGeckoId": {
@@ -156,7 +161,8 @@
               },
               "concurrency": {
                 "type": "integer",
-                "exclusiveMinimum": 0,
+                "minimum": 0,
+                "exclusiveMinimum": true,
                 "description": "Maximum number of concurrent RPC requests."
               },
               "webSocket": {
@@ -176,7 +182,7 @@
                   },
                   "maxBlockAge": {
                     "$ref": "#/definitions/hyperlaneChainMetadata/properties/chainId/anyOf/0",
-                    "description": "The relative different from latest block that this RPC supports."
+                    "description": "The relative difference from latest block that this RPC supports."
                   }
                 },
                 "additionalProperties": false,
@@ -187,12 +193,14 @@
                 "properties": {
                   "maxRequests": {
                     "type": "integer",
-                    "exclusiveMinimum": 0,
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
                     "description": "The maximum number of requests to attempt before failing."
                   },
                   "baseRetryMs": {
                     "type": "integer",
-                    "exclusiveMinimum": 0,
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
                     "description": "The base retry delay in milliseconds."
                   }
                 },
@@ -247,7 +255,9 @@
             "decimals": {
               "type": "integer",
               "minimum": 0,
-              "exclusiveMaximum": 256
+              "maximum": 256,
+              "exclusiveMaximum": true,
+              "description": "The number of decimals (must be less than 256)."
             },
             "denom": {
               "type": "string"
@@ -317,5 +327,9 @@
       "additionalProperties": false
     }
   },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "allOf": [
+    {
+      "$ref": "#/definitions/hyperlaneChainMetadata"
+    }
+  ]
 }


### PR DESCRIPTION
## Fix the usage of `exclusiveMinimum`


### Description


for the “chainId”, “blocks.estimateBlockTime”, “grpcUrls.concurrency”, “retry.maxRequests”, and “retry.baseRetryMs”), the keyword `exclusiveMinimum` is given a numeric value. In JSON Schema draft‑07 the `exclusiveMinimum` keyword is of type boolean, and is used with a separate `minimum` value as this enforces a strict inequality.

### Backward compatibility

Technically, no as there was no strict inequality per se defined.

### Testing

YMMV
