### PR TITLE
fix: only download zip archives when in Node.js

### DIFF
--- a/.changeset/cuddly-sheep-kneel.md
+++ b/.changeset/cuddly-sheep-kneel.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The GithubRegistry now bypasses the new archive downloading logic when running in a browser environment


### PR DESCRIPTION
### Description

This PR fixes the zip-downloading issue experienced by browser-based registry clients. We tried to download the zip archives in a way that's prevented by CORS. There's no quick workaround, so the code now reverts to old behaviour when running in a browser.

### Backward compatibility

Yes

### Testing

- No new unit-tests added
- Manually tested from hyperlane-explorer