### PR TITLE
fix: oUSDT staging symbol

### DIFF
--- a/.changeset/curvy-maps-care.md
+++ b/.changeset/curvy-maps-care.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Change oUSDT staging symbol to oUSDTSTAGE

--- a/deployments/warp_routes/USDTSTAGING/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDTSTAGING/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
@@ -25,7 +25,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x78a2D1891e7D1259695b4795e04285C478E068E6"
     chainName: celo
     collateralAddressOrDenom: "0x9a3D8d7E931679374448FB2B661F664D42d05057"
@@ -51,7 +51,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20Lockbox
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x086dE790943c23c42176236c392Fa9C35e660cE5"
     chainName: fraxtal
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -77,7 +77,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0xBb2eBD68b2FEEe450dce91509897F9AE02211421"
     chainName: ink
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -103,7 +103,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3"
     chainName: lisk
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -129,7 +129,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x0071740Bf129b05C4684abfbBeD248D80971cce2"
     chainName: mode
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -155,7 +155,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x1D833D392379929f15d03d212DbF8c17001c27e3"
     chainName: optimism
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -181,7 +181,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0xA895A9e1D3A2269F57544A8F7E697300626F0900"
     chainName: soneium
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -207,7 +207,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6"
     chainName: superseed
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -233,7 +233,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x7189A511D4312148cC0aEf79129417f714e3155E"
     chainName: unichain
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -259,7 +259,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0xE047cb95FB3b7117989e911c6afb34771183fC35"
     chainName: worldchain
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -285,7 +285,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x978a80bC3E97AAD6F71acF9013A015690E77010a"
     chainName: metal
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -311,7 +311,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732"
     chainName: bitlayer
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -337,7 +337,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x200183De44bf765ECB73cD62A74010EaaBC43146"
     chainName: ronin
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -363,7 +363,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5"
     chainName: metis
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -389,7 +389,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0xeE80ab5B563cB3825133f29502bA34eD3707cb8C"
     chainName: linea
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -415,7 +415,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f"
     chainName: mantle
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -441,7 +441,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78"
     chainName: sonic
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
@@ -467,7 +467,7 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
-    symbol: oUSDT
+    symbol: oUSDTSTAGE
   - addressOrDenom: "0x8a60E4aC11C2Fac40Dc936E048e05145547A4356"
     chainName: ethereum
     collateralAddressOrDenom: "0x935EAaAb78B491Cd9281f438E413767893913983"
@@ -493,4 +493,4 @@ tokens:
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20Lockbox
-    symbol: oUSDT
+    symbol: oUSDTSTAGE


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Change oUSDT symbol to oUSDTSTAGE and fixed issue with build
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
