### PR TITLE
chore: remove worldchain connection in oUSDT

### DIFF
--- a/.changeset/nasty-sloths-train.md
+++ b/.changeset/nasty-sloths-train.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Remove connection to worldchain in oUSDT deployment

--- a/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-config.yaml
@@ -12,7 +12,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -31,7 +30,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT
@@ -49,7 +47,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -75,7 +72,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -93,7 +89,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -111,7 +106,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -129,7 +123,6 @@ tokens:
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -147,7 +140,6 @@ tokens:
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -165,7 +157,6 @@ tokens:
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|worldchain|0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -174,16 +165,6 @@ tokens:
   - addressOrDenom: "0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3"
     chainName: worldchain
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -103,7 +103,7 @@ describe('Registry utilities', () => {
       expect(firstRoute!.tokens.length).to.be.greaterThan(0);
       const noRoutes = await registry.getWarpRoutes({ symbol: 'NOTFOUND' });
       expect(Object.keys(noRoutes).length).to.eql(0);
-    }).timeout(15_000);
+    }).timeout(20_000);
 
     it(`Fetches warp deploy configs for ${registry.type} registry`, async () => {
       const routes = await registry.getWarpDeployConfigs();


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Remove connections from worldchain in oUSDT warp deployments

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
Local UI