### PR TITLE
fix: update fetch method to use GITHUB_API_URL for auth token usage

### DIFF
--- a/.changeset/dirty-masks-pretend.md
+++ b/.changeset/dirty-masks-pretend.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Hot fix GithubRefistry CORS error

--- a/src/registry/GithubRegistry.ts
+++ b/src/registry/GithubRegistry.ts
@@ -271,11 +271,11 @@ export class GithubRegistry extends BaseRegistry implements IRegistry {
 
   protected async fetch(url: string): Promise<Response> {
     this.logger.debug(`Fetching from github: ${url}`);
-    const isProxiedRequest = this.proxyUrl && url.startsWith(this.proxyUrl);
+    const isGithubApiRequest = url.startsWith(GITHUB_API_URL);
     const headers =
-      !isProxiedRequest && !!this.authToken
+      isGithubApiRequest && !!this.authToken
         ? { ...this.baseApiHeaders, Authorization: `Bearer ${this.authToken}` }
-        : this.baseApiHeaders;
+        : undefined;
     const response = await fetch(url, {
       headers,
     });


### PR DESCRIPTION
### Description
Fixes a CORS error that occurs when the GithubRegistry makes requests to raw.githubusercontent.com. The issue was introduced when the X-GitHub-Api-Version header was added to all requests in the @hyperlane-xyz/hyperlane-registry package. While this header is required for GitHub API calls, it causes CORS preflight failures when making requests to raw.githubusercontent.com for metadata and addresses.

This fix:
- Removes the X-GitHub-Api-Version header specifically for raw.githubusercontent.com requests
- Maintains the header for actual GitHub API calls
- Resolves browser-environment CORS errors when fetching metadata and addresses

### Backward compatibility
Yes - This change is fully backward compatible. It only modifies the HTTP request header handling without changing any functional behavior or data structures.

### Testing
All passed including test case written with Github token env.