### PR TITLE
chore: remove total supply from deployments config

### DIFF
--- a/.changeset/slimy-moose-lick.md
+++ b/.changeset/slimy-moose-lick.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Remove totalSupply from warp route deployments

--- a/deployments/warp_routes/ECLIP/arbitrum-neutron-deploy.yaml
+++ b/deployments/warp_routes/ECLIP/arbitrum-neutron-deploy.yaml
@@ -8,7 +8,6 @@ arbitrum:
   ownerOverrides:
     proxyAdmin: "0xfF07222cb0AC905304d6586Aabf13f497C07F0C8"
   symbol: ECLIP
-  totalSupply: 0
   type: synthetic
 neutron:
   foreignDeployment: 6b04c49fcfd98bc4ea9c05cd5790462a39537c00028333474aebe6ddf20b73a3

--- a/deployments/warp_routes/ETH/ethereum-viction-deploy.yaml
+++ b/deployments/warp_routes/ETH/ethereum-viction-deploy.yaml
@@ -24,5 +24,4 @@ viction:
     testRecipient: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
     validatorAnnounce: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: ETH
-  totalSupply: 0
   type: synthetic

--- a/deployments/warp_routes/TIA/arbitrum-neutron-deploy.yaml
+++ b/deployments/warp_routes/TIA/arbitrum-neutron-deploy.yaml
@@ -11,7 +11,6 @@ arbitrum:
     testRecipient: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
     validatorAnnounce: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: TIA.n
-  totalSupply: 0
   type: synthetic
 neutron:
   foreignDeployment: 910926c4cf95d107237a9cf0b3305fe9c81351ebcba3d218ceb0e4935d92ceac

--- a/deployments/warp_routes/TIA/mantapacific-neutron-deploy.yaml
+++ b/deployments/warp_routes/TIA/mantapacific-neutron-deploy.yaml
@@ -11,7 +11,6 @@ mantapacific:
     testRecipient: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
     validatorAnnounce: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: TIA
-  totalSupply: 0
   type: synthetic
 neutron:
   foreignDeployment: "0xc5fc6899019cb4a7649981d89eb7b1a0929d0a85b2d41802f3315129ad4b581a"

--- a/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-deploy.yaml
+++ b/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-deploy.yaml
@@ -7,7 +7,6 @@ arbitrum:
     address: "0x2350389Ea8649Da5dD4Fdd09c414dD8463C2695c"
     owner: "0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e"
   symbol: TRUMP
-  totalSupply: 0
   type: synthetic
 avalanche:
   decimals: 18
@@ -18,7 +17,6 @@ avalanche:
     address: "0x86a2E32BB42584127a24079a4f9113EeFE80db90"
     owner: "0x8c8695cD9905e22d84E466804ABE55408A87e595"
   symbol: TRUMP
-  totalSupply: 0
   type: synthetic
 base:
   decimals: 18
@@ -29,7 +27,6 @@ base:
     address: "0xBaE44c2D667C73e2144d938d6cC87901A6fd1c00"
     owner: "0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF"
   symbol: TRUMP
-  totalSupply: 0
   type: synthetic
 flowmainnet:
   decimals: 18
@@ -40,7 +37,6 @@ flowmainnet:
     address: "0xB504EA900302C7Faf24Cc4F155006d6c0357Dc35"
     owner: "0x65528D447C93CC1A1A7186CB4449d9fE0d5C1928"
   symbol: TRUMP
-  totalSupply: 0
   type: synthetic
 form:
   decimals: 18
@@ -51,7 +47,6 @@ form:
     address: "0x5b3EeADcc0E2d4284eA6816e2E503c24d30a9E54"
     owner: "0x5926599B8Aff45f1708b804B30213babdAD78C83"
   symbol: TRUMP
-  totalSupply: 0
   type: synthetic
 optimism:
   decimals: 18
@@ -62,7 +57,6 @@ optimism:
     address: "0x6Fa52E2Fc86B200e7b80394e226929C1f9Ff2950"
     owner: "0xbd7db3821806bc72D223F0AE521Bf82FcBd6Ef4d"
   symbol: TRUMP
-  totalSupply: 0
   type: synthetic
 solanamainnet:
   foreignDeployment: 21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
@@ -72,7 +66,6 @@ solanamainnet:
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: TRUMP
   token: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
-  totalSupply: 0
   type: collateral
 worldchain:
   decimals: 18
@@ -83,5 +76,4 @@ worldchain:
     address: "0x97e4682dBC4Bfd432F1563a7fa9aC218Bc48c861"
     owner: "0x1996DbFcFB433737fE404F58D2c32A7f5f334210"
   symbol: TRUMP
-  totalSupply: 0
   type: synthetic

--- a/deployments/warp_routes/TRUMP/solanamainnet-trumpchain-deploy.yaml
+++ b/deployments/warp_routes/TRUMP/solanamainnet-trumpchain-deploy.yaml
@@ -6,7 +6,6 @@ solanamainnet:
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: TRUMP
   token: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
-  totalSupply: 0
   type: collateral
 trumpchain:
   decimals: 18
@@ -17,5 +16,4 @@ trumpchain:
     address: "0xC5f2c60073DCAA9D157C45d5B017D639dF9C5CeB"
     owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: TRUMP
-  totalSupply: 0
   type: native

--- a/deployments/warp_routes/USDC/ethereum-viction-deploy.yaml
+++ b/deployments/warp_routes/USDC/ethereum-viction-deploy.yaml
@@ -25,5 +25,4 @@ viction:
     testRecipient: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
     validatorAnnounce: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: USDC
-  totalSupply: 0
   type: synthetic

--- a/deployments/warp_routes/USDT/ethereum-viction-deploy.yaml
+++ b/deployments/warp_routes/USDT/ethereum-viction-deploy.yaml
@@ -25,5 +25,4 @@ viction:
     testRecipient: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
     validatorAnnounce: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   symbol: USDT
-  totalSupply: 0
   type: synthetic


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Remove totalSupply from token metadata in warp deployments. The field seems to not be needed in most cases and could cause misconfiguration issues, on the synthetic token contract `totalSupply` was used, which mints tokens to the message sender. 

Instead we now apply a `initialSupply` directly to the synthetic token without the need to use `totalSupply`

Related [PR](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5686) from the monorepo
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
