### PR TITLE
fix: fix duplicate entries in the configuration list

### DIFF
--- a/test/unit/warp-routes.test.ts
+++ b/test/unit/warp-routes.test.ts
@@ -147,8 +147,6 @@ describe('Warp Deploy Configs', () => {
     'ECLIP/arbitrum-neutron',
     'INJ/inevm-injective',
     'TIA/arbitrum-neutron',
-    'INJ/inevm-injective',
-    'TIA/arbitrum-neutron',
     'TIA/eclipsemainnet-stride',
     'TIA/mantapacific-neutron',
     'stTIA/eclipsemainnet-stride'


### PR DESCRIPTION
### Description

I’ve removed duplicate entries from the list of deployment configurations. Specifically, the entries for `'TIA/arbitrum-neutron'` and `'INJ/inevm-injective'` were listed multiple times, which could have caused issues.
The duplicates are now removed, ensuring the list is accurate.
