### PR TITLE
chore(ci): split nitro check+update to a separate job

### DIFF
--- a/.github/workflows/update-nitro-chains.yml
+++ b/.github/workflows/update-nitro-chains.yml
@@ -1,4 +1,4 @@
-name: combine
+name: update-nitro-chains
 
 on:
   push:
@@ -43,6 +43,11 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
+      - name: update-nitro-chains
+        run: |
+          echo "Updating Nitro chains..."
+          ./scripts/update-nitro-chains.sh
+
       - name: combine-data
         run: |
           echo "Assembling chain metadata and addresses together..."
@@ -53,7 +58,7 @@ jobs:
           CHANGES=$(git status -s)
           if [[ ! -z $CHANGES ]]; then
             git add .
-            git commit -m "Update chain metadata and address files"
+            git commit -m "Update chain metadata for nitro chains"
             git push
           else
             echo "No changes to commit."


### PR DESCRIPTION
### Description

We're currently spending a lot of time laboriously checking if a chain is a nitro chain in main before doing the metadata/addresses update. This PR splits the check to a separate job so that the actual built-out metadata/addresses files can be updated quicker.

### Backward compatibility

yes

### Testing

ci