### PR TITLE
fix: add missing ETH/base-ethereum-lumiaprism deploy config

### DIFF
--- a/.changeset/rare-impalas-thank.md
+++ b/.changeset/rare-impalas-thank.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add missing ETH/base-ethereum-lumiaprism deploy config

--- a/deployments/warp_routes/ETH/base-ethereum-lumiaprism-deploy.yaml
+++ b/deployments/warp_routes/ETH/base-ethereum-lumiaprism-deploy.yaml
@@ -1,0 +1,16 @@
+base:
+  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+  owner: "0xC92aB408512defCf1938858E726dc5C0ada9175a"
+  type: native
+ethereum:
+  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
+  owner: "0xb10B260fBf5F33CC5Ff81761e090aeCDffcb1fd5"
+  type: native
+lumiaprism:
+  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+  mailbox: "0x0dF25A2d59F03F039b56E90EdC5B89679Ace28Bc"
+  owner: "0x1b06089dA471355F8F05C7A6d8DE1D9dAC397629"
+  symbol: WETH
+  type: synthetic


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Deploy config for ETH/base-ethereum-lumiaprism deploy config
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
