### PR TITLE
chore: update unichain and worldchain explorers

### DIFF
--- a/.changeset/witty-pumas-appear.md
+++ b/.changeset/witty-pumas-appear.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update explorers for unichain and worldchain.

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -6086,10 +6086,10 @@ u2utestnet:
     - http: https://rpc-nebulas-testnet.uniultra.xyz
 unichain:
   blockExplorers:
-    - apiUrl: https://unichain.blockscout.com/api
-      family: blockscout
+    - apiUrl: https://api.uniscan.xyz/api
+      family: etherscan
       name: Unichain Explorer
-      url: https://unichain.blockscout.com
+      url: https://uniscan.xyz
   blocks:
     confirmations: 1
     estimateBlockTime: 1
@@ -6263,10 +6263,10 @@ weavevmtestnet:
   technicalStack: other
 worldchain:
   blockExplorers:
-    - apiUrl: https://worldchain-mainnet-explorer.alchemy.com/api
-      family: blockscout
-      name: World Chain explorer
-      url: https://worldchain-mainnet-explorer.alchemy.com
+    - apiUrl: https://api.worldscan.org/api
+      family: etherscan
+      name: Worldscan
+      url: https://worldscan.org
   blocks:
     confirmations: 1
     estimateBlockTime: 2

--- a/chains/unichain/metadata.yaml
+++ b/chains/unichain/metadata.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://unichain.blockscout.com/api
-    family: blockscout
+  - apiUrl: https://api.uniscan.xyz/api
+    family: etherscan
     name: Unichain Explorer
-    url: https://unichain.blockscout.com
+    url: https://uniscan.xyz
 blocks:
   confirmations: 1
   estimateBlockTime: 1

--- a/chains/worldchain/metadata.yaml
+++ b/chains/worldchain/metadata.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://worldchain-mainnet-explorer.alchemy.com/api
-    family: blockscout
-    name: World Chain explorer
-    url: https://worldchain-mainnet-explorer.alchemy.com
+  - apiUrl: https://api.worldscan.org/api
+    family: etherscan
+    name: Worldscan
+    url: https://worldscan.org
 blocks:
   confirmations: 1
   estimateBlockTime: 2


### PR DESCRIPTION
### Description

chore: update unichain and worldchain explorers

api keys have also been added in secrets

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
