### PR TITLE
fix: correct sSOL/solanamainnet-sonicsvm collateralAddressOrDenom

### DIFF
--- a/.changeset/eighty-drinks-smoke.md
+++ b/.changeset/eighty-drinks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Fix sSOL/solanamainnet-sonicsvm collateralAddressOrDenom

--- a/deployments/warp_routes/sSOL/solanamainnet-sonicsvm-config.yaml
+++ b/deployments/warp_routes/sSOL/solanamainnet-sonicsvm-config.yaml
@@ -13,7 +13,7 @@ tokens:
     symbol: sSOL
   - addressOrDenom: XYbsJQGzZgPDbt9Swd2ao54nhGSq8Wjq23MoogHvEq6
     chainName: sonicsvm
-    collateralAddressOrDenom: 21e27teReDgn7Z3J1ogdpJmFhUi75eYeiCD22zqCuwpd
+    collateralAddressOrDenom: DYzxL1BWKytFiEnP7XKeRLvgheuQttHW643srPG6rNRn
     connections:
       - token: sealevel|solanamainnet|9PHKQFEDzedHuigSm1ZBojEX4DVF3cincGZwy3k7VHTN
     decimals: 9


### PR DESCRIPTION
### Description

- Was flagged that the `sSOL/solanamainnet-sonicsvm` `collateralAddressOrDenom` was inaccurate, fixes it
- Ideally we should have this be implied or unit tested but considering this out of the scope for now
- Went through all the other tokens and made sure they're good

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
