### PR TITLE
chore: update plumenetwork.xyz to plume.org

### DIFF
--- a/.changeset/cuddly-experts-jump.md
+++ b/.changeset/cuddly-experts-jump.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update plumenetwork.xyz -> plume.org.

--- a/chains/plume/metadata.yaml
+++ b/chains/plume/metadata.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://phoenix-explorer.plumenetwork.xyz/api
+  - apiUrl: https://explorer.plume.org/api
     family: blockscout
     name: Plume Explorer
-    url: https://phoenix-explorer.plumenetwork.xyz
+    url: https://explorer.plume.org
 blocks:
   confirmations: 1
   estimateBlockTime: 2
@@ -24,5 +24,5 @@ nativeToken:
   symbol: PLUME
 protocol: ethereum
 rpcUrls:
-  - http: https://phoenix-rpc.plumenetwork.xyz
+  - http: https://rpc.plume.org
 technicalStack: arbitrumnitro

--- a/chains/plumetestnet2/metadata.yaml
+++ b/chains/plumetestnet2/metadata.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://testnet-explorer.plumenetwork.xyz/api
+  - apiUrl: https://testnet-explorer.plume.org/api
     family: blockscout
     name: Plume Explorer
-    url: https://testnet-explorer.plumenetwork.xyz
+    url: https://testnet-explorer.plume.org
 blocks:
   confirmations: 1
   estimateBlockTime: 2
@@ -25,5 +25,5 @@ nativeToken:
   symbol: PLUME
 protocol: ethereum
 rpcUrls:
-  - http: https://testnet-rpc.plumenetwork.xyz
+  - http: https://testnet-rpc.plume.org
 technicalStack: arbitrumnitro


### PR DESCRIPTION
### Description

chore: update plumenetwork.xyz to plume.org

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
