### PR TITLE
feat: USDC/ethereum-lumiaprism artifacts

### DIFF
--- a/.changeset/kind-melons-pull.md
+++ b/.changeset/kind-melons-pull.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add USDC/ethereum-lumiaprism warp route artifacts

--- a/deployments/warp_routes/USDC/ethereum-lumiaprism-config.yaml
+++ b/deployments/warp_routes/USDC/ethereum-lumiaprism-config.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x066abc14c59cF7681b4b66844500733D2258032A"
+    chainName: ethereum
+    coinGeckoId: usdc
+    collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    connections:
+      - token: ethereum|lumiaprism|0x2D0b95BB7eC6A8A3B3229e8FB8bE5848aBEA137a
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDC
+  - addressOrDenom: "0x2D0b95BB7eC6A8A3B3229e8FB8bE5848aBEA137a"
+    chainName: lumiaprism
+    coinGeckoId: usdc
+    collateralAddressOrDenom: "0xFF297AC2CB0a236155605EB37cB55cFCAe6D3F01"
+    connections:
+      - token: ethereum|ethereum|0x066abc14c59cF7681b4b66844500733D2258032A
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCollateralFiat
+    symbol: USDC

--- a/deployments/warp_routes/USDC/ethereum-lumiaprism-deploy.yaml
+++ b/deployments/warp_routes/USDC/ethereum-lumiaprism-deploy.yaml
@@ -1,0 +1,11 @@
+ethereum:
+  isNft: false
+  owner: "0x18da35630c84fCD9d9c947fC61cA7a6d9b841577"
+  token: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+  type: collateral
+lumiaprism:
+  isNft: false
+  owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
+  token: "0xFF297AC2CB0a236155605EB37cB55cFCAe6D3F01"
+  type: collateralFiat
+


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Artifacts for USDC/ethereum-lumiaprism warp route deployment
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
CLI