### PR TITLE
Refactor/add warp route config

### DIFF
--- a/.changeset/afraid-mails-call.md
+++ b/.changeset/afraid-mails-call.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': major
+---
+
+Standardized Warp Route configuration API by adding consistent addWarpRouteConfig method to IRegistry interface and removed method overload in FileSystemRegistry.

--- a/src/fs/FileSystemRegistry.ts
+++ b/src/fs/FileSystemRegistry.ts
@@ -126,24 +126,12 @@ export class FileSystemRegistry extends SynchronousRegistry implements IRegistry
       data: toYamlString(config, SCHEMA_REF),
     });
   }
-  //TODO: This string parameter overload is for backwards compatibility with the export-warp-configs.ts script.
-  //It should be removed when all consumers have been updated to use the options parameter.
-  //See: https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/eb3054c59184573f67f79a801965c8e4cc2ed3ce/typescript/infra/scripts/warp-routes/export-warp-configs.ts#L35
-  addWarpRouteConfig(warpConfig: WarpRouteDeployConfig, fileName: string): void;
-  addWarpRouteConfig(warpConfig: WarpRouteDeployConfig, options: AddWarpRouteConfigOptions): void;
-  addWarpRouteConfig(
-    warpConfig: WarpRouteDeployConfig,
-    fileNameOrOptions: string | AddWarpRouteConfigOptions,
-  ): void {
-    let filePath: string;
 
-    if (typeof fileNameOrOptions === 'string') {
-      filePath = path.join(this.uri, this.getWarpRoutesPath(), fileNameOrOptions);
-    } else {
-      filePath = this.getWarpRouteDeployConfigPath(warpConfig, fileNameOrOptions);
-    }
-
-    this.createFile({ filePath, data: toYamlString(warpConfig) });
+  addWarpRouteConfig(warpConfig: WarpRouteDeployConfig, options: AddWarpRouteConfigOptions): void {
+    this.createFile({
+      filePath: this.getWarpRouteDeployConfigPath(warpConfig, options),
+      data: toYamlString(warpConfig),
+    });
   }
 
   protected listFiles(dirPath: string): string[] {

--- a/src/fs/FileSystemRegistry.ts
+++ b/src/fs/FileSystemRegistry.ts
@@ -128,8 +128,9 @@ export class FileSystemRegistry extends SynchronousRegistry implements IRegistry
   }
 
   addWarpRouteConfig(warpConfig: WarpRouteDeployConfig, options: AddWarpRouteConfigOptions): void {
+    const filePath = path.join(this.uri, this.getWarpRouteDeployConfigPath(warpConfig, options));
     this.createFile({
-      filePath: this.getWarpRouteDeployConfigPath(warpConfig, options),
+      filePath,
       data: toYamlString(warpConfig),
     });
   }

--- a/src/registry/BaseRegistry.ts
+++ b/src/registry/BaseRegistry.ts
@@ -98,6 +98,10 @@ export abstract class BaseRegistry implements IRegistry {
   abstract getWarpRoute(routeId: string): MaybePromise<WarpCoreConfig | null>;
   abstract getWarpRoutes(filter?: WarpRouteFilterParams): MaybePromise<WarpRouteConfigMap>;
   abstract addWarpRoute(config: WarpCoreConfig): MaybePromise<void>;
+  abstract addWarpRouteConfig(
+    warpConfig: WarpRouteDeployConfig,
+    options: AddWarpRouteConfigOptions,
+  ): MaybePromise<void>;
 
   abstract getWarpDeployConfig(routeId: string): MaybePromise<WarpRouteDeployConfig | null>;
   abstract getWarpDeployConfigs(filter?: WarpRouteFilterParams): MaybePromise<WarpDeployConfigMap>;

--- a/src/registry/GithubRegistry.ts
+++ b/src/registry/GithubRegistry.ts
@@ -20,6 +20,7 @@ import { ChainAddresses, WarpDeployConfigMap, WarpRouteConfigMap, WarpRouteId } 
 import { concurrentMap, parseGitHubPath, stripLeadingSlash } from '../utils.js';
 import { BaseRegistry } from './BaseRegistry.js';
 import {
+  AddWarpRouteConfigOptions,
   ChainFiles,
   IRegistry,
   RegistryContent,
@@ -224,6 +225,13 @@ export class GithubRegistry extends BaseRegistry implements IRegistry {
   }
 
   async addWarpRoute(_config: WarpCoreConfig): Promise<void> {
+    throw new Error('TODO: Implement');
+  }
+
+  async addWarpRouteConfig(
+    _config: WarpRouteDeployConfig,
+    _options: AddWarpRouteConfigOptions,
+  ): Promise<void> {
     throw new Error('TODO: Implement');
   }
 

--- a/src/registry/IRegistry.ts
+++ b/src/registry/IRegistry.ts
@@ -86,6 +86,10 @@ export interface IRegistry {
   getWarpRoute(routeId: string): MaybePromise<WarpCoreConfig | null>;
   getWarpRoutes(filter?: WarpRouteFilterParams): MaybePromise<WarpRouteConfigMap>;
   addWarpRoute(config: WarpCoreConfig, options?: AddWarpRouteOptions): MaybePromise<void>;
+  addWarpRouteConfig(
+    config: WarpRouteDeployConfig,
+    options: AddWarpRouteConfigOptions,
+  ): MaybePromise<void>;
 
   getWarpDeployConfig(routeId: string): MaybePromise<WarpRouteDeployConfig | null>;
   getWarpDeployConfigs(filter?: WarpRouteFilterParams): MaybePromise<WarpDeployConfigMap>;

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -139,7 +139,7 @@ export class MergedRegistry implements IRegistry {
   ): Promise<void> {
     return this.multiRegistryWrite(
       async (registry) => await registry.addWarpRouteConfig(config, options),
-      'adding warp route config',
+      'adding warp route deploy config',
     );
   }
 

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -1,9 +1,16 @@
 import type { Logger } from 'pino';
 
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type {
+  ChainMap,
+  ChainMetadata,
+  ChainName,
+  WarpCoreConfig,
+  WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
 import { ChainAddresses, WarpDeployConfigMap, WarpRouteConfigMap, WarpRouteId } from '../types.js';
 import { objMerge } from '../utils.js';
 import {
+  AddWarpRouteConfigOptions,
   AddWarpRouteOptions,
   IRegistry,
   RegistryContent,
@@ -46,7 +53,7 @@ export class MergedRegistry implements IRegistry {
       chains: {},
       deployments: {
         warpRoutes: {},
-        warpDeployConfig: {}
+        warpDeployConfig: {},
       },
     });
   }
@@ -123,6 +130,16 @@ export class MergedRegistry implements IRegistry {
     return this.multiRegistryWrite(
       async (registry) => await registry.addWarpRoute(config, options),
       'adding warp route',
+    );
+  }
+
+  async addWarpRouteConfig(
+    config: WarpRouteDeployConfig,
+    options: AddWarpRouteConfigOptions,
+  ): Promise<void> {
+    return this.multiRegistryWrite(
+      async (registry) => await registry.addWarpRouteConfig(config, options),
+      'adding warp route config',
     );
   }
 

--- a/src/registry/PartialRegistry.ts
+++ b/src/registry/PartialRegistry.ts
@@ -1,8 +1,20 @@
 import type { Logger } from 'pino';
 
-import type { ChainMap, ChainMetadata, ChainName, WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import type {
+  ChainMap,
+  ChainMetadata,
+  ChainName,
+  WarpCoreConfig,
+  WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
 import { ChainAddresses, DeepPartial, WarpRouteId } from '../types.js';
-import { ChainFiles, IRegistry, RegistryContent, RegistryType } from './IRegistry.js';
+import {
+  AddWarpRouteConfigOptions,
+  ChainFiles,
+  IRegistry,
+  RegistryContent,
+  RegistryType,
+} from './IRegistry.js';
 import { SynchronousRegistry } from './SynchronousRegistry.js';
 import { warpRouteConfigToId } from './warp-utils.js';
 
@@ -28,7 +40,13 @@ export class PartialRegistry extends SynchronousRegistry implements IRegistry {
   public warpRoutes: Array<DeepPartial<WarpCoreConfig>>;
   public warpDeployConfigs: Array<DeepPartial<WarpRouteDeployConfig>>;
 
-  constructor({ chainMetadata, chainAddresses, warpRoutes, warpDeployConfigs, logger }: PartialRegistryOptions) {
+  constructor({
+    chainMetadata,
+    chainAddresses,
+    warpRoutes,
+    warpDeployConfigs,
+    logger,
+  }: PartialRegistryOptions) {
     super({ uri: PARTIAL_URI_PLACEHOLDER, logger });
     this.chainMetadata = chainMetadata || {};
     this.chainAddresses = chainAddresses || {};
@@ -61,7 +79,7 @@ export class PartialRegistry extends SynchronousRegistry implements IRegistry {
       chains,
       deployments: {
         warpRoutes,
-        warpDeployConfig: {} // TODO: This cannot be implemented without deriving the token symbol from config.token
+        warpDeployConfig: {}, // TODO: This cannot be implemented without deriving the token symbol from config.token
       },
     };
   }
@@ -81,6 +99,10 @@ export class PartialRegistry extends SynchronousRegistry implements IRegistry {
   }
 
   addWarpRoute(_config: WarpCoreConfig): void {
+    throw new Error('Method not implemented.');
+  }
+
+  addWarpRouteConfig(_config: WarpRouteDeployConfig, _options: AddWarpRouteConfigOptions): void {
     throw new Error('Method not implemented.');
   }
 

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -3,7 +3,12 @@ import { use as chaiUse, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import { faker } from '@faker-js/faker';
-import type { ChainMetadata, WarpRouteDeployConfig, WarpCoreConfig } from '@hyperlane-xyz/sdk';
+import {
+  type ChainMetadata,
+  type WarpRouteDeployConfig,
+  type WarpCoreConfig,
+  TokenType,
+} from '@hyperlane-xyz/sdk';
 import type { Logger } from 'pino';
 import fs from 'fs';
 import { CHAIN_FILE_REGEX } from '../../src/consts.js';
@@ -183,6 +188,51 @@ describe('Registry utilities', () => {
       expect(fs.existsSync(configPath)).to.be.true;
       fs.unlinkSync(configPath);
       fs.rmdirSync(`deployments/warp_routes/${MOCKED_OPTION_SYMBOL}`);
+    }).timeout(5_000);
+
+    it(`Adds a warp route deploy config for ${registry.type} registry using the provided symbol`, async () => {
+      registry.addWarpRouteConfig(
+        {
+          [MOCK_CHAIN_NAME]: {
+            type: TokenType.collateral,
+            owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            token: '0x0000000000000000000000000000000000000001',
+          },
+          [MOCK_CHAIN_NAME2]: {
+            type: TokenType.synthetic,
+            owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          },
+        },
+        { symbol: MOCK_SYMBOL },
+      );
+      const outputBasePath = `deployments/warp_routes/${MOCK_SYMBOL}/${MOCK_CHAIN_NAME}-${MOCK_CHAIN_NAME2}-`;
+      const configPath = `${outputBasePath}deploy.yaml`;
+      expect(fs.existsSync(configPath)).to.be.true;
+      fs.unlinkSync(configPath);
+      fs.rmdirSync(`deployments/warp_routes/${MOCK_SYMBOL}`);
+    }).timeout(5_000);
+
+    it(`Adds a warp route deploy config for ${registry.type} registry using the provided warp route id`, async () => {
+      const MOCKED_WARP_ROUTE_ID = 'OPTION/CHAIN1-CHAIN2';
+
+      registry.addWarpRouteConfig(
+        {
+          [MOCK_CHAIN_NAME]: {
+            type: TokenType.collateral,
+            owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            token: '0x0000000000000000000000000000000000000001',
+          },
+          [MOCK_CHAIN_NAME2]: {
+            type: TokenType.synthetic,
+            owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          },
+        },
+        { warpRouteId: MOCKED_WARP_ROUTE_ID },
+      );
+      const configPath = `deployments/warp_routes/${MOCKED_WARP_ROUTE_ID}-deploy.yaml`;
+      expect(fs.existsSync(configPath)).to.be.true;
+      fs.unlinkSync(configPath);
+      fs.rmdirSync(`deployments/warp_routes/${MOCKED_WARP_ROUTE_ID.split('/')[0]}`);
     }).timeout(5_000);
   }
 
@@ -575,6 +625,7 @@ class TestBaseRegistry extends BaseRegistry {
     return {};
   }
   async addWarpRoute() {}
+  async addWarpRouteConfig() {}
   async getWarpDeployConfig() {
     return null;
   }


### PR DESCRIPTION
### Description

Add Warp Route Config interface standardization across all registry implementations by introducing a consistent `addWarpRouteConfig` method to the `IRegistry` interface and refactoring implementations to use a unified approach.

### Backward compatibility

No - Removes the overloaded string parameter version of `addWarpRouteConfig` in FileSystemRegistry which was previously maintained for backward compatibility.

### Related issues
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5244

### Testing

The standardized API has been tested with internal Hyperlane registry operations. All registry implementation classes have been updated to properly implement the new interface method.