### PR TITLE
feat: add oUSDT warp route config

### DIFF
--- a/.changeset/quick-geese-hug.md
+++ b/.changeset/quick-geese-hug.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add oUSDT warp routes config

--- a/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
@@ -1,0 +1,211 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f"
+    chainName: base
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
+    chainName: celo
+    collateralAddressOrDenom: "0x5e5F4d6B03db16E7f00dE7C9AFAA53b92C8d1D42"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: USDT
+    standard: EvmHypXERC20Lockbox
+    symbol: USDT
+  - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
+    chainName: fraxtal
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
+    chainName: ink
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
+    chainName: lisk
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x324d0b921C03b1e42eeFD198086A64beC3d736c2"
+    chainName: mode
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8"
+    chainName: optimism
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x2dC335bDF489f8e978477Ae53924324697e0f7BB"
+    chainName: soneium
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55"
+    chainName: superseed
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f"
+    chainName: unichain
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3"
+    chainName: worldchain
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypXERC20
+    symbol: oUSDT


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Add warp route config for oUSDT for warpRouteId: `base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain`

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
