### PR TITLE
feat: add coinGeckoId to CDX/base-solanamainnet

### DIFF
--- a/.changeset/green-bags-thank.md
+++ b/.changeset/green-bags-thank.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add coinGeckoId to CDX/base-solanamainnet

--- a/deployments/warp_routes/CDX/base-solanamainnet-config.yaml
+++ b/deployments/warp_routes/CDX/base-solanamainnet-config.yaml
@@ -3,6 +3,7 @@ tokens:
   - addressOrDenom: "0x22Fd11F93F0303346c9b9070cc67C4Bc7aB2dABB"
     chainName: base
     collateralAddressOrDenom: "0xC0D3700000c0e32716863323bFd936b54a1633d1"
+    coinGeckoId: cod3x
     connections:
       - token: sealevel|solanamainnet|Dt62xRfWf7h6cURDsr19tqGWhjHMdobNVQ25cfHtZXg7
     decimals: 18


### PR DESCRIPTION
### Description

- Adds coinGeckoId to CDX/base-solanamainnet now that it's live (https://www.coingecko.com/en/coins/cod3x)
- Will redeploy the monitor

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
