### PR TITLE
chore: update eclipsemainnet block explorer

### DIFF
--- a/.changeset/tidy-chairs-pump.md
+++ b/.changeset/tidy-chairs-pump.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update eclipse block explorer URL

--- a/chains/eclipsemainnet/metadata.yaml
+++ b/chains/eclipsemainnet/metadata.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://explorer.eclipse.xyz/api
+  - apiUrl: https://api.eclipsescan.xyz/
     family: other
     name: Eclipse Explorer
-    url: https://explorer.eclipse.xyz/
+    url: https://eclipsescan.xyz/
 blocks:
   confirmations: 1
   estimateBlockTime: 0.4


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Update eclipse block explorer URL 
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
