### PR TITLE
feat: USDC/coti-ethereum warp deployment artifacts

### DIFF
--- a/.changeset/blue-socks-jump.md
+++ b/.changeset/blue-socks-jump.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add USDC/coti-ethereum warp deployment artifacts

--- a/deployments/warp_routes/USDC/coti-ethereum-config.yaml
+++ b/deployments/warp_routes/USDC/coti-ethereum-config.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xAAeb91195C025C9D35F8FF70e13049D8cD25703D"
+    chainName: coti
+    connections:
+      - token: ethereum|ethereum|0xB37b7186B07BEBA590e7439faD55c5b7E1E7e4CE
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC
+  - addressOrDenom: "0xB37b7186B07BEBA590e7439faD55c5b7E1E7e4CE"
+    chainName: ethereum
+    coinGeckoId: usdc
+    collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    connections:
+      - token: ethereum|coti|0xAAeb91195C025C9D35F8FF70e13049D8cD25703D
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDC

--- a/deployments/warp_routes/USDC/coti-ethereum-deploy.yaml
+++ b/deployments/warp_routes/USDC/coti-ethereum-deploy.yaml
@@ -1,0 +1,9 @@
+coti:
+  isNft: false
+  owner: "0xdF2E2886d23ba57F996C203D2Ccd9dCa6373590C"
+  type: synthetic
+ethereum:
+  isNft: false
+  owner: "0x490056F682A417C04c08DE1be0C96965182BBa20"
+  token: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+  type: collateral


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Add deployment artifacts for `USDC/coti-ethereum`

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
manual