### PR TITLE
chore: fix incorrect variable check in routing logic

### DIFF
--- a/scripts/check-mailbox-hooks.sh
+++ b/scripts/check-mailbox-hooks.sh
@@ -43,7 +43,7 @@ for chain_dir in chains/*/; do
 
     # Check if addresses.yaml has a fallbackRoutingHook entry
     fallback_routing_hook=$(yq e '.fallbackRoutingHook' "$addresses_file")
-    if [ "$merkle_tree_hook" = "null" ]; then
+    if [ "$fallback_routing_hook" = "null" ]; then
         echo "$chain_name: No address for fallbackRoutingHook, skipping."
         continue
     fi


### PR DESCRIPTION
### Description

I noticed that the condition was checking the `merkle_tree_hook` variable, but it should have been checking `fallback_routing_hook`.

I've updated the code to reflect the correct variable.