### PR TITLE
fix: fix misleading error label in console.warn message

### DIFF
--- a/scripts/validate-file-data.js
+++ b/scripts/validate-file-data.js
@@ -121,7 +121,7 @@ function validateErrors() {
   // prior to deploying the token. This means we generally submit a first PR with the
   // metadata and a follow-up PR with the addresses / config.
   if (noConfigFileWarning.length > 0)
-    console.warn('Error: no config file at paths:', noConfigFileWarning);
+    console.warn('Warning: no config file at paths:', noConfigFileWarning);
 
   // Then, errors
   const errorCount =


### PR DESCRIPTION
### Description

Noticed a small inconsistency in `validateErrors()`. The function logs a warning using `console.warn`, but the message starts with `"Error:"`, which could be misleading.  

Changed:  
```js
console.warn('Error: no config file at paths:', noConfigFileWarning);
```  
To:  
```js
console.warn('Warning: no config file at paths:', noConfigFileWarning);
```  

Now the message correctly reflects the log level.
