### PR TITLE
feat: Add SOL/hyperevm-solanamainnet

### DIFF
--- a/.changeset/late-suits-eat.md
+++ b/.changeset/late-suits-eat.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add SOL/hyperevm-solanamainnet

--- a/deployments/warp_routes/SOL/hyperevm-solanamainnet-config.yaml
+++ b/deployments/warp_routes/SOL/hyperevm-solanamainnet-config.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x96029bcf706FAC4176492F4a05f63f7d23cE78fb"
+    chainName: hyperevm
+    connections:
+      - token: sealevel|solanamainnet|4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
+    decimals: 9
+    logoURI: /deployments/warp_routes/SOL/logo.svg
+    name: Solana
+    standard: EvmHypSynthetic
+    symbol: SOL
+  - addressOrDenom: 4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
+    chainName: solanamainnet
+    coinGeckoId: solana
+    connections:
+      - token: ethereum|hyperevm|0x96029bcf706FAC4176492F4a05f63f7d23cE78fb
+    decimals: 9
+    logoURI: /deployments/warp_routes/SOL/logo.svg
+    name: Solana
+    standard: SealevelHypNative
+    symbol: SOL

--- a/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
@@ -6,6 +6,9 @@ hyperevm:
   symbol: SOL
   name: Solana
   type: synthetic
+  proxyAdmin:
+    address: "0x3E12271EbD523d0886D0D51A4FF8D8e046CF2E1D"
+    owner: "0x5F7771EA40546e2932754C263455Cb0023a55ca7"
 solanamainnet:
   foreignDeployment: 4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
   gas: 300000

--- a/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
@@ -1,14 +1,14 @@
 hyperevm:
+  decimals: 9
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
-  owner: "0x5F7771EA40546e2932754C263455Cb0023a55ca7"
-  decimals: 9
-  symbol: SOL
   name: Solana
-  type: synthetic
+  owner: "0x5F7771EA40546e2932754C263455Cb0023a55ca7"
   proxyAdmin:
     address: "0x3E12271EbD523d0886D0D51A4FF8D8e046CF2E1D"
     owner: "0x5F7771EA40546e2932754C263455Cb0023a55ca7"
+  symbol: SOL
+  type: synthetic
 solanamainnet:
   foreignDeployment: 4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
   gas: 300000

--- a/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
@@ -1,0 +1,15 @@
+hyperevm:
+  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+  mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  decimals: 9
+  symbol: SOL
+  name: Solana
+  type: synthetic
+solanamainnet:
+  foreignDeployment: 4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
+  gas: 300000
+  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+  mailbox: E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi
+  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  type: native

--- a/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
@@ -1,7 +1,7 @@
 hyperevm:
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
-  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  owner: "0x5F7771EA40546e2932754C263455Cb0023a55ca7"
   decimals: 9
   symbol: SOL
   name: Solana
@@ -11,5 +11,5 @@ solanamainnet:
   gas: 300000
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   mailbox: E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: BNGDJ1h9brgt6FFVd8No1TVAH48Fp44d7jkuydr1URwJ
   type: native


### PR DESCRIPTION
### Description

- Tested in UI
- Ownership has been transferred
- Settled on 9 decimals for the hyperevm side as this is what the e.g. wSOL https://etherscan.io/token/0xd31a59c85ae9d8edefec411d448f90841571b89c token does

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
