### PR TITLE
feat: add authToken parameter to getRegistry function

### DIFF
--- a/.changeset/clean-ladybugs-allow.md
+++ b/.changeset/clean-ladybugs-allow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add authToken parameter to getRegistry function

--- a/src/registry/registry-utils.ts
+++ b/src/registry/registry-utils.ts
@@ -57,11 +57,13 @@ export function getRegistry({
   enableProxy,
   branch,
   logger,
+  authToken,
 }: {
   registryUris: string[];
   enableProxy: boolean;
   branch?: string;
   logger?: Logger;
+  authToken?: string;
 }): IRegistry {
   const registryLogger = logger?.child({ module: 'MergedRegistry' });
   const registries = registryUris
@@ -75,6 +77,7 @@ export function getRegistry({
           branch,
           logger: childLogger,
           proxyUrl: enableProxy ? PROXY_DEPLOYED_URL : undefined,
+          authToken,
         });
       } else {
         if (!isValidFilePath(uri)) {


### PR DESCRIPTION
# Add GitHub Authentication Support

Adds optional `authToken` parameter to `getRegistry` function to support GitHub authentication for private repositories and rate limit handling.

## Changes
- Added `authToken` parameter to `getRegistry`

## Related Issues
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5501