### PR TITLE
fix: milkyway `from` block

### DIFF
--- a/.changeset/cool-seahorses-worry.md
+++ b/.changeset/cool-seahorses-worry.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Fix `from` block from milkyway

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -4102,7 +4102,7 @@ milkyway:
     - http: https://grpc.mainnet.milkyway.zone/
   index:
     chunk: 10
-    from: 2454618
+    from: 2249100
   name: milkyway
   nativeToken:
     decimals: 6


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
