### PR TITLE
chore: change oUSDT token standard

### DIFF
--- a/.changeset/popular-bottles-develop.md
+++ b/.changeset/popular-bottles-develop.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Change oUSDT tokens standard from XERC20 to VSXERC20

--- a/.changeset/popular-bottles-develop.md
+++ b/.changeset/popular-bottles-develop.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': minor
 ---
 
-Change oUSDT tokens standard from XERC20 to VSXERC20
+Change oUSDT tokens standard from XERC20 to VSXERC20 and remove ink connection

--- a/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
@@ -6,7 +6,6 @@ tokens:
     connections:
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -26,7 +25,6 @@ tokens:
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -45,7 +43,6 @@ tokens:
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -61,17 +58,6 @@ tokens:
   - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
     chainName: ink
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -84,7 +70,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
@@ -103,7 +88,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
@@ -122,7 +106,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
@@ -141,7 +124,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -160,7 +142,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -179,7 +160,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -198,7 +178,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8

--- a/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
@@ -17,7 +17,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
     chainName: celo
@@ -37,7 +37,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT
-    standard: EvmHypXERC20Lockbox
+    standard: EvmHypVSXERC20Lockbox
     symbol: oUSDT
   - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
     chainName: fraxtal
@@ -56,7 +56,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
     chainName: ink
@@ -75,7 +75,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
     chainName: lisk
@@ -94,7 +94,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0x324d0b921C03b1e42eeFD198086A64beC3d736c2"
     chainName: mode
@@ -113,7 +113,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8"
     chainName: optimism
@@ -132,7 +132,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0x2dC335bDF489f8e978477Ae53924324697e0f7BB"
     chainName: soneium
@@ -151,7 +151,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55"
     chainName: superseed
@@ -170,7 +170,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f"
     chainName: unichain
@@ -189,7 +189,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
   - addressOrDenom: "0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3"
     chainName: worldchain
@@ -208,5 +208,5 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@changesets/cli": "^2.26.2",
     "@eslint/js": "^9.1.1",
     "@faker-js/faker": "^9.6.0",
-    "@hyperlane-xyz/sdk": "9.0.0",
+    "@hyperlane-xyz/sdk": "9.2.1",
     "@types/chai-as-promised": "^8",
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,14 +2190,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/core@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@hyperlane-xyz/core@npm:6.0.0"
+"@hyperlane-xyz/core@npm:6.0.3":
+  version: 6.0.3
+  resolution: "@hyperlane-xyz/core@npm:6.0.3"
   dependencies:
     "@arbitrum/nitro-contracts": "npm:^1.2.1"
     "@chainlink/contracts-ccip": "npm:^1.5.0"
     "@eth-optimism/contracts": "npm:^0.6.0"
-    "@hyperlane-xyz/utils": "npm:9.0.0"
+    "@hyperlane-xyz/utils": "npm:9.2.1"
     "@layerzerolabs/lz-evm-oapp-v2": "npm:2.0.2"
     "@openzeppelin/contracts": "npm:^4.9.3"
     "@openzeppelin/contracts-upgradeable": "npm:^4.9.3"
@@ -2206,7 +2206,7 @@ __metadata:
     "@ethersproject/abi": "*"
     "@ethersproject/providers": "*"
     "@types/sinon-chai": "*"
-  checksum: 10/8e2a535eb930644f83d315e409a2528111bf1e64f8e7c3b68d1f541f26172c363becd09c349d3e15ef1fc2b5d631af5c146b861524f0b3364c8d1d9565f4d72e
+  checksum: 10/748562971111096d399be54fad5e73404efbb330eecfdf8dd6eddfc92ca0791ab0eaa1249c1184fdb92d9e877bde64e8a0053f2f2d36c8a57f8e16f236c0a9e4
   languageName: node
   linkType: hard
 
@@ -2217,7 +2217,7 @@ __metadata:
     "@changesets/cli": "npm:^2.26.2"
     "@eslint/js": "npm:^9.1.1"
     "@faker-js/faker": "npm:^9.6.0"
-    "@hyperlane-xyz/sdk": "npm:9.0.0"
+    "@hyperlane-xyz/sdk": "npm:9.2.1"
     "@types/chai-as-promised": "npm:^8"
     "@types/mocha": "npm:^10.0.1"
     "@types/node": "npm:^16.9.1"
@@ -2243,17 +2243,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/sdk@npm:9.0.0":
-  version: 9.0.0
-  resolution: "@hyperlane-xyz/sdk@npm:9.0.0"
+"@hyperlane-xyz/sdk@npm:9.2.1":
+  version: 9.2.1
+  resolution: "@hyperlane-xyz/sdk@npm:9.2.1"
   dependencies:
     "@arbitrum/sdk": "npm:^4.0.0"
     "@aws-sdk/client-s3": "npm:^3.577.0"
     "@chain-registry/types": "npm:^0.50.14"
     "@cosmjs/cosmwasm-stargate": "npm:^0.32.4"
     "@cosmjs/stargate": "npm:^0.32.4"
-    "@hyperlane-xyz/core": "npm:6.0.0"
-    "@hyperlane-xyz/utils": "npm:9.0.0"
+    "@hyperlane-xyz/core": "npm:6.0.3"
+    "@hyperlane-xyz/utils": "npm:9.2.1"
     "@safe-global/api-kit": "npm:1.3.0"
     "@safe-global/protocol-kit": "npm:1.3.0"
     "@safe-global/safe-deployments": "npm:1.37.23"
@@ -2270,13 +2270,13 @@ __metadata:
   peerDependencies:
     "@ethersproject/abi": "*"
     "@ethersproject/providers": "*"
-  checksum: 10/a35dea5ea80932dc2f93fc2dcc6a488dbbba859c8459341d081fb05e3404e9c9152342d29ad06a8636edde6e05090709d7688b7ecb4fe397a26771404f25a5b3
+  checksum: 10/ef288fe8056aba9ffa71f4c2471eb2138d34e735f9b20e719f2a168b25e38b0ea29e815ae25c9201048c0a079e6eba0ca7dc2cfc8902c38723415aaf3a0be6c7
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/utils@npm:9.0.0":
-  version: 9.0.0
-  resolution: "@hyperlane-xyz/utils@npm:9.0.0"
+"@hyperlane-xyz/utils@npm:9.2.1":
+  version: 9.2.1
+  resolution: "@hyperlane-xyz/utils@npm:9.2.1"
   dependencies:
     "@cosmjs/encoding": "npm:^0.32.4"
     "@solana/web3.js": "npm:^1.95.4"
@@ -2285,7 +2285,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     pino: "npm:^8.19.0"
     yaml: "npm:2.4.5"
-  checksum: 10/60d12df1b37bda63b2baa58290b325e4ab8533310057d0a7a56ec8ec04b9a351b536620523e04b609b4af572362b4cfe8a646018211aac1912553f01c78ecfef
+  checksum: 10/b806571d526f03b9dec191d35a58ab499112adc9e6c168a6a9dca1d0c8bf36715151fb5441799bd2d4e17f686e0d69fe7bdc2e32a4adaab73144591030f51396
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

1. Update hyperlane sdk package
2. Update oUSDT warp route token standards from:

     - `XERC20` -> `VSXERC20`
     - `XERC20Lockbox` -> `VSXERC20Lockbox`
3. Remove connections to `ink`

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
Local UI