### PR TITLE
chore: Update remoteRouter names to domainIds

### DIFF
--- a/.changeset/tidy-donuts-train.md
+++ b/.changeset/tidy-donuts-train.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update remoteRouter names to domainIds for zeronetwork USDC & USDT, and teasure SMOL

--- a/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-deploy.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-ethereum-solanamainnet-treasure-deploy.yaml
@@ -2,6 +2,11 @@ arbitrum:
   decimals: 18
   name: SMOL
   owner: "0xD1D943c09b9C3355207ce8c85aB1c4558f6Cd851"
+  remoteRouters:
+    "1":
+      address: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
+    "61166":
+      address: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
   symbol: SMOL
   token: "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5"
   type: collateral

--- a/deployments/warp_routes/USDC/arbitrum-base-ethereum-lisk-optimism-polygon-zeronetwork-deploy.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-base-ethereum-lisk-optimism-polygon-zeronetwork-deploy.yaml
@@ -5,8 +5,10 @@ arbitrum:
     address: "0x02317D525FA7ceb5ea388244b4618f0c8Ac1CeC2"
     owner: "0xAC98b0cD1B64EA4fe133C6D2EDaf842cE5cF4b01"
   remoteRouters:
-    lisk: { address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0" }
-    zeronetwork: { address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1" }
+    "1135":
+      address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+    "543210":
+      address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
   token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
   type: collateral
 base:
@@ -16,8 +18,10 @@ base:
     address: "0xB6E9331576C5aBF69376AF6989eA61b7C7ea67F1"
     owner: "0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF"
   remoteRouters:
-    lisk: { address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0" }
-    zeronetwork: { address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1" }
+    "1135":
+      address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+    "543210":
+      address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   type: collateral
 ethereum:
@@ -27,8 +31,10 @@ ethereum:
     address: "0x81063D413Ed6Eac3FCf0521eea14906fD27fEb1A"
     owner: "0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6"
   remoteRouters:
-    lisk: { address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0" }
-    zeronetwork: { address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1" }
+    "1135":
+      address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+    "543210":
+      address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
   token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
   type: collateral
 lisk:
@@ -51,8 +57,10 @@ optimism:
     address: "0xca9e64761C97b049901dF4E7a5926464969528b1"
     owner: "0xbd7db3821806bc72D223F0AE521Bf82FcBd6Ef4d"
   remoteRouters:
-    lisk: { address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0" }
-    zeronetwork: { address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1" }
+    "1135":
+      address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+    "543210":
+      address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
   token: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
   type: collateral
 polygon:
@@ -62,8 +70,10 @@ polygon:
     address: "0x7fd5be37d560626625f395A2e6E30eA89150cc98"
     owner: "0xBDD25dd5203fedE33FD631e30fEF9b9eF2598ECE"
   remoteRouters:
-    lisk: { address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0" }
-    zeronetwork: { address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1" }
+    "1135":
+      address: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+    "543210":
+      address: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
   token: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
   type: collateral
 zeronetwork:

--- a/deployments/warp_routes/USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork-deploy.yaml
+++ b/deployments/warp_routes/USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork-deploy.yaml
@@ -5,7 +5,8 @@ arbitrum:
     address: "0x6701d503369cf6aA9e5EdFfEBFA40A2ffdf3dB21"
     owner: "0xAC98b0cD1B64EA4fe133C6D2EDaf842cE5cF4b01"
   remoteRouters:
-    zeronetwork: { address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab" }
+    "543210":
+      address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
   token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
   type: collateral
 ethereum:
@@ -15,7 +16,8 @@ ethereum:
     address: "0xA92D6084709469A2B2339919FfC568b7C5D7888D"
     owner: "0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6"
   remoteRouters:
-    zeronetwork: { address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab" }
+    "543210":
+      address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
   token: "0xdac17f958d2ee523a2206206994597c13d831ec7"
   type: collateral
 mantle:
@@ -25,7 +27,8 @@ mantle:
     address: "0x633268639892C73Fa7340Ec1da4e397cf3913c8C"
     owner: "0x08C880b88335CA3e85Ebb4E461245a7e899863c9"
   remoteRouters:
-    zeronetwork: { address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab" }
+    "543210":
+      address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
   token: "0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE"
   type: collateral
 mode:
@@ -35,7 +38,8 @@ mode:
     address: "0x633268639892C73Fa7340Ec1da4e397cf3913c8C"
     owner: "0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5"
   remoteRouters:
-    zeronetwork: { address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab" }
+    "543210":
+      address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
   token: "0xf0F161fDA2712DB8b566946122a5af183995e2eD"
   type: collateral
 polygon:
@@ -45,7 +49,8 @@ polygon:
     address: "0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c"
     owner: "0xBDD25dd5203fedE33FD631e30fEF9b9eF2598ECE"
   remoteRouters:
-    zeronetwork: { address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab" }
+    "543210":
+      address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
   token: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
   type: collateral
 scroll:
@@ -55,7 +60,8 @@ scroll:
     address: "0x81Db8B4Bc6F2e95781eeA2a21D0A453Ac046eFc0"
     owner: "0x2a3fe2513F4A7813683d480724AB0a3683EfF8AC"
   remoteRouters:
-    zeronetwork: { address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab" }
+    "543210":
+      address: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
   token: "0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df"
   type: collateral
 zeronetwork:


### PR DESCRIPTION
### Description
This PR Updates remoteRouter names to domainIds. Related https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6066

### Backward compatibility
Yes

### Testing
yarn check-warp-deploy
