### PR TITLE
chore: remove ink connection for oUSDT

### DIFF
--- a/.changeset/rotten-windows-drop.md
+++ b/.changeset/rotten-windows-drop.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Remove ink connection for oUSDT

--- a/deployments/warp_routes/USDT/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDT/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
@@ -6,7 +6,6 @@ tokens:
     connections:
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -28,7 +27,6 @@ tokens:
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -49,7 +47,6 @@ tokens:
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -67,19 +64,6 @@ tokens:
   - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
     chainName: ink
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -92,7 +76,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
@@ -113,7 +96,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
@@ -134,7 +116,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
@@ -155,7 +136,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -176,7 +156,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -197,7 +176,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -234,7 +212,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -263,7 +240,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
@@ -309,7 +285,6 @@ tokens:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Remove connection to ink from oUSDT route

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
