### PR TITLE
chore: update oUSDT route connections

### DIFF
--- a/.changeset/violet-ads-burn.md
+++ b/.changeset/violet-ads-burn.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Remove connections to and from sonic, bitlayer, ronin, mantle and linea for oUSDT route

--- a/deployments/warp_routes/USDT/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDT/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
@@ -13,13 +13,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -40,13 +35,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -66,13 +56,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -92,13 +77,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -118,13 +98,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -144,13 +119,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -170,13 +140,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -196,13 +161,8 @@ tokens:
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -222,13 +182,8 @@ tokens:
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -248,13 +203,8 @@ tokens:
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -272,24 +222,6 @@ tokens:
   - addressOrDenom: "0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d"
     chainName: ronin
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -309,12 +241,7 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -324,24 +251,6 @@ tokens:
   - addressOrDenom: "0xC58eeC72352b04358b0b6979ba10462190f0d54C"
     chainName: bitlayer
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -361,12 +270,7 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
@@ -376,24 +280,6 @@ tokens:
   - addressOrDenom: "0x9909F6C638f61CFcEc4464e5b746402F56ced8F0"
     chainName: linea
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -402,24 +288,6 @@ tokens:
   - addressOrDenom: "0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683"
     chainName: mantle
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -428,24 +296,6 @@ tokens:
   - addressOrDenom: "0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C"
     chainName: sonic
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -466,13 +316,8 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|linea|0x9909F6C638f61CFcEc4464e5b746402F56ced8F0
-      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
-      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Remove connections for:
- sonic
- bitlayer
- ronin
- mantle
- linea

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
