### PR TITLE
chore: fix incorrect variable check for fallbackRoutingHook

### DIFF
--- a/scripts/check-mailbox-hooks.sh
+++ b/scripts/check-mailbox-hooks.sh
@@ -43,7 +43,7 @@ for chain_dir in chains/*/; do
 
     # Check if addresses.yaml has a fallbackRoutingHook entry
     fallback_routing_hook=$(yq e '.fallbackRoutingHook' "$addresses_file")
-    if [ "$merkle_tree_hook" = "null" ]; then
+    if [ "$fallback_routing_hook" = "null" ]; then
         echo "$chain_name: No address for fallbackRoutingHook, skipping."
         continue
     fi


### PR DESCRIPTION
### **Description**  
Fixed an incorrect variable check in the script. Previously, the condition was checking `merkle_tree_hook` instead of `fallback_routing_hook`. Now, it correctly verifies `fallbackRoutingHook` before proceeding, ensuring the intended logic is applied.  

### **Backward compatibility**  
No breaking changes. The fix only corrects the variable being checked, preserving existing behavior while ensuring proper validation.  

### **Testing**  
Manually tested by running the script on various `addresses.yaml` files, confirming that `fallbackRoutingHook` is correctly validated and the script behaves as expected.
