### PR TITLE
chore: add drpc endpoint to default ethereum RPC set

### DIFF
--- a/.changeset/quiet-adults-greet.md
+++ b/.changeset/quiet-adults-greet.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add drpc fallback rpc to ethereum metadata.

--- a/chains/ethereum/metadata.yaml
+++ b/chains/ethereum/metadata.yaml
@@ -30,4 +30,5 @@ rpcUrls:
   - http: https://rpc.ankr.com/eth
   - http: https://ethereum.publicnode.com
   - http: https://cloudflare-eth.com
+  - http: wss://eth.drpc.org
 technicalStack: other

--- a/chains/ethereum/metadata.yaml
+++ b/chains/ethereum/metadata.yaml
@@ -30,5 +30,5 @@ rpcUrls:
   - http: https://rpc.ankr.com/eth
   - http: https://ethereum.publicnode.com
   - http: https://cloudflare-eth.com
-  - http: wss://eth.drpc.org
+  - http: https://eth.drpc.org
 technicalStack: other

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -2083,6 +2083,7 @@ ethereum:
     - http: https://rpc.ankr.com/eth
     - http: https://ethereum.publicnode.com
     - http: https://cloudflare-eth.com
+    - http: wss://eth.drpc.org
   technicalStack: other
 euphoriatestnet:
   blockExplorers:

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -2083,7 +2083,7 @@ ethereum:
     - http: https://rpc.ankr.com/eth
     - http: https://ethereum.publicnode.com
     - http: https://cloudflare-eth.com
-    - http: wss://eth.drpc.org
+    - http: https://eth.drpc.org
   technicalStack: other
 euphoriatestnet:
   blockExplorers:


### PR DESCRIPTION
### Description

chore: add drpc endpoint to default ethereum RPC set

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
