### PR TITLE
chore: remove lorenzo routes default ISM

### DIFF
--- a/.changeset/thirty-roses-play.md
+++ b/.changeset/thirty-roses-play.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Remove Lorenzo routes default ISM config

--- a/deployments/warp_routes/enzoBTC/bsc-hyperevm-deploy.yaml
+++ b/deployments/warp_routes/enzoBTC/bsc-hyperevm-deploy.yaml
@@ -1,11 +1,9 @@
 bsc:
-  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   owner: "0x2313057ba402C55dAE1a1E8086B37fc6Ef7B3503"
   token: "0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a"
   type: collateral
 hyperevm:
-  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
   owner: "0x5A2ee9A4B4D6076cDb3a08c9ae5aca1bD8AD3b02"
   type: synthetic

--- a/deployments/warp_routes/stBTC/bsc-hyperevm-deploy.yaml
+++ b/deployments/warp_routes/stBTC/bsc-hyperevm-deploy.yaml
@@ -1,11 +1,9 @@
 bsc:
-  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   owner: "0x2313057ba402C55dAE1a1E8086B37fc6Ef7B3503"
   token: "0xf6718b2701d4a6498ef77d7c152b2137ab28b8a3"
   type: collateral
 hyperevm:
-  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
   owner: "0x5A2ee9A4B4D6076cDb3a08c9ae5aca1bD8AD3b02"
   type: synthetic


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Default ISM/empty addresses are not needed anymore for deploy config, removed from lorenzo warp routes

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
