### PR TITLE
feat: Remove routing between base and ethereum for superseed cbbtc

### DIFF
--- a/.changeset/dry-buttons-unite.md
+++ b/.changeset/dry-buttons-unite.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Remove routing between base and ethereum

--- a/deployments/warp_routes/CBBTC/base-ethereum-superseed-config.yaml
+++ b/deployments/warp_routes/CBBTC/base-ethereum-superseed-config.yaml
@@ -6,7 +6,6 @@ tokens:
     collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
     connections:
       - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
-      - token: ethereum|base|0x66477F84bd21697c7781fc3992b3163463e3B224
     decimals: 8
     logoURI: /deployments/warp_routes/CBBTC/logo.svg
     name: Coinbase Wrapped BTC
@@ -28,7 +27,6 @@ tokens:
     coinGeckoId: coinbase-wrapped-btc
     collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
     connections:
-      - token: ethereum|ethereum|0x7710d2FC9A2E0452b28a2cBf550429b579347199
       - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
     decimals: 8
     logoURI: /deployments/warp_routes/CBBTC/logo.svg


### PR DESCRIPTION
### Description
This PR removes routing between base and ethereum for superseed cbbtc

### Backward compatibility
Yes

### Testing
Local testing with `yarn link` on warp ui