### PR TITLE
fix: rotate default ethereum RPCs

### DIFF
--- a/.changeset/three-balloons-remain.md
+++ b/.changeset/three-balloons-remain.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Rotate default ethereum RPC to llamarpc.

--- a/chains/ethereum/metadata.yaml
+++ b/chains/ethereum/metadata.yaml
@@ -27,7 +27,7 @@ nativeToken:
   symbol: ETH
 protocol: ethereum
 rpcUrls:
-  - http: https://rpc.ankr.com/eth
+  - http: https://eth.llamarpc.com
   - http: https://ethereum.publicnode.com
   - http: https://cloudflare-eth.com
   - http: https://eth.drpc.org

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -2239,7 +2239,7 @@ ethereum:
     symbol: ETH
   protocol: ethereum
   rpcUrls:
-    - http: https://rpc.ankr.com/eth
+    - http: https://eth.llamarpc.com
     - http: https://ethereum.publicnode.com
     - http: https://cloudflare-eth.com
     - http: https://eth.drpc.org


### PR DESCRIPTION
### Description

fix: rotate default ethereum RPCs

since ankr endpoint is severely rate limiting in CI

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
