### PR TITLE
fix: update default polygon RPCs

### DIFF
--- a/.changeset/moody-mugs-whisper.md
+++ b/.changeset/moody-mugs-whisper.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update polygon RPCs, removing default ankr one.

--- a/chains/polygon/metadata.yaml
+++ b/chains/polygon/metadata.yaml
@@ -25,5 +25,6 @@ protocol: ethereum
 rpcUrls:
   - http: https://polygon-bor.publicnode.com
   - http: https://polygon-rpc.com
-  - http: https://rpc.ankr.com/polygon
+  - http: https://polygon.drpc.org
+  - http: https://polygon-pokt.nodies.app
 technicalStack: other


### PR DESCRIPTION
### Description

fix: update default polygon RPCs

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
