### PR TITLE
chore: rename usdc route to usdcstage

### DIFF
--- a/.changeset/healthy-cows-argue.md
+++ b/.changeset/healthy-cows-argue.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Rename staging USDC route with proper symbol

--- a/deployments/warp_routes/USDCSTAGE/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed-config.yaml
+++ b/deployments/warp_routes/USDCSTAGE/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed-config.yaml
@@ -8,7 +8,7 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: EvmHypCollateral
-    symbol: USDC
+    symbol: USDCSTAGE
   - addressOrDenom: "0xf728C884De5275a608dEC222dACd0f2BF2E23AB6"
     chainName: superseed
     collateralAddressOrDenom: "0x99a38322cAF878Ef55AE4d0Eda535535eF8C7960"
@@ -22,7 +22,7 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: EvmHypCollateralFiat
-    symbol: USDC
+    symbol: USDCSTAGE
   - addressOrDenom: "0xD74706A5Be0cb87357EF80b4fAEa709287D4f640"
     chainName: arbitrum
     collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
@@ -31,7 +31,7 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: EvmHypCollateral
-    symbol: USDC
+    symbol: USDCSTAGE
   - addressOrDenom: "0x23eE98fD566eBae12296d1B111064921143AD6a7"
     chainName: base
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
@@ -40,7 +40,7 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: EvmHypCollateral
-    symbol: USDC
+    symbol: USDCSTAGE
   - addressOrDenom: "0x5D71b91B92AAE933cbf85065F49bC14f16c55c55"
     chainName: ink
     collateralAddressOrDenom: "0xF1815bd50389c46847f0Bda824eC8da914045D14"
@@ -49,7 +49,7 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: EvmHypCollateral
-    symbol: USDC
+    symbol: USDCSTAGE
   - addressOrDenom: "0x2171e985D95eB12451B723b19458A7f1AdEbc086"
     chainName: optimism
     collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
@@ -58,7 +58,7 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: EvmHypCollateral
-    symbol: USDC
+    symbol: USDCSTAGE
   - addressOrDenom: 8UUnM8wheNwAf3KM65Yx72Mq8mSAHf33GUwEp3MAyQX1
     chainName: solanamainnet
     coinGeckoId: usd-coin
@@ -68,4 +68,4 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: SealevelHypCollateral
-    symbol: USDC
+    symbol: USDCSTAGE


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Rename superseed staging warp route's symbol from USDC to USDCSTAGE

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
