### PR TITLE
feat: ETH/base-ethereum-lumiaprism Warp Route Deployment

### DIFF
--- a/.changeset/tidy-parrots-promise.md
+++ b/.changeset/tidy-parrots-promise.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add ETH/base-ethereum-lumiaprism warp route deployment

--- a/deployments/warp_routes/ETH/base-ethereum-lumiaprism-config.yaml
+++ b/deployments/warp_routes/ETH/base-ethereum-lumiaprism-config.yaml
@@ -2,19 +2,23 @@
 tokens:
   - addressOrDenom: "0xE4A9622Bf50025fE99A576D484AEf16280A5304f"
     chainName: base
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|ethereum|0xE0A5921Bcc37eb2FeCc452AE574b86bD4c332196
       - token: ethereum|lumiaprism|0xdCB5227EA8E5FDE0f761A55dC669EC09807E7C8b
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
   - addressOrDenom: "0xE0A5921Bcc37eb2FeCc452AE574b86bD4c332196"
     chainName: ethereum
+    coinGeckoId: ethereum
     connections:
       - token: ethereum|base|0xE4A9622Bf50025fE99A576D484AEf16280A5304f
       - token: ethereum|lumiaprism|0xdCB5227EA8E5FDE0f761A55dC669EC09807E7C8b
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -24,6 +28,7 @@ tokens:
       - token: ethereum|base|0xE4A9622Bf50025fE99A576D484AEf16280A5304f
       - token: ethereum|ethereum|0xE0A5921Bcc37eb2FeCc452AE574b86bD4c332196
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypSynthetic
     symbol: WETH

--- a/deployments/warp_routes/ETH/base-ethereum-lumiaprism-config.yaml
+++ b/deployments/warp_routes/ETH/base-ethereum-lumiaprism-config.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xE4A9622Bf50025fE99A576D484AEf16280A5304f"
+    chainName: base
+    connections:
+      - token: ethereum|ethereum|0xE0A5921Bcc37eb2FeCc452AE574b86bD4c332196
+      - token: ethereum|lumiaprism|0xdCB5227EA8E5FDE0f761A55dC669EC09807E7C8b
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: "0xE0A5921Bcc37eb2FeCc452AE574b86bD4c332196"
+    chainName: ethereum
+    connections:
+      - token: ethereum|base|0xE4A9622Bf50025fE99A576D484AEf16280A5304f
+      - token: ethereum|lumiaprism|0xdCB5227EA8E5FDE0f761A55dC669EC09807E7C8b
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: "0xdCB5227EA8E5FDE0f761A55dC669EC09807E7C8b"
+    chainName: lumiaprism
+    connections:
+      - token: ethereum|base|0xE4A9622Bf50025fE99A576D484AEf16280A5304f
+      - token: ethereum|ethereum|0xE0A5921Bcc37eb2FeCc452AE574b86bD4c332196
+    decimals: 18
+    name: Ether
+    standard: EvmHypSynthetic
+    symbol: WETH


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Add `ETH/base-ethereum-lumiaprism` warp route deployment
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
CLI