### PR TITLE
Feat/yaml custom sorting

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -3,5 +3,5 @@
   "*.ts": "prettier --write", 
   "*.md": "prettier --write",
   "*.json": "prettier --write",
-  "*.yaml": "prettier --write"
+  "*.yaml": ["eslint --fix", "prettier --write"]
 }

--- a/deployments/warp_routes/AIXBT/base-form-config.yaml
+++ b/deployments/warp_routes/AIXBT/base-form-config.yaml
@@ -1,14 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x40Ca4155c0334F7e0F6d7F80536B59EF8831c9fb"
-    chainName: form
-    connections:
-      - token: ethereum|base|0xa6536c88A7f86d2b189c58A5a19BF5F03241d6A0
-    decimals: 18
-    logoURI: /deployments/warp_routes/AIXBT/logo.svg
-    name: aixbt by Virtuals
-    standard: EvmHypSynthetic
-    symbol: AIXBT
   - addressOrDenom: "0xa6536c88A7f86d2b189c58A5a19BF5F03241d6A0"
     chainName: base
     coinGeckoId: aixbt-by-virtuals
@@ -19,4 +10,13 @@ tokens:
     logoURI: /deployments/warp_routes/AIXBT/logo.svg
     name: aixbt by Virtuals
     standard: EvmHypCollateral
+    symbol: AIXBT
+  - addressOrDenom: "0x40Ca4155c0334F7e0F6d7F80536B59EF8831c9fb"
+    chainName: form
+    connections:
+      - token: ethereum|base|0xa6536c88A7f86d2b189c58A5a19BF5F03241d6A0
+    decimals: 18
+    logoURI: /deployments/warp_routes/AIXBT/logo.svg
+    name: aixbt by Virtuals
+    standard: EvmHypSynthetic
     symbol: AIXBT

--- a/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-config.yaml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: 9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: 6AjQBsySS1FtQmA7a4oYc6GYpHBTDqtSswptsVSTz3Tv
+    connections:
+      - token: ethereum|ethereum|0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c
+    decimals: 9
+    logoURI: /deployments/warp_routes/APXETH/logo.svg
+    name: Autocompounding Pirex Ether
+    standard: SealevelHypSynthetic
+    symbol: apxETH
   - addressOrDenom: "0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c"
     chainName: ethereum
     # Not directly listed on Coingecko, but Ethereum is a close approximation
@@ -11,14 +21,4 @@ tokens:
     logoURI: /deployments/warp_routes/APXETH/logo.svg
     name: Autocompounding Pirex Ether
     standard: EvmHypCollateral
-    symbol: apxETH
-  - addressOrDenom: 9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: 6AjQBsySS1FtQmA7a4oYc6GYpHBTDqtSswptsVSTz3Tv
-    connections:
-      - token: ethereum|ethereum|0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c
-    decimals: 9
-    logoURI: /deployments/warp_routes/APXETH/logo.svg
-    name: Autocompounding Pirex Ether
-    standard: SealevelHypSynthetic
     symbol: apxETH

--- a/deployments/warp_routes/Bonk/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/Bonk/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: BMjPo9Yz9bdiLuKVfHfjuAEE6JgmnMWYaVEv1ehFYnd7
-    chainName: soon
-    collateralAddressOrDenom: 71kRXzJMvSeArtXYNEWa8KAjpRJosdMQ7Dpgy5Jt5zfd
-    connections:
-      - token: sealevel|solanamainnet|2mYa5q9chqBxR89Nc5CtAqdy5Wwjev5269GyxNFaT95U
-    decimals: 5
-    logoURI: /deployments/warp_routes/Bonk/logo.svg
-    name: Bonk
-    standard: SealevelHypSynthetic
-    symbol: Bonk
   - addressOrDenom: 2mYa5q9chqBxR89Nc5CtAqdy5Wwjev5269GyxNFaT95U
     chainName: solanamainnet
     coinGeckoId: bonk
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/Bonk/logo.svg
     name: Bonk
     standard: SealevelHypCollateral
+    symbol: Bonk
+  - addressOrDenom: BMjPo9Yz9bdiLuKVfHfjuAEE6JgmnMWYaVEv1ehFYnd7
+    chainName: soon
+    collateralAddressOrDenom: 71kRXzJMvSeArtXYNEWa8KAjpRJosdMQ7Dpgy5Jt5zfd
+    connections:
+      - token: sealevel|solanamainnet|2mYa5q9chqBxR89Nc5CtAqdy5Wwjev5269GyxNFaT95U
+    decimals: 5
+    logoURI: /deployments/warp_routes/Bonk/logo.svg
+    name: Bonk
+    standard: SealevelHypSynthetic
     symbol: Bonk

--- a/deployments/warp_routes/CBBTC/base-ethereum-superseed-config.yaml
+++ b/deployments/warp_routes/CBBTC/base-ethereum-superseed-config.yaml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x66477F84bd21697c7781fc3992b3163463e3B224"
+    chainName: base
+    coinGeckoId: coinbase-wrapped-btc
+    collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    connections:
+      - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
+    decimals: 8
+    logoURI: /deployments/warp_routes/CBBTC/logo.svg
+    name: Coinbase Wrapped BTC
+    standard: EvmHypCollateral
+    symbol: cbBTC
   - addressOrDenom: "0x7710d2FC9A2E0452b28a2cBf550429b579347199"
     chainName: ethereum
     coinGeckoId: coinbase-wrapped-btc
@@ -15,21 +26,10 @@ tokens:
     chainName: superseed
     collateralAddressOrDenom: "0x6f36dbd829de9b7e077db8a35b480d4329ceb331"
     connections:
-      - token: ethereum|ethereum|0x7710d2FC9A2E0452b28a2cBf550429b579347199
       - token: ethereum|base|0x66477F84bd21697c7781fc3992b3163463e3B224
+      - token: ethereum|ethereum|0x7710d2FC9A2E0452b28a2cBf550429b579347199
     decimals: 8
     logoURI: /deployments/warp_routes/CBBTC/logo.svg
     name: Coinbase Wrapped BTC
     standard: EvmHypCollateralFiat
-    symbol: cbBTC
-  - addressOrDenom: "0x66477F84bd21697c7781fc3992b3163463e3B224"
-    chainName: base
-    coinGeckoId: coinbase-wrapped-btc
-    collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
-    connections:
-      - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
-    decimals: 8
-    logoURI: /deployments/warp_routes/CBBTC/logo.svg
-    name: Coinbase Wrapped BTC
-    standard: EvmHypCollateral
     symbol: cbBTC

--- a/deployments/warp_routes/CDX/base-solanamainnet-sophon-config.yaml
+++ b/deployments/warp_routes/CDX/base-solanamainnet-sophon-config.yaml
@@ -5,8 +5,8 @@ tokens:
     coinGeckoId: cod3x
     collateralAddressOrDenom: "0xC0D3700000c0e32716863323bFd936b54a1633d1"
     connections:
-      - token: sealevel|solanamainnet|Dt62xRfWf7h6cURDsr19tqGWhjHMdobNVQ25cfHtZXg7
       - token: ethereum|sophon|0x6ce50f6536fe864952d5aB9abAA3A52E4a7A125F
+      - token: sealevel|solanamainnet|Dt62xRfWf7h6cURDsr19tqGWhjHMdobNVQ25cfHtZXg7
     decimals: 18
     logoURI: /deployments/warp_routes/CDX/logo.svg
     name: Cod3x Token

--- a/deployments/warp_routes/ECLIP/arbitrum-neutron-config.yaml
+++ b/deployments/warp_routes/ECLIP/arbitrum-neutron-config.yaml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x93ca0d85837FF83158Cd14D65B169CdB223b1921"
+    chainName: arbitrum
+    connections:
+      - token: cosmos|neutron|neutron1dvzvf870mx9uf65uqhx40yzx9gu4xlqqq2pnx362a0ndmustww3smumrf5
+    decimals: 6
+    logoURI: /deployments/warp_routes/ECLIP/logo.svg
+    name: Eclipse Fi
+    standard: EvmHypSynthetic
+    symbol: ECLIP
   - addressOrDenom: neutron1dvzvf870mx9uf65uqhx40yzx9gu4xlqqq2pnx362a0ndmustww3smumrf5
     chainName: neutron
     coinGeckoId: eclipse-fi
@@ -11,15 +20,6 @@ tokens:
     logoURI: /deployments/warp_routes/ECLIP/logo.svg
     name: Eclipse Fi
     standard: CwHypCollateral
-    symbol: ECLIP
-  - addressOrDenom: "0x93ca0d85837FF83158Cd14D65B169CdB223b1921"
-    chainName: arbitrum
-    connections:
-      - token: cosmos|neutron|neutron1dvzvf870mx9uf65uqhx40yzx9gu4xlqqq2pnx362a0ndmustww3smumrf5
-    decimals: 6
-    logoURI: /deployments/warp_routes/ECLIP/logo.svg
-    name: Eclipse Fi
-    standard: EvmHypSynthetic
     symbol: ECLIP
   - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
     chainName: neutron

--- a/deployments/warp_routes/ELIZA/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/ELIZA/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: 8f8C12h7b3HfYDbU9YWrf5q1K7jTVYYan2MgjzVWpynE
-    chainName: soon
-    collateralAddressOrDenom: BMrhaq5Q3PBtLdyybAf2SKiYx2ZjAC93BMJgYjVoTwYt
-    connections:
-      - token: sealevel|solanamainnet|8Xu98zz1oHGeBEkvK1xsrkGpZeVayVmr4discHxmmV3S
-    decimals: 6
-    logoURI: /deployments/warp_routes/ELIZA/logo.svg
-    name: Eliza
-    standard: SealevelHypSynthetic
-    symbol: ELIZA
   - addressOrDenom: 8Xu98zz1oHGeBEkvK1xsrkGpZeVayVmr4discHxmmV3S
     chainName: solanamainnet
     coinGeckoId: ELIZA
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/ELIZA/logo.svg
     name: Eliza
     standard: SealevelHypCollateral
+    symbol: ELIZA
+  - addressOrDenom: 8f8C12h7b3HfYDbU9YWrf5q1K7jTVYYan2MgjzVWpynE
+    chainName: soon
+    collateralAddressOrDenom: BMrhaq5Q3PBtLdyybAf2SKiYx2ZjAC93BMJgYjVoTwYt
+    connections:
+      - token: sealevel|solanamainnet|8Xu98zz1oHGeBEkvK1xsrkGpZeVayVmr4discHxmmV3S
+    decimals: 6
+    logoURI: /deployments/warp_routes/ELIZA/logo.svg
+    name: Eliza
+    standard: SealevelHypSynthetic
     symbol: ELIZA

--- a/deployments/warp_routes/ES/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/ES/eclipsemainnet-ethereum-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x3eE1BEA3A10f7508b76219f109eBe19419b3dd85"
-    chainName: ethereum
-    collateralAddressOrDenom: "0x6055Dc6Ff1077eebe5e6D2BA1a1f53d7Ef8430dE"
-    connections:
-      - token: sealevel|eclipsemainnet|2JvSu7PzquY2b8NDZbnupFZ1jezqMBtNUhi7TuU3GQJD
-    decimals: 6
-    logoURI: /deployments/warp_routes/ES/logo.svg
-    name: Eclipse
-    standard: EvmHypCollateral
-    symbol: ES
   - addressOrDenom: 2JvSu7PzquY2b8NDZbnupFZ1jezqMBtNUhi7TuU3GQJD
     chainName: eclipsemainnet
     collateralAddressOrDenom: GnBAskb2SQjrLgpTjtgatz4hEugUsYV7XrWU1idV3oqW
@@ -19,4 +9,14 @@ tokens:
     logoURI: /deployments/warp_routes/ES/logo.svg
     name: Eclipse
     standard: SealevelHypSynthetic
+    symbol: ES
+  - addressOrDenom: "0x3eE1BEA3A10f7508b76219f109eBe19419b3dd85"
+    chainName: ethereum
+    collateralAddressOrDenom: "0x6055Dc6Ff1077eebe5e6D2BA1a1f53d7Ef8430dE"
+    connections:
+      - token: sealevel|eclipsemainnet|2JvSu7PzquY2b8NDZbnupFZ1jezqMBtNUhi7TuU3GQJD
+    decimals: 6
+    logoURI: /deployments/warp_routes/ES/logo.svg
+    name: Eclipse
+    standard: EvmHypCollateral
     symbol: ES

--- a/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
@@ -9,6 +9,7 @@ tokens:
       - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
       - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
       - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
       - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
@@ -16,7 +17,6 @@ tokens:
       - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
     name: Ether
     standard: EvmHypNative
@@ -30,6 +30,7 @@ tokens:
       - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
       - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
       - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
       - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
@@ -37,7 +38,6 @@ tokens:
       - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
     name: Ether
     standard: EvmHypNative
@@ -51,6 +51,7 @@ tokens:
       - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
       - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
       - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
       - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
@@ -58,7 +59,6 @@ tokens:
       - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
     name: Ether
     standard: EvmHypNative
@@ -73,6 +73,7 @@ tokens:
       - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
       - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
       - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
@@ -80,7 +81,6 @@ tokens:
       - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
     name: Ether
     standard: EvmHypCollateral
@@ -94,6 +94,7 @@ tokens:
       - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
       - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
       - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
       - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
@@ -101,7 +102,6 @@ tokens:
       - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
     name: Ether
     standard: EvmHypNative
@@ -116,6 +116,7 @@ tokens:
       - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
       - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
       - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
       - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
       - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
@@ -123,159 +124,9 @@ tokens:
       - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
     name: Ether
     standard: EvmHypCollateral
-    symbol: ETH
-  - addressOrDenom: "0xA92D6084709469A2B2339919FfC568b7C5D7888D"
-    chainName: mantle
-    coinGeckoId: ethereum
-    collateralAddressOrDenom: "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
-    connections:
-      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
-      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
-      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
-      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
-      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
-      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
-      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
-      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
-      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
-      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-    decimals: 18
-    name: Ether
-    standard: EvmHypCollateral
-    symbol: ETH
-  - addressOrDenom: "0xef043d913b196dc87CB1256850894AA72DAD5933"
-    chainName: mode
-    coinGeckoId: ethereum
-    connections:
-      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
-      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
-      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
-      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
-      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
-      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
-      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
-      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
-      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
-      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-    decimals: 18
-    name: Ether
-    standard: EvmHypNative
-    symbol: ETH
-  - addressOrDenom: "0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539"
-    chainName: optimism
-    coinGeckoId: ethereum
-    connections:
-      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
-      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
-      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
-      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
-      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
-      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
-      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
-      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
-      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
-      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-    decimals: 18
-    name: Ether
-    standard: EvmHypNative
-    symbol: ETH
-  - addressOrDenom: "0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779"
-    chainName: polygon
-    coinGeckoId: ethereum
-    collateralAddressOrDenom: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
-    connections:
-      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
-      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
-      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
-      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
-      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
-      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
-      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
-      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
-      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
-      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-    decimals: 18
-    name: Ether
-    standard: EvmHypCollateral
-    symbol: ETH
-  - addressOrDenom: "0xF85379CF296f84871dee84826153d6F5ccA9de3B"
-    chainName: scroll
-    coinGeckoId: ethereum
-    connections:
-      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
-      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
-      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
-      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
-      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
-      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
-      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
-      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
-      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
-      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-    decimals: 18
-    name: Ether
-    standard: EvmHypNative
-    symbol: ETH
-  - addressOrDenom: "0x2E2c9BeE342398E26156Da12769262087de6EdDC"
-    chainName: zeronetwork
-    coinGeckoId: ethereum
-    connections:
-      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
-      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
-      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
-      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
-      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
-      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
-      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
-      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
-      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
-      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-    decimals: 18
-    name: Ether
-    standard: EvmHypNative
-    symbol: ETH
-  - addressOrDenom: "0xA900858116D7605a01AfC7595450d8D78555Bc83"
-    chainName: zoramainnet
-    coinGeckoId: ethereum
-    connections:
-      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
-      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
-      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
-      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
-      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
-      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
-      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
-      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
-      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
-      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
-      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
-      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
-    decimals: 18
-    name: Ether
-    standard: EvmHypNative
     symbol: ETH
   - addressOrDenom: "0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0"
     chainName: lisk
@@ -296,4 +147,153 @@ tokens:
     decimals: 18
     name: Ether
     standard: EvmHypSynthetic
+    symbol: ETH
+  - addressOrDenom: "0xA92D6084709469A2B2339919FfC568b7C5D7888D"
+    chainName: mantle
+    coinGeckoId: ethereum
+    collateralAddressOrDenom: "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
+    connections:
+      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
+      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
+      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
+      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
+      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
+      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
+      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
+      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
+      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
+      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
+    decimals: 18
+    name: Ether
+    standard: EvmHypCollateral
+    symbol: ETH
+  - addressOrDenom: "0xef043d913b196dc87CB1256850894AA72DAD5933"
+    chainName: mode
+    coinGeckoId: ethereum
+    connections:
+      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
+      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
+      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
+      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
+      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
+      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
+      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
+      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
+      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
+      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: "0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539"
+    chainName: optimism
+    coinGeckoId: ethereum
+    connections:
+      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
+      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
+      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
+      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
+      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
+      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
+      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
+      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
+      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
+      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: "0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779"
+    chainName: polygon
+    coinGeckoId: ethereum
+    collateralAddressOrDenom: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
+    connections:
+      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
+      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
+      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
+      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
+      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
+      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
+      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
+      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
+      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
+      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
+    decimals: 18
+    name: Ether
+    standard: EvmHypCollateral
+    symbol: ETH
+  - addressOrDenom: "0xF85379CF296f84871dee84826153d6F5ccA9de3B"
+    chainName: scroll
+    coinGeckoId: ethereum
+    connections:
+      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
+      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
+      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
+      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
+      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
+      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
+      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
+      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
+      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
+      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: "0x2E2c9BeE342398E26156Da12769262087de6EdDC"
+    chainName: zeronetwork
+    coinGeckoId: ethereum
+    connections:
+      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
+      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
+      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
+      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
+      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
+      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
+      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
+      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
+      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
+      - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: "0xA900858116D7605a01AfC7595450d8D78555Bc83"
+    chainName: zoramainnet
+    coinGeckoId: ethereum
+    connections:
+      - token: ethereum|arbitrum|0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88
+      - token: ethereum|base|0x885598858b68562FE5001F8eE022522313257C7a
+      - token: ethereum|blast|0xA900858116D7605a01AfC7595450d8D78555Bc83
+      - token: ethereum|bsc|0xFc9F3387eb4385785420f661CE7A9E486f404b8F
+      - token: ethereum|ethereum|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|gnosis|0x5DBeAEC137d1ef9a240599656073Ae3E717fae3c
+      - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
+      - token: ethereum|mantle|0xA92D6084709469A2B2339919FfC568b7C5D7888D
+      - token: ethereum|mode|0xef043d913b196dc87CB1256850894AA72DAD5933
+      - token: ethereum|optimism|0x14A77BdAb46bBEb7DAfc3E4cB4732A51241Ef539
+      - token: ethereum|polygon|0xda8b55BB3Dc6B74042033f9493A5Bffa3d8EA779
+      - token: ethereum|scroll|0xF85379CF296f84871dee84826153d6F5ccA9de3B
+      - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
     symbol: ETH

--- a/deployments/warp_routes/ETH/arbitrum-base-ethereum-lumiaprism-optimism-polygon-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-base-ethereum-lumiaprism-optimism-polygon-config.yaml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x19dcF74D21d85Cf82d1a047ef80C64954E4aa009"
+    chainName: arbitrum
+    coinGeckoId: ethereum
+    decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
   - addressOrDenom: "0xE4A9622Bf50025fE99A576D484AEf16280A5304f"
     chainName: base
     coinGeckoId: ethereum
@@ -27,14 +35,6 @@ tokens:
     name: Ether
     standard: EvmHypSynthetic
     symbol: WETH
-  - addressOrDenom: "0x19dcF74D21d85Cf82d1a047ef80C64954E4aa009"
-    chainName: arbitrum
-    coinGeckoId: ethereum
-    decimals: 18
-    logoURI: /deployments/warp_routes/ETH/logo.svg
-    name: Ether
-    standard: EvmHypNative
-    symbol: ETH
   - addressOrDenom: "0x4e550422D67f208eE25A730D11dCe9201cF3Aa3a"
     chainName: optimism
     coinGeckoId: ethereum

--- a/deployments/warp_routes/ETH/coti-ethereum-config.yaml
+++ b/deployments/warp_routes/ETH/coti-ethereum-config.yaml
@@ -1,4 +1,13 @@
 tokens:
+  - addressOrDenom: "0x639aCc80569c5FC83c6FBf2319A6Cc38bBfe26d1"
+    chainName: coti
+    connections:
+      - token: ethereum|ethereum|0x07C747b0D99aBE8132f771cf6D2365D19ED1FfbA
+    decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    name: Ether
+    standard: EvmHypSynthetic
+    symbol: ETH
   - addressOrDenom: "0x07C747b0D99aBE8132f771cf6D2365D19ED1FfbA"
     chainName: ethereum
     coinGeckoId: ethereum
@@ -8,13 +17,4 @@ tokens:
     logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
-    symbol: ETH
-  - addressOrDenom: "0x639aCc80569c5FC83c6FBf2319A6Cc38bBfe26d1"
-    chainName: coti
-    connections:
-      - token: ethereum|ethereum|0x07C747b0D99aBE8132f771cf6D2365D19ED1FfbA
-    decimals: 18
-    logoURI: /deployments/warp_routes/ETH/logo.svg
-    name: Ether
-    standard: EvmHypSynthetic
     symbol: ETH

--- a/deployments/warp_routes/EZETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-config.yaml
+++ b/deployments/warp_routes/EZETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-config.yaml
@@ -17,8 +17,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -41,8 +41,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -65,8 +65,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -89,8 +89,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -113,8 +113,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -138,8 +138,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -162,8 +162,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -186,8 +186,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -210,8 +210,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -234,8 +234,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -258,8 +258,8 @@ tokens:
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -282,8 +282,8 @@ tokens:
       - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -306,8 +306,8 @@ tokens:
       - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -330,32 +330,8 @@ tokens:
       - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-    decimals: 18
-    logoURI: /deployments/warp_routes/EZETH/logo.svg
-    name: Renzo Restaked ETH
-    standard: EvmHypXERC20
-    symbol: ezETH
-  - addressOrDenom: "0x2552516453368e42705D791F674b312b8b87CD9e"
-    chainName: zircuit
-    collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections:
-      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
-      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
-      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
-      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -380,6 +356,30 @@ tokens:
       - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
+    decimals: 18
+    logoURI: /deployments/warp_routes/EZETH/logo.svg
+    name: Renzo Restaked ETH
+    standard: EvmHypXERC20
+    symbol: ezETH
+  - addressOrDenom: "0x2552516453368e42705D791F674b312b8b87CD9e"
+    chainName: zircuit
+    collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
+    connections:
+      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
+      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
+      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
+      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
+      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
+      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
+      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
+      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
+      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
+      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
+      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH

--- a/deployments/warp_routes/EZETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-deploy.yaml
+++ b/deployments/warp_routes/EZETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-deploy.yaml
@@ -11,16 +11,19 @@ arbitrum:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
+        type: defaultFallbackRoutingIsm
       - domains:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -29,12 +32,12 @@ arbitrum:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -43,12 +46,12 @@ arbitrum:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -57,12 +60,12 @@ arbitrum:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -71,12 +74,12 @@ arbitrum:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -85,12 +88,12 @@ arbitrum:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -99,12 +102,12 @@ arbitrum:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -113,12 +116,12 @@ arbitrum:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -127,12 +130,12 @@ arbitrum:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -141,12 +144,12 @@ arbitrum:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -155,12 +158,12 @@ arbitrum:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -169,12 +172,12 @@ arbitrum:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -183,12 +186,12 @@ arbitrum:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -197,12 +200,12 @@ arbitrum:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -211,12 +214,12 @@ arbitrum:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -224,9 +227,6 @@ arbitrum:
             type: staticAggregationIsm
         owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -249,16 +249,19 @@ base:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -267,12 +270,12 @@ base:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -281,12 +284,12 @@ base:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -295,12 +298,12 @@ base:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -309,12 +312,12 @@ base:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -323,12 +326,12 @@ base:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -337,12 +340,12 @@ base:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -351,12 +354,12 @@ base:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -365,12 +368,12 @@ base:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -379,12 +382,12 @@ base:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -393,12 +396,12 @@ base:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -407,12 +410,12 @@ base:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -421,12 +424,12 @@ base:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -435,12 +438,12 @@ base:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -449,12 +452,12 @@ base:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -462,9 +465,6 @@ base:
             type: staticAggregationIsm
         owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -487,16 +487,19 @@ berachain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x865BA5789D82F2D4C5595a3968dad729A8C3daE6"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -505,12 +508,12 @@ berachain:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -519,12 +522,12 @@ berachain:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -533,12 +536,12 @@ berachain:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -547,12 +550,12 @@ berachain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -561,12 +564,12 @@ berachain:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -575,12 +578,12 @@ berachain:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -589,12 +592,12 @@ berachain:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -603,12 +606,12 @@ berachain:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -617,12 +620,12 @@ berachain:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -631,12 +634,12 @@ berachain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -645,12 +648,12 @@ berachain:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -659,12 +662,12 @@ berachain:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -673,12 +676,12 @@ berachain:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -687,12 +690,12 @@ berachain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -700,9 +703,6 @@ berachain:
             type: staticAggregationIsm
         owner: "0x865BA5789D82F2D4C5595a3968dad729A8C3daE6"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x865BA5789D82F2D4C5595a3968dad729A8C3daE6"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -722,16 +722,19 @@ blast:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xda7dBF0DB81882372B598a715F86eD5254A01b0a"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -740,12 +743,12 @@ blast:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -754,12 +757,12 @@ blast:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -768,12 +771,12 @@ blast:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -782,12 +785,12 @@ blast:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -796,12 +799,12 @@ blast:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -810,12 +813,12 @@ blast:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -824,12 +827,12 @@ blast:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -838,12 +841,12 @@ blast:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -852,12 +855,12 @@ blast:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -866,12 +869,12 @@ blast:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -880,12 +883,12 @@ blast:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -894,12 +897,12 @@ blast:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -908,12 +911,12 @@ blast:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -922,12 +925,12 @@ blast:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -935,9 +938,6 @@ blast:
             type: staticAggregationIsm
         owner: "0xda7dBF0DB81882372B598a715F86eD5254A01b0a"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xda7dBF0DB81882372B598a715F86eD5254A01b0a"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -960,16 +960,19 @@ bsc:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -978,12 +981,12 @@ bsc:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -992,12 +995,12 @@ bsc:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1006,12 +1009,12 @@ bsc:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1020,12 +1023,12 @@ bsc:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -1034,12 +1037,12 @@ bsc:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -1048,12 +1051,12 @@ bsc:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -1062,12 +1065,12 @@ bsc:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1076,12 +1079,12 @@ bsc:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1090,12 +1093,12 @@ bsc:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1104,12 +1107,12 @@ bsc:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1118,12 +1121,12 @@ bsc:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1132,12 +1135,12 @@ bsc:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1146,12 +1149,12 @@ bsc:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1160,12 +1163,12 @@ bsc:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1173,9 +1176,6 @@ bsc:
             type: staticAggregationIsm
         owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1198,16 +1198,19 @@ ethereum:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1216,12 +1219,12 @@ ethereum:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1230,12 +1233,12 @@ ethereum:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1244,12 +1247,12 @@ ethereum:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1258,12 +1261,12 @@ ethereum:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1272,12 +1275,12 @@ ethereum:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -1286,12 +1289,12 @@ ethereum:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -1300,12 +1303,12 @@ ethereum:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1314,12 +1317,12 @@ ethereum:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1328,12 +1331,12 @@ ethereum:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1342,12 +1345,12 @@ ethereum:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1356,12 +1359,12 @@ ethereum:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1370,12 +1373,12 @@ ethereum:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1384,12 +1387,12 @@ ethereum:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1398,12 +1401,12 @@ ethereum:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1411,9 +1414,6 @@ ethereum:
             type: staticAggregationIsm
         owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1436,16 +1436,19 @@ fraxtal:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1454,12 +1457,12 @@ fraxtal:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1468,12 +1471,12 @@ fraxtal:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1482,12 +1485,12 @@ fraxtal:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1496,12 +1499,12 @@ fraxtal:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1510,12 +1513,12 @@ fraxtal:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -1524,12 +1527,12 @@ fraxtal:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -1538,12 +1541,12 @@ fraxtal:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1552,12 +1555,12 @@ fraxtal:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1566,12 +1569,12 @@ fraxtal:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1580,12 +1583,12 @@ fraxtal:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1594,12 +1597,12 @@ fraxtal:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1608,12 +1611,12 @@ fraxtal:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1622,12 +1625,12 @@ fraxtal:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1636,12 +1639,12 @@ fraxtal:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1649,9 +1652,6 @@ fraxtal:
             type: staticAggregationIsm
         owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1674,16 +1674,19 @@ linea:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xb7092685571B49786F1248c6205B5ac3A691c65E"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1692,12 +1695,12 @@ linea:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1706,12 +1709,12 @@ linea:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1720,12 +1723,12 @@ linea:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1734,12 +1737,12 @@ linea:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1748,12 +1751,12 @@ linea:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -1762,12 +1765,12 @@ linea:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -1776,12 +1779,12 @@ linea:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1790,12 +1793,12 @@ linea:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1804,12 +1807,12 @@ linea:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1818,12 +1821,12 @@ linea:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1832,12 +1835,12 @@ linea:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1846,12 +1849,12 @@ linea:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1860,12 +1863,12 @@ linea:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1874,12 +1877,12 @@ linea:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1887,9 +1890,6 @@ linea:
             type: staticAggregationIsm
         owner: "0xb7092685571B49786F1248c6205B5ac3A691c65E"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xb7092685571B49786F1248c6205B5ac3A691c65E"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1912,16 +1912,19 @@ mode:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x7791eeA3484Ba4E5860B7a2293840767619c2B58"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1930,12 +1933,12 @@ mode:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1944,12 +1947,12 @@ mode:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1958,12 +1961,12 @@ mode:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1972,12 +1975,12 @@ mode:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1986,12 +1989,12 @@ mode:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2000,12 +2003,12 @@ mode:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2014,12 +2017,12 @@ mode:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2028,12 +2031,12 @@ mode:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -2042,12 +2045,12 @@ mode:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -2056,12 +2059,12 @@ mode:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -2070,12 +2073,12 @@ mode:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2084,12 +2087,12 @@ mode:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2098,12 +2101,12 @@ mode:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2112,12 +2115,12 @@ mode:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2125,9 +2128,6 @@ mode:
             type: staticAggregationIsm
         owner: "0x7791eeA3484Ba4E5860B7a2293840767619c2B58"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x7791eeA3484Ba4E5860B7a2293840767619c2B58"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2150,16 +2150,19 @@ optimism:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2168,12 +2171,12 @@ optimism:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2182,12 +2185,12 @@ optimism:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2196,12 +2199,12 @@ optimism:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2210,12 +2213,12 @@ optimism:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2224,12 +2227,12 @@ optimism:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2238,12 +2241,12 @@ optimism:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2252,12 +2255,12 @@ optimism:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2266,12 +2269,12 @@ optimism:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2280,12 +2283,12 @@ optimism:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -2294,12 +2297,12 @@ optimism:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -2308,12 +2311,12 @@ optimism:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2322,12 +2325,12 @@ optimism:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2336,12 +2339,12 @@ optimism:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2350,12 +2353,12 @@ optimism:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2363,9 +2366,6 @@ optimism:
             type: staticAggregationIsm
         owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2388,16 +2388,19 @@ sei:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2406,12 +2409,12 @@ sei:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2420,12 +2423,12 @@ sei:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2434,12 +2437,12 @@ sei:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2448,12 +2451,12 @@ sei:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2462,12 +2465,12 @@ sei:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2476,12 +2479,12 @@ sei:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2490,12 +2493,12 @@ sei:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2504,12 +2507,12 @@ sei:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2518,12 +2521,12 @@ sei:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -2532,12 +2535,12 @@ sei:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -2546,12 +2549,12 @@ sei:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2560,12 +2563,12 @@ sei:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2574,12 +2577,12 @@ sei:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2588,12 +2591,12 @@ sei:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2601,9 +2604,6 @@ sei:
             type: staticAggregationIsm
         owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2626,16 +2626,19 @@ swell:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x435E8c9652Da151292F3981bbf663EBEB6668501"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2644,12 +2647,12 @@ swell:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2658,12 +2661,12 @@ swell:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2672,12 +2675,12 @@ swell:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2686,12 +2689,12 @@ swell:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2700,12 +2703,12 @@ swell:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2714,12 +2717,12 @@ swell:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2728,12 +2731,12 @@ swell:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2742,12 +2745,12 @@ swell:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2756,12 +2759,12 @@ swell:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -2770,12 +2773,12 @@ swell:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -2784,12 +2787,12 @@ swell:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2798,12 +2801,12 @@ swell:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2812,12 +2815,12 @@ swell:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2826,12 +2829,12 @@ swell:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2839,9 +2842,6 @@ swell:
             type: staticAggregationIsm
         owner: "0x435E8c9652Da151292F3981bbf663EBEB6668501"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x435E8c9652Da151292F3981bbf663EBEB6668501"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2861,16 +2861,19 @@ taiko:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2879,12 +2882,12 @@ taiko:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2893,12 +2896,12 @@ taiko:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2907,12 +2910,12 @@ taiko:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2921,12 +2924,12 @@ taiko:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2935,12 +2938,12 @@ taiko:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2949,12 +2952,12 @@ taiko:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2963,12 +2966,12 @@ taiko:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2977,12 +2980,12 @@ taiko:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2991,12 +2994,12 @@ taiko:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -3005,12 +3008,12 @@ taiko:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -3019,12 +3022,12 @@ taiko:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3033,12 +3036,12 @@ taiko:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -3047,12 +3050,12 @@ taiko:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -3061,12 +3064,12 @@ taiko:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -3074,9 +3077,6 @@ taiko:
             type: staticAggregationIsm
         owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -3099,16 +3099,19 @@ unichain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x70aF964829DA7F3f51973EE806AEeAB9225F2661"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -3117,12 +3120,12 @@ unichain:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -3131,12 +3134,12 @@ unichain:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -3145,12 +3148,12 @@ unichain:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -3159,12 +3162,12 @@ unichain:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -3173,12 +3176,12 @@ unichain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -3187,12 +3190,12 @@ unichain:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -3201,12 +3204,12 @@ unichain:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -3215,12 +3218,12 @@ unichain:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -3229,12 +3232,12 @@ unichain:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -3243,12 +3246,12 @@ unichain:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -3257,12 +3260,12 @@ unichain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3271,12 +3274,12 @@ unichain:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -3285,12 +3288,12 @@ unichain:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -3299,12 +3302,12 @@ unichain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -3312,9 +3315,6 @@ unichain:
             type: staticAggregationIsm
         owner: "0x70aF964829DA7F3f51973EE806AEeAB9225F2661"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x70aF964829DA7F3f51973EE806AEeAB9225F2661"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -3334,16 +3334,19 @@ worldchain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x7Be36310285cA4e809C296526745DA983c8F8e0f"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -3352,12 +3355,12 @@ worldchain:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -3366,12 +3369,12 @@ worldchain:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -3380,12 +3383,12 @@ worldchain:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -3394,12 +3397,12 @@ worldchain:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -3408,12 +3411,12 @@ worldchain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -3422,12 +3425,12 @@ worldchain:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -3436,12 +3439,12 @@ worldchain:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -3450,12 +3453,12 @@ worldchain:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -3464,12 +3467,12 @@ worldchain:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -3478,12 +3481,12 @@ worldchain:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -3492,12 +3495,12 @@ worldchain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3506,12 +3509,12 @@ worldchain:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -3520,12 +3523,12 @@ worldchain:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -3534,12 +3537,12 @@ worldchain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -3547,9 +3550,6 @@ worldchain:
             type: staticAggregationIsm
         owner: "0x7Be36310285cA4e809C296526745DA983c8F8e0f"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x7Be36310285cA4e809C296526745DA983c8F8e0f"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -3569,16 +3569,19 @@ zircuit:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -3587,12 +3590,12 @@ zircuit:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -3601,12 +3604,12 @@ zircuit:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -3615,12 +3618,12 @@ zircuit:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -3629,12 +3632,12 @@ zircuit:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -3643,12 +3646,12 @@ zircuit:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -3657,12 +3660,12 @@ zircuit:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -3671,12 +3674,12 @@ zircuit:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -3685,12 +3688,12 @@ zircuit:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -3699,12 +3702,12 @@ zircuit:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -3713,12 +3716,12 @@ zircuit:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -3727,12 +3730,12 @@ zircuit:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3741,12 +3744,12 @@ zircuit:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -3755,12 +3758,12 @@ zircuit:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -3769,12 +3772,12 @@ zircuit:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -3782,9 +3785,6 @@ zircuit:
             type: staticAggregationIsm
         owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false

--- a/deployments/warp_routes/EZETHSTAGE/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-config.yaml
+++ b/deployments/warp_routes/EZETHSTAGE/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-config.yaml
@@ -17,8 +17,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -40,8 +40,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -63,8 +63,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -86,8 +86,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -109,8 +109,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -132,8 +132,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20Lockbox
@@ -155,8 +155,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -178,8 +178,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -201,8 +201,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -224,8 +224,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -247,8 +247,8 @@ tokens:
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -270,8 +270,8 @@ tokens:
       - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -293,8 +293,8 @@ tokens:
       - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
       - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -316,31 +316,8 @@ tokens:
       - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
       - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+      - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
       - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-      - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-    decimals: 18
-    name: Renzo Restaked ETH Stage 9
-    standard: EvmHypXERC20
-    symbol: EZETHSTAGE
-  - addressOrDenom: "0xa2656c131A9F204F73944D7B60DDB17565E71292"
-    chainName: zircuit
-    collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-    connections:
-      - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-      - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-      - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-      - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-      - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-      - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-      - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-      - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-      - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-      - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-      - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-      - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-      - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-      - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20
@@ -364,6 +341,29 @@ tokens:
       - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
       - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+    decimals: 18
+    name: Renzo Restaked ETH Stage 9
+    standard: EvmHypXERC20
+    symbol: EZETHSTAGE
+  - addressOrDenom: "0xa2656c131A9F204F73944D7B60DDB17565E71292"
+    chainName: zircuit
+    collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+    connections:
+      - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+      - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+      - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+      - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+      - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+      - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+      - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+      - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+      - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+      - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+      - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+      - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+      - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+      - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
     decimals: 18
     name: Renzo Restaked ETH Stage 9
     standard: EvmHypXERC20

--- a/deployments/warp_routes/EZETHSTAGE/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-deploy.yaml
+++ b/deployments/warp_routes/EZETHSTAGE/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit-deploy.yaml
@@ -11,16 +11,19 @@ arbitrum:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -29,12 +32,12 @@ arbitrum:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -43,12 +46,12 @@ arbitrum:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -57,12 +60,12 @@ arbitrum:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -71,12 +74,12 @@ arbitrum:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -85,12 +88,12 @@ arbitrum:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -99,12 +102,12 @@ arbitrum:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -113,12 +116,12 @@ arbitrum:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -127,12 +130,12 @@ arbitrum:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -141,12 +144,12 @@ arbitrum:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -155,12 +158,12 @@ arbitrum:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -169,12 +172,12 @@ arbitrum:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -183,12 +186,12 @@ arbitrum:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -197,12 +200,12 @@ arbitrum:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -211,12 +214,12 @@ arbitrum:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -224,9 +227,6 @@ arbitrum:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -246,16 +246,19 @@ base:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -264,12 +267,12 @@ base:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -278,12 +281,12 @@ base:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -292,12 +295,12 @@ base:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -306,12 +309,12 @@ base:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -320,12 +323,12 @@ base:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -334,12 +337,12 @@ base:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -348,12 +351,12 @@ base:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -362,12 +365,12 @@ base:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -376,12 +379,12 @@ base:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -390,12 +393,12 @@ base:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -404,12 +407,12 @@ base:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -418,12 +421,12 @@ base:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -432,12 +435,12 @@ base:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -446,12 +449,12 @@ base:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -459,9 +462,6 @@ base:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -481,16 +481,19 @@ berachain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf013c8Be28421b050cca5bD95cc57Af49568e8be"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -499,12 +502,12 @@ berachain:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -513,12 +516,12 @@ berachain:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -527,12 +530,12 @@ berachain:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -541,12 +544,12 @@ berachain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -555,12 +558,12 @@ berachain:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -569,12 +572,12 @@ berachain:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -583,12 +586,12 @@ berachain:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -597,12 +600,12 @@ berachain:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -611,12 +614,12 @@ berachain:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -625,12 +628,12 @@ berachain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -639,12 +642,12 @@ berachain:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -653,12 +656,12 @@ berachain:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -667,12 +670,12 @@ berachain:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -681,12 +684,12 @@ berachain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -694,9 +697,6 @@ berachain:
             type: staticAggregationIsm
         owner: "0xf013c8Be28421b050cca5bD95cc57Af49568e8be"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf013c8Be28421b050cca5bD95cc57Af49568e8be"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -716,16 +716,19 @@ blast:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -734,12 +737,12 @@ blast:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -748,12 +751,12 @@ blast:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -762,12 +765,12 @@ blast:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -776,12 +779,12 @@ blast:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -790,12 +793,12 @@ blast:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -804,12 +807,12 @@ blast:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -818,12 +821,12 @@ blast:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -832,12 +835,12 @@ blast:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -846,12 +849,12 @@ blast:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -860,12 +863,12 @@ blast:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -874,12 +877,12 @@ blast:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -888,12 +891,12 @@ blast:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -902,12 +905,12 @@ blast:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -916,12 +919,12 @@ blast:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -929,9 +932,6 @@ blast:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -951,16 +951,19 @@ bsc:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -969,12 +972,12 @@ bsc:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -983,12 +986,12 @@ bsc:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -997,12 +1000,12 @@ bsc:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1011,12 +1014,12 @@ bsc:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -1025,12 +1028,12 @@ bsc:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -1039,12 +1042,12 @@ bsc:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -1053,12 +1056,12 @@ bsc:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1067,12 +1070,12 @@ bsc:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1081,12 +1084,12 @@ bsc:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1095,12 +1098,12 @@ bsc:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1109,12 +1112,12 @@ bsc:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1123,12 +1126,12 @@ bsc:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1137,12 +1140,12 @@ bsc:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1151,12 +1154,12 @@ bsc:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1164,9 +1167,6 @@ bsc:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1186,16 +1186,19 @@ ethereum:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1204,12 +1207,12 @@ ethereum:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1218,12 +1221,12 @@ ethereum:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1232,12 +1235,12 @@ ethereum:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1246,12 +1249,12 @@ ethereum:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1260,12 +1263,12 @@ ethereum:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -1274,12 +1277,12 @@ ethereum:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -1288,12 +1291,12 @@ ethereum:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1302,12 +1305,12 @@ ethereum:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1316,12 +1319,12 @@ ethereum:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1330,12 +1333,12 @@ ethereum:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1344,12 +1347,12 @@ ethereum:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1358,12 +1361,12 @@ ethereum:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1372,12 +1375,12 @@ ethereum:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1386,12 +1389,12 @@ ethereum:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1399,9 +1402,6 @@ ethereum:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1421,16 +1421,19 @@ fraxtal:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1439,12 +1442,12 @@ fraxtal:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1453,12 +1456,12 @@ fraxtal:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1467,12 +1470,12 @@ fraxtal:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1481,12 +1484,12 @@ fraxtal:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1495,12 +1498,12 @@ fraxtal:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -1509,12 +1512,12 @@ fraxtal:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -1523,12 +1526,12 @@ fraxtal:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1537,12 +1540,12 @@ fraxtal:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1551,12 +1554,12 @@ fraxtal:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1565,12 +1568,12 @@ fraxtal:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1579,12 +1582,12 @@ fraxtal:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1593,12 +1596,12 @@ fraxtal:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1607,12 +1610,12 @@ fraxtal:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1621,12 +1624,12 @@ fraxtal:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1634,9 +1637,6 @@ fraxtal:
             type: staticAggregationIsm
         owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1656,16 +1656,19 @@ linea:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1674,12 +1677,12 @@ linea:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1688,12 +1691,12 @@ linea:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1702,12 +1705,12 @@ linea:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1716,12 +1719,12 @@ linea:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1730,12 +1733,12 @@ linea:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -1744,12 +1747,12 @@ linea:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -1758,12 +1761,12 @@ linea:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -1772,12 +1775,12 @@ linea:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -1786,12 +1789,12 @@ linea:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -1800,12 +1803,12 @@ linea:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -1814,12 +1817,12 @@ linea:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -1828,12 +1831,12 @@ linea:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -1842,12 +1845,12 @@ linea:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -1856,12 +1859,12 @@ linea:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -1869,9 +1872,6 @@ linea:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -1891,16 +1891,19 @@ mode:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -1909,12 +1912,12 @@ mode:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -1923,12 +1926,12 @@ mode:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -1937,12 +1940,12 @@ mode:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -1951,12 +1954,12 @@ mode:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -1965,12 +1968,12 @@ mode:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -1979,12 +1982,12 @@ mode:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -1993,12 +1996,12 @@ mode:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2007,12 +2010,12 @@ mode:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -2021,12 +2024,12 @@ mode:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -2035,12 +2038,12 @@ mode:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -2049,12 +2052,12 @@ mode:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2063,12 +2066,12 @@ mode:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2077,12 +2080,12 @@ mode:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2091,12 +2094,12 @@ mode:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2104,9 +2107,6 @@ mode:
             type: staticAggregationIsm
         owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2126,16 +2126,19 @@ optimism:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2144,12 +2147,12 @@ optimism:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2158,12 +2161,12 @@ optimism:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2172,12 +2175,12 @@ optimism:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2186,12 +2189,12 @@ optimism:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2200,12 +2203,12 @@ optimism:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2214,12 +2217,12 @@ optimism:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2228,12 +2231,12 @@ optimism:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2242,12 +2245,12 @@ optimism:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2256,12 +2259,12 @@ optimism:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -2270,12 +2273,12 @@ optimism:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -2284,12 +2287,12 @@ optimism:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2298,12 +2301,12 @@ optimism:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2312,12 +2315,12 @@ optimism:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2326,12 +2329,12 @@ optimism:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2339,9 +2342,6 @@ optimism:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2361,16 +2361,19 @@ sei:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xa30FF77d30Eb2d785f574344B4D11CAAe1949807"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2379,12 +2382,12 @@ sei:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2393,12 +2396,12 @@ sei:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2407,12 +2410,12 @@ sei:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2421,12 +2424,12 @@ sei:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2435,12 +2438,12 @@ sei:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2449,12 +2452,12 @@ sei:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2463,12 +2466,12 @@ sei:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2477,12 +2480,12 @@ sei:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2491,12 +2494,12 @@ sei:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -2505,12 +2508,12 @@ sei:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -2519,12 +2522,12 @@ sei:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2533,12 +2536,12 @@ sei:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2547,12 +2550,12 @@ sei:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2561,12 +2564,12 @@ sei:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2574,9 +2577,6 @@ sei:
             type: staticAggregationIsm
         owner: "0xa30FF77d30Eb2d785f574344B4D11CAAe1949807"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xa30FF77d30Eb2d785f574344B4D11CAAe1949807"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2596,16 +2596,19 @@ swell:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2614,12 +2617,12 @@ swell:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2628,12 +2631,12 @@ swell:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2642,12 +2645,12 @@ swell:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2656,12 +2659,12 @@ swell:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2670,12 +2673,12 @@ swell:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2684,12 +2687,12 @@ swell:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2698,12 +2701,12 @@ swell:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2712,12 +2715,12 @@ swell:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2726,12 +2729,12 @@ swell:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -2740,12 +2743,12 @@ swell:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -2754,12 +2757,12 @@ swell:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -2768,12 +2771,12 @@ swell:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -2782,12 +2785,12 @@ swell:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -2796,12 +2799,12 @@ swell:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -2809,9 +2812,6 @@ swell:
             type: staticAggregationIsm
         owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -2831,16 +2831,19 @@ taiko:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x31FF35F84ADB120DbE089D190F03Ac74731Ae83F"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -2849,12 +2852,12 @@ taiko:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -2863,12 +2866,12 @@ taiko:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -2877,12 +2880,12 @@ taiko:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -2891,12 +2894,12 @@ taiko:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -2905,12 +2908,12 @@ taiko:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -2919,12 +2922,12 @@ taiko:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -2933,12 +2936,12 @@ taiko:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -2947,12 +2950,12 @@ taiko:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -2961,12 +2964,12 @@ taiko:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -2975,12 +2978,12 @@ taiko:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -2989,12 +2992,12 @@ taiko:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3003,12 +3006,12 @@ taiko:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -3017,12 +3020,12 @@ taiko:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -3031,12 +3034,12 @@ taiko:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -3044,9 +3047,6 @@ taiko:
             type: staticAggregationIsm
         owner: "0x31FF35F84ADB120DbE089D190F03Ac74731Ae83F"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x31FF35F84ADB120DbE089D190F03Ac74731Ae83F"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -3066,16 +3066,19 @@ unichain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x9D5FCF39FF17a67eB9CB4505f83920519EfEB01B"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -3084,12 +3087,12 @@ unichain:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -3098,12 +3101,12 @@ unichain:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -3112,12 +3115,12 @@ unichain:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -3126,12 +3129,12 @@ unichain:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -3140,12 +3143,12 @@ unichain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -3154,12 +3157,12 @@ unichain:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -3168,12 +3171,12 @@ unichain:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -3182,12 +3185,12 @@ unichain:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -3196,12 +3199,12 @@ unichain:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -3210,12 +3213,12 @@ unichain:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -3224,12 +3227,12 @@ unichain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3238,12 +3241,12 @@ unichain:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -3252,12 +3255,12 @@ unichain:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -3266,12 +3269,12 @@ unichain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -3279,9 +3282,6 @@ unichain:
             type: staticAggregationIsm
         owner: "0x9D5FCF39FF17a67eB9CB4505f83920519EfEB01B"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x9D5FCF39FF17a67eB9CB4505f83920519EfEB01B"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -3301,16 +3301,19 @@ worldchain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x3DA9AE6359Ad3eFFD33Ad334ae12bE55904BE4eA"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -3319,12 +3322,12 @@ worldchain:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -3333,12 +3336,12 @@ worldchain:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -3347,12 +3350,12 @@ worldchain:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -3361,12 +3364,12 @@ worldchain:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -3375,12 +3378,12 @@ worldchain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -3389,12 +3392,12 @@ worldchain:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -3403,12 +3406,12 @@ worldchain:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -3417,12 +3420,12 @@ worldchain:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -3431,12 +3434,12 @@ worldchain:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -3445,12 +3448,12 @@ worldchain:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -3459,12 +3462,12 @@ worldchain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3473,12 +3476,12 @@ worldchain:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -3487,12 +3490,12 @@ worldchain:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -3501,12 +3504,12 @@ worldchain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -3514,9 +3517,6 @@ worldchain:
             type: staticAggregationIsm
         owner: "0x3DA9AE6359Ad3eFFD33Ad334ae12bE55904BE4eA"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x3DA9AE6359Ad3eFFD33Ad334ae12bE55904BE4eA"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -3536,16 +3536,19 @@ zircuit:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
+        type: defaultFallbackRoutingIsm
       - domains:
           arbitrum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9bccfad3bd12ef0ee8ae839dd9ed7835bccadc9d"
                   - "0xc27032c6bbd48c20005f552af3aaa0dbf14260f3"
@@ -3554,12 +3557,12 @@ zircuit:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -3568,12 +3571,12 @@ zircuit:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -3582,12 +3585,12 @@ zircuit:
           blast:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1652d8ba766821cf01aeea34306dfc1cab964a32"
                   - "0x54bb0036f777202371429e062fe6aee0d59442f9"
@@ -3596,12 +3599,12 @@ zircuit:
           bsc:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x3156db97a3b3e2dcc3d69fddfd3e12dc7c937b6d"
                   - "0x9a0326c43e4713ae2477f09e0f28ffedc24d8266"
@@ -3610,12 +3613,12 @@ zircuit:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -3624,12 +3627,12 @@ zircuit:
           fraxtal:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91"
                   - "0xe986f457965227a05dcf984c8d0c29e01253c44d"
@@ -3638,12 +3641,12 @@ zircuit:
           linea:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x06a5a2a429560034d38bf62ca6d470942535947e"
                   - "0xcb3e44edd2229860bdbaa58ba2c3817d111bee9a"
@@ -3652,12 +3655,12 @@ zircuit:
           mode:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x456fbbe05484fc9f2f38ea09648424f54d6872be"
                   - "0x7e29608c6e5792bbf9128599ca309be0728af7b4"
@@ -3666,12 +3669,12 @@ zircuit:
           optimism:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x6f4cb8e96db5d44422a4495faa73fffb9d30e9e2"
                   - "0xe2593d205f5e7f74a50fa900824501084e092ebd"
@@ -3680,12 +3683,12 @@ zircuit:
           sei:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x7a0f4a8672f603e0c12468551db03f3956d10910"
                   - "0x952df7f0cb8611573a53dd7cbf29768871d9f8b0"
@@ -3694,12 +3697,12 @@ zircuit:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -3708,12 +3711,12 @@ zircuit:
           taiko:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x2f007c82672f2bb97227d4e3f80ac481bfb40a2a"
                   - "0xd4F6000d8e1108bd4998215d51d5dF559BdB43a1"
@@ -3722,12 +3725,12 @@ zircuit:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -3736,12 +3739,12 @@ zircuit:
           worldchain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19"
                   - "0x650a1bcb489BE2079d82602c10837780ef6dADA8"
@@ -3749,9 +3752,6 @@ zircuit:
             type: staticAggregationIsm
         owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false

--- a/deployments/warp_routes/FASTUSD/ethereum-sei-config.yaml
+++ b/deployments/warp_routes/FASTUSD/ethereum-sei-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0xeA895A7Ff45d8d3857A04c1E38A362f3bd9a076f"
-    chainName: sei
-    collateralAddressOrDenom: "0x37a4dD9CED2b19Cfe8FAC251cd727b5787E45269"
-    connections:
-      - token: ethereum|ethereum|0x9AD81058c6C3Bf552C9014CB30E824717A0ee21b
-    decimals: 18
-    logoURI: /deployments/warp_routes/FASTUSD/logo.svg
-    name: fastUSD
-    standard: EvmHypXERC20
-    symbol: fastUSD
   - addressOrDenom: "0x9AD81058c6C3Bf552C9014CB30E824717A0ee21b"
     chainName: ethereum
     # Unique setup where deUSD is deposited as collateral on Ethereum and fastUSD is minted as a synthetic on Sei
@@ -21,4 +11,14 @@ tokens:
     logoURI: /deployments/warp_routes/FASTUSD/logo.svg
     name: fastUSD
     standard: EvmHypCollateral
+    symbol: fastUSD
+  - addressOrDenom: "0xeA895A7Ff45d8d3857A04c1E38A362f3bd9a076f"
+    chainName: sei
+    collateralAddressOrDenom: "0x37a4dD9CED2b19Cfe8FAC251cd727b5787E45269"
+    connections:
+      - token: ethereum|ethereum|0x9AD81058c6C3Bf552C9014CB30E824717A0ee21b
+    decimals: 18
+    logoURI: /deployments/warp_routes/FASTUSD/logo.svg
+    name: fastUSD
+    standard: EvmHypXERC20
     symbol: fastUSD

--- a/deployments/warp_routes/FUEL/base-bsc-ethereum-config.yaml
+++ b/deployments/warp_routes/FUEL/base-bsc-ethereum-config.yaml
@@ -2,8 +2,8 @@ tokens:
   - addressOrDenom: "0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634"
     chainName: base
     connections:
-      - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
       - token: ethereum|bsc|0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5
+      - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
     decimals: 9
     logoURI: /deployments/warp_routes/FUEL/logo.svg
     name: FUEL
@@ -12,8 +12,8 @@ tokens:
   - addressOrDenom: "0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5"
     chainName: bsc
     connections:
-      - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
       - token: ethereum|base|0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634
+      - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
     decimals: 9
     logoURI: /deployments/warp_routes/FUEL/logo.svg
     name: FUEL
@@ -24,8 +24,8 @@ tokens:
     coinGeckoId: fuel-network
     collateralAddressOrDenom: "0x675B68AA4d9c2d3BB3F0397048e62E6B7192079c"
     connections:
-      - token: ethereum|bsc|0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5
       - token: ethereum|base|0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634
+      - token: ethereum|bsc|0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5
     decimals: 9
     logoURI: /deployments/warp_routes/FUEL/logo.svg
     name: FUEL

--- a/deployments/warp_routes/GAME/base-form-config.yaml
+++ b/deployments/warp_routes/GAME/base-form-config.yaml
@@ -1,14 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x96D51cc3f7500d501bAeB1A2a62BB96fa03532F8"
-    chainName: form
-    connections:
-      - token: ethereum|base|0x6a5579ABECE07b73d4d92a8bBFF51aF827bB21f1
-    decimals: 18
-    logoURI: /deployments/warp_routes/GAME/logo.svg
-    name: GAME by Virtuals
-    standard: EvmHypSynthetic
-    symbol: GAME
   - addressOrDenom: "0x6a5579ABECE07b73d4d92a8bBFF51aF827bB21f1"
     chainName: base
     coinGeckoId: game-by-virtuals
@@ -19,4 +10,13 @@ tokens:
     logoURI: /deployments/warp_routes/GAME/logo.svg
     name: GAME by Virtuals
     standard: EvmHypCollateral
+    symbol: GAME
+  - addressOrDenom: "0x96D51cc3f7500d501bAeB1A2a62BB96fa03532F8"
+    chainName: form
+    connections:
+      - token: ethereum|base|0x6a5579ABECE07b73d4d92a8bBFF51aF827bB21f1
+    decimals: 18
+    logoURI: /deployments/warp_routes/GAME/logo.svg
+    name: GAME by Virtuals
+    standard: EvmHypSynthetic
     symbol: GAME

--- a/deployments/warp_routes/GIGA/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/GIGA/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: GHcg7qY2cXQ4Ej9xQqjnLdYUV41bt2ncaPuo5AxN5eTy
-    chainName: soon
-    collateralAddressOrDenom: 5msdLukGrv3nkRH8Nwz6LELahbMB5yzmaM6xGhUfcysm
-    connections:
-      - token: sealevel|solanamainnet|CjP8N5L2KV4iWobXoVV1dhftRdfQ7S3rKVrT7Lja9Jku
-    decimals: 5
-    logoURI: /deployments/warp_routes/GIGA/logo.svg
-    name: GIGACHAD
-    standard: SealevelHypSynthetic
-    symbol: GIGA
   - addressOrDenom: CjP8N5L2KV4iWobXoVV1dhftRdfQ7S3rKVrT7Lja9Jku
     chainName: solanamainnet
     coinGeckoId: gigachad-2
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/GIGA/logo.svg
     name: GIGACHAD
     standard: SealevelHypCollateral
+    symbol: GIGA
+  - addressOrDenom: GHcg7qY2cXQ4Ej9xQqjnLdYUV41bt2ncaPuo5AxN5eTy
+    chainName: soon
+    collateralAddressOrDenom: 5msdLukGrv3nkRH8Nwz6LELahbMB5yzmaM6xGhUfcysm
+    connections:
+      - token: sealevel|solanamainnet|CjP8N5L2KV4iWobXoVV1dhftRdfQ7S3rKVrT7Lja9Jku
+    decimals: 5
+    logoURI: /deployments/warp_routes/GIGA/logo.svg
+    name: GIGACHAD
+    standard: SealevelHypSynthetic
     symbol: GIGA

--- a/deployments/warp_routes/GOAT/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/GOAT/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: 9NhiDziXERQUsb3NxRNdamR6ivfeF8GanUJvBffQbyBF
-    chainName: soon
-    collateralAddressOrDenom: 6ABPSb8Pj7B6waFjcPf8JgosQnghqqqiL9kAL3ykatk4
-    connections:
-      - token: sealevel|solanamainnet|HM4qABV4C6KPYhZQmJnQXJ9Q9Syo5waPcxFWLQNiDq2e
-    decimals: 6
-    logoURI: /deployments/warp_routes/GOAT/logo.svg
-    name: Goatseus Maximus
-    standard: SealevelHypSynthetic
-    symbol: GOAT
   - addressOrDenom: HM4qABV4C6KPYhZQmJnQXJ9Q9Syo5waPcxFWLQNiDq2e
     chainName: solanamainnet
     coinGeckoId: goatseus-maximus
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/GOAT/logo.svg
     name: Goatseus Maximus
     standard: SealevelHypCollateral
+    symbol: GOAT
+  - addressOrDenom: 9NhiDziXERQUsb3NxRNdamR6ivfeF8GanUJvBffQbyBF
+    chainName: soon
+    collateralAddressOrDenom: 6ABPSb8Pj7B6waFjcPf8JgosQnghqqqiL9kAL3ykatk4
+    connections:
+      - token: sealevel|solanamainnet|HM4qABV4C6KPYhZQmJnQXJ9Q9Syo5waPcxFWLQNiDq2e
+    decimals: 6
+    logoURI: /deployments/warp_routes/GOAT/logo.svg
+    name: Goatseus Maximus
+    standard: SealevelHypSynthetic
     symbol: GOAT

--- a/deployments/warp_routes/INJ/inevm-injective-config.yaml
+++ b/deployments/warp_routes/INJ/inevm-injective-config.yaml
@@ -11,6 +11,15 @@ options:
       destination: inevm
       origin: injective
 tokens:
+  - addressOrDenom: "0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4"
+    chainName: inevm
+    connections:
+      - token: cosmos|injective|inj1mv9tjvkaw7x8w8y9vds8pkfq46g2vcfkjehc6k
+    decimals: 18
+    logoURI: /deployments/warp_routes/INJ/logo.svg
+    name: Injective Coin
+    standard: EvmHypNative
+    symbol: INJ
   - addressOrDenom: inj1mv9tjvkaw7x8w8y9vds8pkfq46g2vcfkjehc6k
     chainName: injective
     coinGeckoId: injective-protocol
@@ -20,13 +29,4 @@ tokens:
     logoURI: /deployments/warp_routes/INJ/logo.svg
     name: Injective Coin
     standard: CwHypNative
-    symbol: INJ
-  - addressOrDenom: "0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4"
-    chainName: inevm
-    connections:
-      - token: cosmos|injective|inj1mv9tjvkaw7x8w8y9vds8pkfq46g2vcfkjehc6k
-    decimals: 18
-    logoURI: /deployments/warp_routes/INJ/logo.svg
-    name: Injective Coin
-    standard: EvmHypNative
     symbol: INJ

--- a/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-config.yaml
+++ b/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-config.yaml
@@ -1,13 +1,58 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1"
+    chainName: arbitrum
+    connections:
+      - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+      - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+      - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+      - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+    decimals: 18
+    logoURI: /deployments/warp_routes/LUMIA/logo.svg
+    name: Lumia Token
+    standard: EvmHypSynthetic
+    symbol: LUMIA
+  - addressOrDenom: "0x02EB40D41676F20eDcF95f9110f00412ca53a85F"
+    chainName: avalanche
+    connections:
+      - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+      - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+      - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+      - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+    decimals: 18
+    logoURI: /deployments/warp_routes/LUMIA/logo.svg
+    name: Lumia Token
+    standard: EvmHypSynthetic
+    symbol: LUMIA
+  - addressOrDenom: "0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4"
+    chainName: base
+    connections:
+      - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+      - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+      - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+      - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+    decimals: 18
+    logoURI: /deployments/warp_routes/LUMIA/logo.svg
+    name: Lumia Token
+    standard: EvmHypSynthetic
+    symbol: LUMIA
   - addressOrDenom: "0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047"
     chainName: bsc
     connections:
-      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
       - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
       - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
       - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
     decimals: 18
@@ -20,11 +65,11 @@ tokens:
     coinGeckoId: lumia
     collateralAddressOrDenom: "0xD9343a049D5DBd89CD19DC6BcA8c48fB3a0a42a7"
     connections:
-      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
       - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
       - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
       - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
     decimals: 18
@@ -36,11 +81,11 @@ tokens:
     chainName: lumiaprism
     coinGeckoId: lumia
     connections:
-      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
       - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
       - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
       - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
       - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
       - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
     decimals: 18
@@ -48,60 +93,15 @@ tokens:
     name: Lumia Token
     standard: EvmHypNative
     symbol: LUMIA
-  - addressOrDenom: "0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1"
-    chainName: arbitrum
-    connections:
-      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-      - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-      - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-      - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-      - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-    decimals: 18
-    logoURI: /deployments/warp_routes/LUMIA/logo.svg
-    name: Lumia Token
-    standard: EvmHypSynthetic
-    symbol: LUMIA
-  - addressOrDenom: "0x02EB40D41676F20eDcF95f9110f00412ca53a85F"
-    chainName: avalanche
-    connections:
-      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-      - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-      - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-      - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-      - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-    decimals: 18
-    logoURI: /deployments/warp_routes/LUMIA/logo.svg
-    name: Lumia Token
-    standard: EvmHypSynthetic
-    symbol: LUMIA
-  - addressOrDenom: "0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4"
-    chainName: base
-    connections:
-      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-      - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-      - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-      - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-      - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-    decimals: 18
-    logoURI: /deployments/warp_routes/LUMIA/logo.svg
-    name: Lumia Token
-    standard: EvmHypSynthetic
-    symbol: LUMIA
   - addressOrDenom: "0x978B9dE4D8A41b023408383e3B4F760932AaDdc1"
     chainName: optimism
     connections:
-      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
       - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
       - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
     decimals: 18
     logoURI: /deployments/warp_routes/LUMIA/logo.svg
@@ -111,12 +111,12 @@ tokens:
   - addressOrDenom: "0x72749806df5A6BBb72032039bbE9a3f1b17D1936"
     chainName: polygon
     connections:
-      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
       - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
       - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+      - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+      - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+      - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
       - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
     decimals: 18
     logoURI: /deployments/warp_routes/LUMIA/logo.svg

--- a/deployments/warp_routes/MEW/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/MEW/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: 9JcBcd9bRDQjRtkZq7sWfNF4DRFRA24KsuhV9rTemUgC
-    chainName: soon
-    collateralAddressOrDenom: GvW8my8MggjKf8m3LAds4bpL4GgQRmRaDhbWUon7ZzF3
-    connections:
-      - token: sealevel|solanamainnet|BEzLRBDBJyRrzZN2CfGJB3bedBj3HwHqj6MB8BQn1mdL
-    decimals: 5
-    logoURI: /deployments/warp_routes/MEW/logo.svg
-    name: MEW
-    standard: SealevelHypSynthetic
-    symbol: MEW
   - addressOrDenom: BEzLRBDBJyRrzZN2CfGJB3bedBj3HwHqj6MB8BQn1mdL
     chainName: solanamainnet
     coinGeckoId: mew
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/MEW/logo.svg
     name: MEW
     standard: SealevelHypCollateral
+    symbol: MEW
+  - addressOrDenom: 9JcBcd9bRDQjRtkZq7sWfNF4DRFRA24KsuhV9rTemUgC
+    chainName: soon
+    collateralAddressOrDenom: GvW8my8MggjKf8m3LAds4bpL4GgQRmRaDhbWUon7ZzF3
+    connections:
+      - token: sealevel|solanamainnet|BEzLRBDBJyRrzZN2CfGJB3bedBj3HwHqj6MB8BQn1mdL
+    decimals: 5
+    logoURI: /deployments/warp_routes/MEW/logo.svg
+    name: MEW
+    standard: SealevelHypSynthetic
     symbol: MEW

--- a/deployments/warp_routes/MILK/bsc-milkyway-config.yaml
+++ b/deployments/warp_routes/MILK/bsc-milkyway-config.yaml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD"
+    chainName: bsc
+    connections:
+      - token: cosmosnative|milkyway|0x726f757465725f61707000000000000000000000000000010000000000000000
+    decimals: 6
+    logoURI: /deployments/warp_routes/MILK/logo.svg
+    name: MilkyWay
+    standard: EvmHypSynthetic
+    symbol: MILK
   - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
     chainName: milkyway
     coinGeckoId: milkyway-2
@@ -9,13 +18,4 @@ tokens:
     logoURI: /deployments/warp_routes/MILK/logo.svg
     name: MilkyWay
     standard: CosmosNativeHypCollateral
-    symbol: MILK
-  - addressOrDenom: "0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD"
-    chainName: bsc
-    connections:
-      - token: cosmosnative|milkyway|0x726f757465725f61707000000000000000000000000000010000000000000000
-    decimals: 6
-    logoURI: /deployments/warp_routes/MILK/logo.svg
-    name: MilkyWay
-    standard: EvmHypSynthetic
     symbol: MILK

--- a/deployments/warp_routes/MILK/bsc-milkyway-deploy.yaml
+++ b/deployments/warp_routes/MILK/bsc-milkyway-deploy.yaml
@@ -7,18 +7,18 @@ bsc:
           - threshold: 3
             type: messageIdMultisigIsm
             validators:
-              - "0x9985e0c6df8e25b655b46a317af422f5e7756875"
               - "0x55010624d5e239281d0850dc7915b78187e8bc0e"
-              - "0x9ecf299947b030f9898faf328e5edbf77b13e974"
               - "0x56fa9ac314ad49836ffb35918043d6b2dec304fb"
+              - "0x9985e0c6df8e25b655b46a317af422f5e7756875"
+              - "0x9ecf299947b030f9898faf328e5edbf77b13e974"
               - "0xb69c0d1aacd305edeca88b482b9dd9657f3a8b5c"
           - threshold: 3
             type: merkleRootMultisigIsm
             validators:
-              - "0x9985e0c6df8e25b655b46a317af422f5e7756875"
               - "0x55010624d5e239281d0850dc7915b78187e8bc0e"
-              - "0x9ecf299947b030f9898faf328e5edbf77b13e974"
               - "0x56fa9ac314ad49836ffb35918043d6b2dec304fb"
+              - "0x9985e0c6df8e25b655b46a317af422f5e7756875"
+              - "0x9ecf299947b030f9898faf328e5edbf77b13e974"
               - "0xb69c0d1aacd305edeca88b482b9dd9657f3a8b5c"
         threshold: 1
         type: staticAggregationIsm

--- a/deployments/warp_routes/OORT/bsc-ethereum-oortmainnet-config.yaml
+++ b/deployments/warp_routes/OORT/bsc-ethereum-oortmainnet-config.yaml
@@ -4,8 +4,19 @@ tokens:
     chainName: bsc
     collateralAddressOrDenom: "0x5651fA7a726B9Ec0cAd00Ee140179912B6E73599"
     connections:
-      - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
       - token: ethereum|ethereum|0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697
+      - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
+    decimals: 18
+    logoURI: /deployments/warp_routes/OORT/logo.svg
+    name: OORT
+    standard: EvmHypCollateral
+    symbol: OORT
+  - addressOrDenom: "0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697"
+    chainName: ethereum
+    collateralAddressOrDenom: "0x5651fA7a726B9Ec0cAd00Ee140179912B6E73599"
+    connections:
+      - token: ethereum|bsc|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
+      - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
     decimals: 18
     logoURI: /deployments/warp_routes/OORT/logo.svg
     name: OORT
@@ -20,15 +31,4 @@ tokens:
     logoURI: /deployments/warp_routes/OORT/logo.svg
     name: OORT
     standard: EvmHypNative
-    symbol: OORT
-  - addressOrDenom: "0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697"
-    chainName: ethereum
-    collateralAddressOrDenom: "0x5651fA7a726B9Ec0cAd00Ee140179912B6E73599"
-    connections:
-      - token: ethereum|bsc|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
-      - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
-    decimals: 18
-    logoURI: /deployments/warp_routes/OORT/logo.svg
-    name: OORT
-    standard: EvmHypCollateral
     symbol: OORT

--- a/deployments/warp_routes/PAXG/arbitrum-ethereum-config.yaml
+++ b/deployments/warp_routes/PAXG/arbitrum-ethereum-config.yaml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0xE7eFb127249Ec17B484B5Bb0Ea5f79A14A6d0721"
+    chainName: arbitrum
+    connections:
+      - token: ethereum|ethereum|0x68A593C7F42e0f6616F9356dCb1CFd130e4e7694
+    decimals: 18
+    logoURI: /deployments/warp_routes/PAXG/logo.svg
+    name: Paxos Gold
+    standard: EvmHypSynthetic
+    symbol: PAXG
   - addressOrDenom: "0x68A593C7F42e0f6616F9356dCb1CFd130e4e7694"
     chainName: ethereum
     coinGeckoId: pax-gold
@@ -10,13 +19,4 @@ tokens:
     logoURI: /deployments/warp_routes/PAXG/logo.svg
     name: Paxos Gold
     standard: EvmHypCollateral
-    symbol: PAXG
-  - addressOrDenom: "0xE7eFb127249Ec17B484B5Bb0Ea5f79A14A6d0721"
-    chainName: arbitrum
-    connections:
-      - token: ethereum|ethereum|0x68A593C7F42e0f6616F9356dCb1CFd130e4e7694
-    decimals: 18
-    logoURI: /deployments/warp_routes/PAXG/logo.svg
-    name: Paxos Gold
-    standard: EvmHypSynthetic
     symbol: PAXG

--- a/deployments/warp_routes/PNDR/bsc-ethereum-lumiaprism-config.yaml
+++ b/deployments/warp_routes/PNDR/bsc-ethereum-lumiaprism-config.yaml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1"
+    chainName: bsc
+    connections:
+      - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
+      - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
+    decimals: 18
+    logoURI: /deployments/warp_routes/PNDR/logo.jpeg
+    name: Ponder
+    standard: EvmHypSynthetic
+    symbol: PNDR
   - addressOrDenom: "0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a"
     chainName: ethereum
     coinGeckoId: ponder-one
@@ -12,21 +22,11 @@ tokens:
     name: Ponder
     standard: EvmHypCollateral
     symbol: PNDR
-  - addressOrDenom: "0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1"
-    chainName: bsc
-    connections:
-      - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
-      - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
-    decimals: 18
-    logoURI: /deployments/warp_routes/PNDR/logo.jpeg
-    name: Ponder
-    standard: EvmHypSynthetic
-    symbol: PNDR
   - addressOrDenom: "0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1"
     chainName: lumiaprism
     connections:
-      - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
       - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
+      - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
     decimals: 18
     logoURI: /deployments/warp_routes/PNDR/logo.jpeg
     name: Ponder

--- a/deployments/warp_routes/POPCAT/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/POPCAT/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: 2CPGmQCNdGrh45n6BgTG98G7AkQfEKPZCcYW2reju2kn
-    chainName: soon
-    collateralAddressOrDenom: Hxf93wyFCRi4Je5R1dYc4xAtPug48YdC6vuorUJFW5dv
-    connections:
-      - token: sealevel|solanamainnet|BSrwJNiHM88XRYX93CRXGSTR4GfnZfxn3kTa4rvanPKr
-    decimals: 9
-    logoURI: /deployments/warp_routes/POPCAT/logo.svg
-    name: POPCAT
-    standard: SealevelHypSynthetic
-    symbol: POPCAT
   - addressOrDenom: BSrwJNiHM88XRYX93CRXGSTR4GfnZfxn3kTa4rvanPKr
     chainName: solanamainnet
     coinGeckoId: popcat
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/POPCAT/logo.svg
     name: POPCAT
     standard: SealevelHypCollateral
+    symbol: POPCAT
+  - addressOrDenom: 2CPGmQCNdGrh45n6BgTG98G7AkQfEKPZCcYW2reju2kn
+    chainName: soon
+    collateralAddressOrDenom: Hxf93wyFCRi4Je5R1dYc4xAtPug48YdC6vuorUJFW5dv
+    connections:
+      - token: sealevel|solanamainnet|BSrwJNiHM88XRYX93CRXGSTR4GfnZfxn3kTa4rvanPKr
+    decimals: 9
+    logoURI: /deployments/warp_routes/POPCAT/logo.svg
+    name: POPCAT
+    standard: SealevelHypSynthetic
     symbol: POPCAT

--- a/deployments/warp_routes/PZETH/berachain-ethereum-swell-unichain-zircuit-config.yaml
+++ b/deployments/warp_routes/PZETH/berachain-ethereum-swell-unichain-zircuit-config.yaml
@@ -1,14 +1,27 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0"
+    chainName: berachain
+    collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
+    connections:
+      - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
+      - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
+      - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
+      - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
+    decimals: 18
+    logoURI: /deployments/warp_routes/PZETH/logo.svg
+    name: Renzo Restaked LST
+    standard: EvmHypXERC20
+    symbol: pzETH
   - addressOrDenom: "0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd"
     chainName: ethereum
     coinGeckoId: renzo-restaked-lst
     collateralAddressOrDenom: "0xbC5511354C4A9a50DE928F56DB01DD327c4e56d5"
     connections:
-      - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
-      - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
       - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
+      - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
       - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
+      - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
     decimals: 18
     logoURI: /deployments/warp_routes/PZETH/logo.svg
     name: Renzo Restaked LST
@@ -18,36 +31,10 @@ tokens:
     chainName: swell
     collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
     connections:
-      - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
-      - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
       - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
-      - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
-    decimals: 18
-    logoURI: /deployments/warp_routes/PZETH/logo.svg
-    name: Renzo Restaked LST
-    standard: EvmHypXERC20
-    symbol: pzETH
-  - addressOrDenom: "0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764"
-    chainName: zircuit
-    collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
-    connections:
       - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
-      - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
-      - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
       - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
-    decimals: 18
-    logoURI: /deployments/warp_routes/PZETH/logo.svg
-    name: Renzo Restaked LST
-    standard: EvmHypXERC20
-    symbol: pzETH
-  - addressOrDenom: "0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0"
-    chainName: berachain
-    collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
-    connections:
-      - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
-      - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
       - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
-      - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
     decimals: 18
     logoURI: /deployments/warp_routes/PZETH/logo.svg
     name: Renzo Restaked LST
@@ -57,10 +44,23 @@ tokens:
     chainName: unichain
     collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
     connections:
+      - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
       - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
       - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
       - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
+    decimals: 18
+    logoURI: /deployments/warp_routes/PZETH/logo.svg
+    name: Renzo Restaked LST
+    standard: EvmHypXERC20
+    symbol: pzETH
+  - addressOrDenom: "0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764"
+    chainName: zircuit
+    collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
+    connections:
       - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
+      - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
+      - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
+      - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
     decimals: 18
     logoURI: /deployments/warp_routes/PZETH/logo.svg
     name: Renzo Restaked LST

--- a/deployments/warp_routes/PZETH/berachain-ethereum-swell-unichain-zircuit-deploy.yaml
+++ b/deployments/warp_routes/PZETH/berachain-ethereum-swell-unichain-zircuit-deploy.yaml
@@ -11,16 +11,19 @@ berachain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x865BA5789D82F2D4C5595a3968dad729A8C3daE6"
+        type: defaultFallbackRoutingIsm
       - domains:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -29,12 +32,12 @@ berachain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -43,12 +46,12 @@ berachain:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -57,12 +60,12 @@ berachain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -70,9 +73,6 @@ berachain:
             type: staticAggregationIsm
         owner: "0x865BA5789D82F2D4C5595a3968dad729A8C3daE6"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x865BA5789D82F2D4C5595a3968dad729A8C3daE6"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -92,16 +92,19 @@ ethereum:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -110,12 +113,12 @@ ethereum:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -124,12 +127,12 @@ ethereum:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -138,12 +141,12 @@ ethereum:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -151,9 +154,6 @@ ethereum:
             type: staticAggregationIsm
         owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -176,16 +176,19 @@ swell:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x435E8c9652Da151292F3981bbf663EBEB6668501"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -194,12 +197,12 @@ swell:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -208,12 +211,12 @@ swell:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -222,12 +225,12 @@ swell:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -235,9 +238,6 @@ swell:
             type: staticAggregationIsm
         owner: "0x435E8c9652Da151292F3981bbf663EBEB6668501"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x435E8c9652Da151292F3981bbf663EBEB6668501"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -257,16 +257,19 @@ unichain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x70aF964829DA7F3f51973EE806AEeAB9225F2661"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -275,12 +278,12 @@ unichain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -289,12 +292,12 @@ unichain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -303,12 +306,12 @@ unichain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -316,9 +319,6 @@ unichain:
             type: staticAggregationIsm
         owner: "0x70aF964829DA7F3f51973EE806AEeAB9225F2661"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x70aF964829DA7F3f51973EE806AEeAB9225F2661"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -338,16 +338,19 @@ zircuit:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -356,12 +359,12 @@ zircuit:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -370,12 +373,12 @@ zircuit:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -384,12 +387,12 @@ zircuit:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -397,9 +400,6 @@ zircuit:
             type: staticAggregationIsm
         owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false

--- a/deployments/warp_routes/PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit-config.yaml
+++ b/deployments/warp_routes/PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit-config.yaml
@@ -1,13 +1,25 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74"
+    chainName: berachain
+    collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
+    connections:
+      - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
+      - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
+      - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
+      - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
+    decimals: 18
+    name: Renzo Restaked LST Stage
+    standard: EvmHypXERC20
+    symbol: PZETHSTAGE
   - addressOrDenom: "0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC"
     chainName: ethereum
     collateralAddressOrDenom: "0x9E1a2b6de93164b77Fc5CA11e647EECB38BB463D"
     connections:
-      - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
-      - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
       - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
+      - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
       - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
+      - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
     decimals: 18
     name: Renzo Restaked LST Stage
     standard: EvmHypXERC20Lockbox
@@ -16,34 +28,10 @@ tokens:
     chainName: swell
     collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
     connections:
-      - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
-      - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
       - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
-      - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
-    decimals: 18
-    name: Renzo Restaked LST Stage
-    standard: EvmHypXERC20
-    symbol: PZETHSTAGE
-  - addressOrDenom: "0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6"
-    chainName: zircuit
-    collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
-    connections:
       - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
-      - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
-      - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
       - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
-    decimals: 18
-    name: Renzo Restaked LST Stage
-    standard: EvmHypXERC20
-    symbol: PZETHSTAGE
-  - addressOrDenom: "0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74"
-    chainName: berachain
-    collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
-    connections:
-      - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
-      - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
       - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
-      - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
     decimals: 18
     name: Renzo Restaked LST Stage
     standard: EvmHypXERC20
@@ -52,10 +40,22 @@ tokens:
     chainName: unichain
     collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
     connections:
+      - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
       - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
       - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
       - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
+    decimals: 18
+    name: Renzo Restaked LST Stage
+    standard: EvmHypXERC20
+    symbol: PZETHSTAGE
+  - addressOrDenom: "0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6"
+    chainName: zircuit
+    collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
+    connections:
       - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
+      - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
+      - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
+      - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
     decimals: 18
     name: Renzo Restaked LST Stage
     standard: EvmHypXERC20

--- a/deployments/warp_routes/PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit-deploy.yaml
+++ b/deployments/warp_routes/PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit-deploy.yaml
@@ -11,16 +11,19 @@ berachain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf013c8Be28421b050cca5bD95cc57Af49568e8be"
+        type: defaultFallbackRoutingIsm
       - domains:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -29,12 +32,12 @@ berachain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -43,12 +46,12 @@ berachain:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -57,12 +60,12 @@ berachain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -70,9 +73,6 @@ berachain:
             type: staticAggregationIsm
         owner: "0xf013c8Be28421b050cca5bD95cc57Af49568e8be"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf013c8Be28421b050cca5bD95cc57Af49568e8be"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -92,16 +92,19 @@ ethereum:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -110,12 +113,12 @@ ethereum:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -124,12 +127,12 @@ ethereum:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -138,12 +141,12 @@ ethereum:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -151,9 +154,6 @@ ethereum:
             type: staticAggregationIsm
         owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xA9421c6F339eC414b7e77449986bE9C2Ae430C25"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -173,16 +173,19 @@ swell:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -191,12 +194,12 @@ swell:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -205,12 +208,12 @@ swell:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -219,12 +222,12 @@ swell:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -232,9 +235,6 @@ swell:
             type: staticAggregationIsm
         owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -254,16 +254,19 @@ unichain:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x9D5FCF39FF17a67eB9CB4505f83920519EfEB01B"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -272,12 +275,12 @@ unichain:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -286,12 +289,12 @@ unichain:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -300,12 +303,12 @@ unichain:
           zircuit:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1da9176c2ce5cc7115340496fa7d1800a98911ce"
                   - "0x7ac6584c068eb2a72d4db82a7b7cd5ab34044061"
@@ -313,9 +316,6 @@ unichain:
             type: staticAggregationIsm
         owner: "0x9D5FCF39FF17a67eB9CB4505f83920519EfEB01B"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x9D5FCF39FF17a67eB9CB4505f83920519EfEB01B"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -335,16 +335,19 @@ zircuit:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
+        type: defaultFallbackRoutingIsm
       - domains:
           berachain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa7341aa60faad0ce728aa9aeb67bb880f55e4392"
                   - "0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6"
@@ -353,12 +356,12 @@ zircuit:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -367,12 +370,12 @@ zircuit:
           swell:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x9eadf9217be22d9878e0e464727a2176d5c69ff8"
                   - "0xb6b9b4bd4eb6eb3aef5e9826e7f8b8455947f67c"
@@ -381,12 +384,12 @@ zircuit:
           unichain:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0xa9d517776fe8beba7d67c21cac1e805bd609c08e"
                   - "0xfe318024ca6197f2157905209149067a11e6982c"
@@ -394,9 +397,6 @@ zircuit:
             type: staticAggregationIsm
         owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xf40b75fb85C3bEc70D75A1B45ef08FC48Db61115"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false

--- a/deployments/warp_routes/Pnut/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/Pnut/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: 5WHM6rm9HpFqNY8hye9ZY9vrgCCM7M5YnCeKcq29FpXz
-    chainName: soon
-    collateralAddressOrDenom: HHJDLRYkp2SPdo2Wv7F62ccKeqVcgEzowaEctUP2r2Cu
-    connections:
-      - token: sealevel|solanamainnet|J8fVLBiLMniYxaBYhfpGmqDpf2qtgaiDAPuznfRMhLs6
-    decimals: 6
-    logoURI: /deployments/warp_routes/Pnut/logo.svg
-    name: Peanut the Squirrel
-    standard: SealevelHypSynthetic
-    symbol: Pnut
   - addressOrDenom: J8fVLBiLMniYxaBYhfpGmqDpf2qtgaiDAPuznfRMhLs6
     chainName: solanamainnet
     coinGeckoId: Pnut
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/Pnut/logo.svg
     name: Peanut the Squirrel
     standard: SealevelHypCollateral
+    symbol: Pnut
+  - addressOrDenom: 5WHM6rm9HpFqNY8hye9ZY9vrgCCM7M5YnCeKcq29FpXz
+    chainName: soon
+    collateralAddressOrDenom: HHJDLRYkp2SPdo2Wv7F62ccKeqVcgEzowaEctUP2r2Cu
+    connections:
+      - token: sealevel|solanamainnet|J8fVLBiLMniYxaBYhfpGmqDpf2qtgaiDAPuznfRMhLs6
+    decimals: 6
+    logoURI: /deployments/warp_routes/Pnut/logo.svg
+    name: Peanut the Squirrel
+    standard: SealevelHypSynthetic
     symbol: Pnut

--- a/deployments/warp_routes/REZ/base-ethereum-deploy.yaml
+++ b/deployments/warp_routes/REZ/base-ethereum-deploy.yaml
@@ -11,16 +11,19 @@ base:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
+        type: defaultFallbackRoutingIsm
       - domains:
           ethereum:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x1fd889337f60986aa57166bc5ac121efd13e4fdd"
                   - "0xc7f7b94a6baf2fffa54dfe1dde6e5fcbb749e04f"
@@ -28,9 +31,6 @@ base:
             type: staticAggregationIsm
         owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0x8410927C286A38883BC23721e640F31D3E3E79F8"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false
@@ -50,16 +50,19 @@ ethereum:
     type: aggregationHook
   interchainSecurityModule:
     modules:
+      - domains: {}
+        owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
+        type: defaultFallbackRoutingIsm
       - domains:
           base:
             modules:
               - threshold: 1
-                type: messageIdMultisigIsm
+                type: merkleRootMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
               - threshold: 1
-                type: merkleRootMultisigIsm
+                type: messageIdMultisigIsm
                 validators:
                   - "0x25ba4ee5268cbfb8d69bac531aa10368778702bd"
                   - "0x9ec803b503e9c7d2611e231521ef3fde73f7a21c"
@@ -67,9 +70,6 @@ ethereum:
             type: staticAggregationIsm
         owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
         type: domainRoutingIsm
-      - domains: {}
-        owner: "0xD1e6626310fD54Eceb5b9a51dA2eC329D6D4B68A"
-        type: defaultFallbackRoutingIsm
     threshold: 2
     type: staticAggregationIsm
   isNft: false

--- a/deployments/warp_routes/SOL/solanamainnet-sonicsvm-config.yaml
+++ b/deployments/warp_routes/SOL/solanamainnet-sonicsvm-config.yaml
@@ -1,19 +1,19 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: 7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY
-    chainName: sonicsvm
-    connections:
-      - token: sealevel|solanamainnet|BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
-    decimals: 9
-    logoURI: /deployments/warp_routes/SOL/logo.svg
-    name: Solana
-    standard: SealevelHypNative
-    symbol: SOL
   - addressOrDenom: BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
     chainName: solanamainnet
     coinGeckoId: solana
     connections:
       - token: sealevel|sonicsvm|7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY
+    decimals: 9
+    logoURI: /deployments/warp_routes/SOL/logo.svg
+    name: Solana
+    standard: SealevelHypNative
+    symbol: SOL
+  - addressOrDenom: 7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY
+    chainName: sonicsvm
+    connections:
+      - token: sealevel|solanamainnet|BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
     decimals: 9
     logoURI: /deployments/warp_routes/SOL/logo.svg
     name: Solana

--- a/deployments/warp_routes/SOL/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/SOL/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: 6SGK4PnHefm4egyUUeVro8wKBkuPexVehsjuUK8auJ8b
-    chainName: soon
-    collateralAddressOrDenom: ERFzpDteGNo8LTDKW1WwVGrkRMmA2y9WZHXNHxMA6BSV
-    connections:
-      - token: sealevel|solanamainnet|GPFwRQ5Cw6dTWnmappUKJt76DD8yawxPx28QugfCaGaA
-    decimals: 9
-    logoURI: /deployments/warp_routes/SOL/logo.svg
-    name: Solana
-    standard: SealevelHypSynthetic
-    symbol: SOL
   - addressOrDenom: GPFwRQ5Cw6dTWnmappUKJt76DD8yawxPx28QugfCaGaA
     chainName: solanamainnet
     coinGeckoId: solana
@@ -19,4 +9,14 @@ tokens:
     logoURI: /deployments/warp_routes/SOL/logo.svg
     name: Solana
     standard: SealevelHypNative
+    symbol: SOL
+  - addressOrDenom: 6SGK4PnHefm4egyUUeVro8wKBkuPexVehsjuUK8auJ8b
+    chainName: soon
+    collateralAddressOrDenom: ERFzpDteGNo8LTDKW1WwVGrkRMmA2y9WZHXNHxMA6BSV
+    connections:
+      - token: sealevel|solanamainnet|GPFwRQ5Cw6dTWnmappUKJt76DD8yawxPx28QugfCaGaA
+    decimals: 9
+    logoURI: /deployments/warp_routes/SOL/logo.svg
+    name: Solana
+    standard: SealevelHypSynthetic
     symbol: SOL

--- a/deployments/warp_routes/SPORE/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/SPORE/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: JDnjXhoucA9HwTk1s7piyoCLvwQSKdnaRitdkpXsRgtj
-    chainName: soon
-    collateralAddressOrDenom: 4zCFfTv26uUgo9APJcbCuGEwx5hhyb9HMgbM35gnsQ6B
-    connections:
-      - token: sealevel|solanamainnet|34V29ar8oahnZVnnQqEfd9pUE3MBrAxpgMtQf1Xccs1A
-    decimals: 6
-    logoURI: /deployments/warp_routes/SPORE/logo.svg
-    name: SPORE
-    standard: SealevelHypSynthetic
-    symbol: SPORE
   - addressOrDenom: 34V29ar8oahnZVnnQqEfd9pUE3MBrAxpgMtQf1Xccs1A
     chainName: solanamainnet
     coinGeckoId: spore-2
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/SPORE/logo.svg
     name: SPORE
     standard: SealevelHypCollateral
+    symbol: SPORE
+  - addressOrDenom: JDnjXhoucA9HwTk1s7piyoCLvwQSKdnaRitdkpXsRgtj
+    chainName: soon
+    collateralAddressOrDenom: 4zCFfTv26uUgo9APJcbCuGEwx5hhyb9HMgbM35gnsQ6B
+    connections:
+      - token: sealevel|solanamainnet|34V29ar8oahnZVnnQqEfd9pUE3MBrAxpgMtQf1Xccs1A
+    decimals: 6
+    logoURI: /deployments/warp_routes/SPORE/logo.svg
+    name: SPORE
+    standard: SealevelHypSynthetic
     symbol: SPORE

--- a/deployments/warp_routes/TIA/arbitrum-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/arbitrum-neutron-config.yaml
@@ -6,6 +6,15 @@ options:
       destination: arbitrum
       origin: neutron
 tokens:
+  - addressOrDenom: "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C"
+    chainName: arbitrum
+    connections:
+      - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA.n
+    standard: EvmHypSynthetic
+    symbol: TIA.n
   - addressOrDenom: neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
     chainName: neutron
     coinGeckoId: celestia
@@ -16,15 +25,6 @@ tokens:
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA.n
     standard: CwHypCollateral
-    symbol: TIA.n
-  - addressOrDenom: "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C"
-    chainName: arbitrum
-    connections:
-      - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
-    decimals: 6
-    logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: TIA.n
-    standard: EvmHypSynthetic
     symbol: TIA.n
   - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
     chainName: neutron

--- a/deployments/warp_routes/TIA/eclipsemainnet-stride-config.yaml
+++ b/deployments/warp_routes/TIA/eclipsemainnet-stride-config.yaml
@@ -6,6 +6,17 @@ options:
       destination: eclipsemainnet
       origin: stride
 tokens:
+  # TIA on Eclipsemainnet to Stride
+  - addressOrDenom: BpXHAiktwjx7fN6M9ST9wr6qKAsH27wZFhdHEhReJsR6
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: 9RryNMhAVJpAwAGjCAMKbbTFwgjapqPkzpGMfTQhEjf8
+    connections:
+      - token: cosmos|stride|stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: Celestia
+    standard: SealevelHypSynthetic
+    symbol: TIA
   # TIA on Stride to Eclipsemainnet
   - addressOrDenom: stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6
     chainName: stride
@@ -17,17 +28,6 @@ tokens:
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: Celestia
     standard: CwHypCollateral
-    symbol: TIA
-  # TIA on Eclipsemainnet to Stride
-  - addressOrDenom: BpXHAiktwjx7fN6M9ST9wr6qKAsH27wZFhdHEhReJsR6
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: 9RryNMhAVJpAwAGjCAMKbbTFwgjapqPkzpGMfTQhEjf8
-    connections:
-      - token: cosmos|stride|stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6
-    decimals: 6
-    logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: Celestia
-    standard: SealevelHypSynthetic
     symbol: TIA
   # TIA, required for the IGP payment but not connected to any other chain
   - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801

--- a/deployments/warp_routes/TIA/forma-stride-config.yaml
+++ b/deployments/warp_routes/TIA/forma-stride-config.yaml
@@ -23,6 +23,10 @@ tokens:
   - addressOrDenom: utia
     chainName: celestia
     connections:
+      - sourceChannel: channel-4
+        sourcePort: transfer
+        token: cosmos|stride|ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+        type: ibc
       - intermediateChainName: stride
         intermediateIbcDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
         intermediateRouterAddress: stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
@@ -30,14 +34,20 @@ tokens:
         sourcePort: transfer
         token: ethereum|forma|0x832d26B6904BA7539248Db4D58614251FD63dC05
         type: ibc-hyperlane
-      - sourceChannel: channel-4
-        sourcePort: transfer
-        token: cosmos|stride|ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-        type: ibc
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA
     standard: CosmosIbc
+    symbol: TIA
+  # TIA on Forma from Stride
+  - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
+    chainName: forma
+    connections:
+      - token: cosmos|stride|stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
+    decimals: 18
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA
+    standard: EvmNative
     symbol: TIA
   # TIA on Stride to Forma
   - addressOrDenom: stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
@@ -49,16 +59,6 @@ tokens:
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA
     standard: CwHypCollateral
-    symbol: TIA
-  # TIA on Forma from Stride
-  - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
-    chainName: forma
-    connections:
-      - token: cosmos|stride|stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
-    decimals: 18
-    logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: TIA
-    standard: EvmNative
     symbol: TIA
   # TIA on Stride from Celestia
   - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801

--- a/deployments/warp_routes/TIA/mantapacific-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/mantapacific-neutron-config.yaml
@@ -6,6 +6,15 @@ options:
       destination: mantapacific
       origin: neutron
 tokens:
+  - addressOrDenom: "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa"
+    chainName: mantapacific
+    connections:
+      - token: cosmos|neutron|neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA.n
+    standard: EvmHypSynthetic
+    symbol: TIA.n
   - addressOrDenom: neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
     chainName: neutron
     coinGeckoId: celestia
@@ -16,15 +25,6 @@ tokens:
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA.n
     standard: CwHypCollateral
-    symbol: TIA.n
-  - addressOrDenom: "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa"
-    chainName: mantapacific
-    connections:
-      - token: cosmos|neutron|neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
-    decimals: 6
-    logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: TIA.n
-    standard: EvmHypSynthetic
     symbol: TIA.n
   - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
     chainName: neutron

--- a/deployments/warp_routes/TIA/mantapacific-osmosis-config.yaml
+++ b/deployments/warp_routes/TIA/mantapacific-osmosis-config.yaml
@@ -6,6 +6,15 @@ options:
       destination: mantapacific
       origin: osmosis
 tokens:
+  - addressOrDenom: "0x88410F3D8135b4D23b98dC37C4652C6969a5B1a8"
+    chainName: mantapacific
+    connections:
+      - token: cosmos|osmosis|osmo1h4y9xjcvs8lrx4z8ha48uq9a338w74dpl2ly3tf74fzvugp2kj4q9l0jkw
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA.o
+    standard: EvmHypSynthetic
+    symbol: TIA.o
   - addressOrDenom: osmo1h4y9xjcvs8lrx4z8ha48uq9a338w74dpl2ly3tf74fzvugp2kj4q9l0jkw
     chainName: osmosis
     collateralAddressOrDenom: ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877
@@ -15,13 +24,4 @@ tokens:
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA.o
     standard: CwHypCollateral
-    symbol: TIA.o
-  - addressOrDenom: "0x88410F3D8135b4D23b98dC37C4652C6969a5B1a8"
-    chainName: mantapacific
-    connections:
-      - token: cosmos|osmosis|osmo1h4y9xjcvs8lrx4z8ha48uq9a338w74dpl2ly3tf74fzvugp2kj4q9l0jkw
-    decimals: 6
-    logoURI: /deployments/warp_routes/TIA/logo.svg
-    name: TIA.o
-    standard: EvmHypSynthetic
     symbol: TIA.o

--- a/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-config.yaml
+++ b/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-config.yaml
@@ -1,30 +1,15 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8"
-    chainName: base
-    connections:
-      - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-      - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-      - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-      - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-    decimals: 18
-    logoURI: /deployments/warp_routes/TRUMP/logo.png
-    name: OFFICIAL TRUMP
-    standard: EvmHypSynthetic
-    symbol: TRUMP
   - addressOrDenom: "0x5155EB1bcD30189915cF84717550Acfa537068bF"
     chainName: arbitrum
     connections:
+      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
       - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
     decimals: 18
     logoURI: /deployments/warp_routes/TRUMP/logo.png
     name: OFFICIAL TRUMP
@@ -33,13 +18,28 @@ tokens:
   - addressOrDenom: "0x0e2A546a53678ee8F8605748193a8c114fA0317F"
     chainName: avalanche
     connections:
-      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+    decimals: 18
+    logoURI: /deployments/warp_routes/TRUMP/logo.png
+    name: OFFICIAL TRUMP
+    standard: EvmHypSynthetic
+    symbol: TRUMP
+  - addressOrDenom: "0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8"
+    chainName: base
+    connections:
+      - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
       - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+      - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
     decimals: 18
     logoURI: /deployments/warp_routes/TRUMP/logo.png
     name: OFFICIAL TRUMP
@@ -48,13 +48,13 @@ tokens:
   - addressOrDenom: "0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760"
     chainName: flowmainnet
     connections:
-      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-      - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
       - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+      - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
     decimals: 18
     logoURI: /deployments/warp_routes/TRUMP/logo.png
     name: OFFICIAL TRUMP
@@ -64,27 +64,12 @@ tokens:
     chainName: form
     connections:
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-    decimals: 18
-    logoURI: /deployments/warp_routes/TRUMP/logo.png
-    name: OFFICIAL TRUMP
-    standard: EvmHypSynthetic
-    symbol: TRUMP
-  - addressOrDenom: "0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922"
-    chainName: worldchain
-    connections:
-      - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-      - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-      - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
     decimals: 18
     logoURI: /deployments/warp_routes/TRUMP/logo.png
     name: OFFICIAL TRUMP
@@ -94,11 +79,11 @@ tokens:
     chainName: optimism
     connections:
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
     decimals: 18
     logoURI: /deployments/warp_routes/TRUMP/logo.png
@@ -110,15 +95,30 @@ tokens:
     coinGeckoId: official-trump
     collateralAddressOrDenom: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
     connections:
-      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
       - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-      - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
     decimals: 6
     logoURI: /deployments/warp_routes/TRUMP/logo.png
     name: OFFICIAL TRUMP
     standard: SealevelHypCollateral
+    symbol: TRUMP
+  - addressOrDenom: "0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922"
+    chainName: worldchain
+    connections:
+      - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+    decimals: 18
+    logoURI: /deployments/warp_routes/TRUMP/logo.png
+    name: OFFICIAL TRUMP
+    standard: EvmHypSynthetic
     symbol: TRUMP

--- a/deployments/warp_routes/TRUMP/solanamainnet-trumpchain-config.yaml
+++ b/deployments/warp_routes/TRUMP/solanamainnet-trumpchain-config.yaml
@@ -1,14 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0xD84981Ecd4c411A86E1Ccda77F944c8f3D9737ab"
-    chainName: trumpchain
-    connections:
-      - token: sealevel|solanamainnet|AyJk3V2SjswRv1ppDazVofXnFgjCTeydNEDSyA2UyVNX
-    decimals: 18
-    logoURI: /deployments/warp_routes/TRUMP/logo.png
-    name: OFFICIAL TRUMP
-    standard: EvmHypNative
-    symbol: TRUMP
   - addressOrDenom: AyJk3V2SjswRv1ppDazVofXnFgjCTeydNEDSyA2UyVNX
     chainName: solanamainnet
     coinGeckoId: official-trump
@@ -19,4 +10,13 @@ tokens:
     logoURI: /deployments/warp_routes/TRUMP/logo.png
     name: OFFICIAL TRUMP
     standard: SealevelHypCollateral
+    symbol: TRUMP
+  - addressOrDenom: "0xD84981Ecd4c411A86E1Ccda77F944c8f3D9737ab"
+    chainName: trumpchain
+    connections:
+      - token: sealevel|solanamainnet|AyJk3V2SjswRv1ppDazVofXnFgjCTeydNEDSyA2UyVNX
+    decimals: 18
+    logoURI: /deployments/warp_routes/TRUMP/logo.png
+    name: OFFICIAL TRUMP
+    standard: EvmHypNative
     symbol: TRUMP

--- a/deployments/warp_routes/UBTC/boba-bsquared-soneium-swell-config.yaml
+++ b/deployments/warp_routes/UBTC/boba-bsquared-soneium-swell-config.yaml
@@ -4,8 +4,8 @@ tokens:
     chainName: boba
     connections:
       - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-      - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
       - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
+      - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
     decimals: 18
     logoURI: /deployments/warp_routes/UBTC/logo.svg
     name: uBTC
@@ -16,12 +16,23 @@ tokens:
     collateralAddressOrDenom: "0x796e4D53067FF374B89b2Ac101ce0c1f72ccaAc2"
     connections:
       - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-      - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
       - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
+      - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
     decimals: 18
     logoURI: /deployments/warp_routes/UBTC/logo.svg
     name: uBTC
     standard: EvmHypCollateral
+    symbol: uBTC
+  - addressOrDenom: "0x61F2993a644762A345b483ADF0d6351C5EdFB3b5"
+    chainName: soneium
+    connections:
+      - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+      - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+      - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+    decimals: 18
+    logoURI: /deployments/warp_routes/UBTC/logo.svg
+    name: uBTC
+    standard: EvmHypSynthetic
     symbol: uBTC
   - addressOrDenom: "0xFA3198ecF05303a6d96E57a45E6c815055D255b1"
     chainName: swell
@@ -29,17 +40,6 @@ tokens:
       - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
       - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
       - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
-    decimals: 18
-    logoURI: /deployments/warp_routes/UBTC/logo.svg
-    name: uBTC
-    standard: EvmHypSynthetic
-    symbol: uBTC
-  - addressOrDenom: "0x61F2993a644762A345b483ADF0d6351C5EdFB3b5"
-    chainName: soneium
-    connections:
-      - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-      - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-      - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
     decimals: 18
     logoURI: /deployments/warp_routes/UBTC/logo.svg
     name: uBTC

--- a/deployments/warp_routes/USDC/ancient8-ethereum-config.yaml
+++ b/deployments/warp_routes/USDC/ancient8-ethereum-config.yaml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x97423A68BAe94b5De52d767a17aBCc54c157c0E5"
+    chainName: ancient8
+    connections:
+      - token: ethereum|ethereum|0x8b4192B9Ad1fCa440A5808641261e5289e6de95D
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC
   - addressOrDenom: "0x8b4192B9Ad1fCa440A5808641261e5289e6de95D"
     chainName: ethereum
     coinGeckoId: usd-coin
@@ -10,13 +19,4 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
-    symbol: USDC
-  - addressOrDenom: "0x97423A68BAe94b5De52d767a17aBCc54c157c0E5"
-    chainName: ancient8
-    connections:
-      - token: ethereum|ethereum|0x8b4192B9Ad1fCa440A5808641261e5289e6de95D
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDC/logo.svg
-    name: USD Coin
-    standard: EvmHypSynthetic
     symbol: USDC

--- a/deployments/warp_routes/USDC/ancient8-ethereum-deploy.yaml
+++ b/deployments/warp_routes/USDC/ancient8-ethereum-deploy.yaml
@@ -16,17 +16,17 @@ ethereum:
   interchainSecurityModule:
     modules:
       - threshold: 2
-        type: messageIdMultisigIsm
-        validators:
-          - "0xbb5842ae0e05215b53df4787a29144efb7e67551"
-          - "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969"
-          - "0x95c7bf235837cb5a609fe6c95870410b9f68bcff"
-      - threshold: 2
         type: merkleRootMultisigIsm
         validators:
-          - "0xbb5842ae0e05215b53df4787a29144efb7e67551"
-          - "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969"
           - "0x95c7bf235837cb5a609fe6c95870410b9f68bcff"
+          - "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969"
+          - "0xbb5842ae0e05215b53df4787a29144efb7e67551"
+      - threshold: 2
+        type: messageIdMultisigIsm
+        validators:
+          - "0x95c7bf235837cb5a609fe6c95870410b9f68bcff"
+          - "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969"
+          - "0xbb5842ae0e05215b53df4787a29144efb7e67551"
     threshold: 1
     type: staticAggregationIsm
   owner: "0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6"

--- a/deployments/warp_routes/USDC/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed-config.yaml
@@ -1,32 +1,6 @@
 # yaml-language-server: $schema=../schema.json
 # This is a semi-connected collateral warp route. This is intended to only go between Superseed and non-Superseed chains, but not directly with each other.
 tokens:
-  - addressOrDenom: "0xc927767CF7bddc5e8b996A0f957e5F22250A2F67"
-    chainName: ethereum
-    coinGeckoId: usd-coin
-    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-    connections:
-      - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDC/logo.svg
-    name: USD Coin
-    standard: EvmHypCollateral
-    symbol: USDC
-  - addressOrDenom: "0xa7D6042eEf06E81168e640b5C41632eE5295227D"
-    chainName: superseed
-    collateralAddressOrDenom: "0xc316c8252b5f2176d0135ebb0999e99296998f2e"
-    connections:
-      - token: ethereum|arbitrum|0x2cB0E5AbE11346679749063d3FBfC1f390e6e70A
-      - token: ethereum|base|0x955132016f9B6376B1392aA7BFF50538d21Ababc
-      - token: ethereum|ethereum|0xc927767CF7bddc5e8b996A0f957e5F22250A2F67
-      - token: ethereum|ink|0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC
-      - token: ethereum|optimism|0x741B077c69FA219CEdb11364706a3880A792423e
-      - token: sealevel|solanamainnet|7aM3itqXToHXhdR97EwJjZc7fay6uBszhUs1rzJm3tto
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDC/logo.svg
-    name: USD Coin
-    standard: EvmHypCollateralFiat
-    symbol: USDC
   - addressOrDenom: "0x2cB0E5AbE11346679749063d3FBfC1f390e6e70A"
     chainName: arbitrum
     coinGeckoId: usd-coin
@@ -42,6 +16,17 @@ tokens:
     chainName: base
     coinGeckoId: usd-coin
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    connections:
+      - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDC
+  - addressOrDenom: "0xc927767CF7bddc5e8b996A0f957e5F22250A2F67"
+    chainName: ethereum
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
     decimals: 6
@@ -81,4 +66,19 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: SealevelHypCollateral
+    symbol: USDC
+  - addressOrDenom: "0xa7D6042eEf06E81168e640b5C41632eE5295227D"
+    chainName: superseed
+    collateralAddressOrDenom: "0xc316c8252b5f2176d0135ebb0999e99296998f2e"
+    connections:
+      - token: ethereum|arbitrum|0x2cB0E5AbE11346679749063d3FBfC1f390e6e70A
+      - token: ethereum|base|0x955132016f9B6376B1392aA7BFF50538d21Ababc
+      - token: ethereum|ethereum|0xc927767CF7bddc5e8b996A0f957e5F22250A2F67
+      - token: ethereum|ink|0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC
+      - token: ethereum|optimism|0x741B077c69FA219CEdb11364706a3880A792423e
+      - token: sealevel|solanamainnet|7aM3itqXToHXhdR97EwJjZc7fay6uBszhUs1rzJm3tto
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCollateralFiat
     symbol: USDC

--- a/deployments/warp_routes/USDC/arbitrum-cheesechain-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-cheesechain-config.yaml
@@ -1,14 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41"
-    chainName: cheesechain
-    connections:
-      - token: ethereum|arbitrum|0xC9e048011E4A47584CE5b91AbD8695338A640648
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDC/logo.svg
-    name: USDC
-    standard: EvmHypSynthetic
-    symbol: USDC
   - addressOrDenom: "0xC9e048011E4A47584CE5b91AbD8695338A640648"
     chainName: arbitrum
     coinGeckoId: usd-coin
@@ -19,4 +10,13 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypOwnerCollateral
+    symbol: USDC
+  - addressOrDenom: "0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41"
+    chainName: cheesechain
+    connections:
+      - token: ethereum|arbitrum|0xC9e048011E4A47584CE5b91AbD8695338A640648
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USDC
+    standard: EvmHypSynthetic
     symbol: USDC

--- a/deployments/warp_routes/USDC/base-ethereum-solanamainnet-subtensor-config.yaml
+++ b/deployments/warp_routes/USDC/base-ethereum-solanamainnet-subtensor-config.yaml
@@ -6,8 +6,8 @@ tokens:
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
-      - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
       - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
+      - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
@@ -19,23 +19,12 @@ tokens:
     collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
-      - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
       - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
+      - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
-    symbol: USDC
-  - addressOrDenom: "0xB833E8137FEDf80de7E908dc6fea43a029142F20"
-    chainName: subtensor
-    connections:
-      - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
-      - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
-      - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDC/logo.svg
-    name: USD Coin
-    standard: EvmHypSynthetic
     symbol: USDC
   - addressOrDenom: GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
     chainName: solanamainnet
@@ -49,4 +38,15 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: SealevelHypCollateral
+    symbol: USDC
+  - addressOrDenom: "0xB833E8137FEDf80de7E908dc6fea43a029142F20"
+    chainName: subtensor
+    connections:
+      - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
+      - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
+      - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypSynthetic
     symbol: USDC

--- a/deployments/warp_routes/USDC/eclipsemainnet-ethereum-solanamainnet-config.yaml
+++ b/deployments/warp_routes/USDC/eclipsemainnet-ethereum-solanamainnet-config.yaml
@@ -1,16 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0xe1De9910fe71cC216490AC7FCF019e13a34481D7"
-    chainName: ethereum
-    coinGeckoId: usd-coin
-    collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-    connections:
-      - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDC/logo.svg
-    name: USD Coin
-    standard: EvmHypCollateral
-    symbol: USDC
   - addressOrDenom: EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
     chainName: eclipsemainnet
     collateralAddressOrDenom: AKEWE7Bgh87GPp171b4cJPSSZfmZwQ3KaqYqXoKLNAEE
@@ -21,6 +10,17 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: SealevelHypSynthetic
+    symbol: USDC
+  - addressOrDenom: "0xe1De9910fe71cC216490AC7FCF019e13a34481D7"
+    chainName: ethereum
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    connections:
+      - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: 3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
     chainName: solanamainnet

--- a/deployments/warp_routes/USDCSTAGE/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed-config.yaml
+++ b/deployments/warp_routes/USDCSTAGE/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed-config.yaml
@@ -1,28 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x1d82BC329E5E6CA5CBc41571435824dda7895e92"
-    chainName: ethereum
-    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-    connections:
-      - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
-    decimals: 6
-    name: USD Coin
-    standard: EvmHypCollateral
-    symbol: USDCSTAGE
-  - addressOrDenom: "0xf728C884De5275a608dEC222dACd0f2BF2E23AB6"
-    chainName: superseed
-    collateralAddressOrDenom: "0x99a38322cAF878Ef55AE4d0Eda535535eF8C7960"
-    connections:
-      - token: ethereum|ethereum|0x1d82BC329E5E6CA5CBc41571435824dda7895e92
-      - token: ethereum|arbitrum|0xD74706A5Be0cb87357EF80b4fAEa709287D4f640
-      - token: ethereum|base|0x23eE98fD566eBae12296d1B111064921143AD6a7
-      - token: ethereum|ink|0x5D71b91B92AAE933cbf85065F49bC14f16c55c55
-      - token: ethereum|optimism|0x2171e985D95eB12451B723b19458A7f1AdEbc086
-      - token: sealevel|solanamainnet|8UUnM8wheNwAf3KM65Yx72Mq8mSAHf33GUwEp3MAyQX1
-    decimals: 6
-    name: USD Coin
-    standard: EvmHypCollateralFiat
-    symbol: USDCSTAGE
   - addressOrDenom: "0xD74706A5Be0cb87357EF80b4fAEa709287D4f640"
     chainName: arbitrum
     collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
@@ -35,6 +12,15 @@ tokens:
   - addressOrDenom: "0x23eE98fD566eBae12296d1B111064921143AD6a7"
     chainName: base
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    connections:
+      - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDCSTAGE
+  - addressOrDenom: "0x1d82BC329E5E6CA5CBc41571435824dda7895e92"
+    chainName: ethereum
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
     decimals: 6
@@ -68,4 +54,18 @@ tokens:
     decimals: 6
     name: USD Coin
     standard: SealevelHypCollateral
+    symbol: USDCSTAGE
+  - addressOrDenom: "0xf728C884De5275a608dEC222dACd0f2BF2E23AB6"
+    chainName: superseed
+    collateralAddressOrDenom: "0x99a38322cAF878Ef55AE4d0Eda535535eF8C7960"
+    connections:
+      - token: ethereum|arbitrum|0xD74706A5Be0cb87357EF80b4fAEa709287D4f640
+      - token: ethereum|base|0x23eE98fD566eBae12296d1B111064921143AD6a7
+      - token: ethereum|ethereum|0x1d82BC329E5E6CA5CBc41571435824dda7895e92
+      - token: ethereum|ink|0x5D71b91B92AAE933cbf85065F49bC14f16c55c55
+      - token: ethereum|optimism|0x2171e985D95eB12451B723b19458A7f1AdEbc086
+      - token: sealevel|solanamainnet|8UUnM8wheNwAf3KM65Yx72Mq8mSAHf33GUwEp3MAyQX1
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypCollateralFiat
     symbol: USDCSTAGE

--- a/deployments/warp_routes/USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork-config.yaml
+++ b/deployments/warp_routes/USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork-config.yaml
@@ -11,6 +11,17 @@ tokens:
     name: Tether USD
     standard: EvmHypCollateral
     symbol: USDT
+  - addressOrDenom: "0x95fBD1037a307A49587174E06a6600fD05c5f58e"
+    chainName: ethereum
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    connections:
+      - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    standard: EvmHypCollateral
+    symbol: USDT
   - addressOrDenom: "0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec"
     chainName: mantle
     coinGeckoId: tether
@@ -59,24 +70,13 @@ tokens:
     chainName: zeronetwork
     connections:
       - token: ethereum|arbitrum|0x83AF845F002c2dA8748eaB8203D2704BdAE6fB8e
+      - token: ethereum|ethereum|0x95fBD1037a307A49587174E06a6600fD05c5f58e
       - token: ethereum|mantle|0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec
       - token: ethereum|mode|0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec
       - token: ethereum|polygon|0x6701d503369cf6aA9e5EdFfEBFA40A2ffdf3dB21
       - token: ethereum|scroll|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-      - token: ethereum|ethereum|0x95fBD1037a307A49587174E06a6600fD05c5f58e
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
     standard: EvmHypSynthetic
-    symbol: USDT
-  - addressOrDenom: "0x95fBD1037a307A49587174E06a6600fD05c5f58e"
-    chainName: ethereum
-    coinGeckoId: tether
-    collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-    connections:
-      - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: Tether USD
-    standard: EvmHypCollateral
     symbol: USDT

--- a/deployments/warp_routes/USDT/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDT/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
@@ -5,221 +5,16 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
-    chainName: celo
-    coinGeckoId: openusdt
-    collateralAddressOrDenom: "0x5e5F4d6B03db16E7f00dE7C9AFAA53b92C8d1D42"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20Lockbox
-    symbol: oUSDT
-  - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
-    chainName: fraxtal
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
-    chainName: ink
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
-    chainName: lisk
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x324d0b921C03b1e42eeFD198086A64beC3d736c2"
-    chainName: mode
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8"
-    chainName: optimism
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x2dC335bDF489f8e978477Ae53924324697e0f7BB"
-    chainName: soneium
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55"
-    chainName: superseed
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f"
-    chainName: unichain
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3"
-    chainName: worldchain
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d"
-    chainName: ronin
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-  - addressOrDenom: "0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0"
-    chainName: metal
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -233,21 +28,71 @@ tokens:
     name: OpenUSDT
     standard: EvmHypVSXERC20
     symbol: oUSDT
-  - addressOrDenom: "0x6267Dbfc38f7Af897536563c15f07B89634cb656"
-    chainName: metis
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+  - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
+    chainName: celo
+    coinGeckoId: openusdt
+    collateralAddressOrDenom: "0x5e5F4d6B03db16E7f00dE7C9AFAA53b92C8d1D42"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20Lockbox
+    symbol: oUSDT
+  - addressOrDenom: "0x88AC0fC430130983c0DDEB4C22574056D8340Ca8"
+    chainName: ethereum
+    coinGeckoId: openusdt
+    collateralAddressOrDenom: "0x6D265C7dD8d76F25155F1a7687C693FDC1220D12"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20Lockbox
+    symbol: oUSDT
+  - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
+    chainName: fraxtal
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
+    chainName: ink
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -261,9 +106,137 @@ tokens:
     name: OpenUSDT
     standard: EvmHypVSXERC20
     symbol: oUSDT
+  - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
+    chainName: lisk
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
   - addressOrDenom: "0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683"
     chainName: mantle
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0"
+    chainName: metal
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x6267Dbfc38f7Af897536563c15f07B89634cb656"
+    chainName: metis
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x324d0b921C03b1e42eeFD198086A64beC3d736c2"
+    chainName: mode
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8"
+    chainName: optimism
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d"
+    chainName: ronin
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x2dC335bDF489f8e978477Ae53924324697e0f7BB"
+    chainName: soneium
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
@@ -277,24 +250,51 @@ tokens:
     name: OpenUSDT
     standard: EvmHypVSXERC20
     symbol: oUSDT
-  - addressOrDenom: "0x88AC0fC430130983c0DDEB4C22574056D8340Ca8"
-    chainName: ethereum
-    coinGeckoId: openusdt
-    collateralAddressOrDenom: "0x6D265C7dD8d76F25155F1a7687C693FDC1220D12"
+  - addressOrDenom: "0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55"
+    chainName: superseed
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f"
+    chainName: unichain
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
     name: OpenUSDT
-    standard: EvmHypVSXERC20Lockbox
+    standard: EvmHypVSXERC20
+    symbol: oUSDT
+  - addressOrDenom: "0xAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3"
+    chainName: worldchain
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/oUSDT-logo.svg
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
     symbol: oUSDT

--- a/deployments/warp_routes/USDT/eclipsemainnet-ethereum-solanamainnet-config.yaml
+++ b/deployments/warp_routes/USDT/eclipsemainnet-ethereum-solanamainnet-config.yaml
@@ -1,16 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
-    chainName: ethereum
-    coinGeckoId: tether
-    collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
-    connections:
-      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: Tether USD
-    standard: EvmHypCollateral
-    symbol: USDT
   - addressOrDenom: 5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
     chainName: eclipsemainnet
     collateralAddressOrDenom: CEBP3CqAbW4zdZA57H2wfaSG1QNdzQ72GiQEbQXyW9Tm
@@ -21,6 +10,17 @@ tokens:
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT
     standard: SealevelHypSynthetic
+    symbol: USDT
+  - addressOrDenom: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
+    chainName: ethereum
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+    connections:
+      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    standard: EvmHypCollateral
     symbol: USDT
   - addressOrDenom: Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
     chainName: solanamainnet

--- a/deployments/warp_routes/USDTSTAGING/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
+++ b/deployments/warp_routes/USDTSTAGING/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain-config.yaml
@@ -4,310 +4,24 @@ tokens:
     chainName: base
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
     connections:
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
       - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
       - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
       - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0x78a2D1891e7D1259695b4795e04285C478E068E6"
-    chainName: celo
-    collateralAddressOrDenom: "0x9a3D8d7E931679374448FB2B661F664D42d05057"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20Lockbox
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0x086dE790943c23c42176236c392Fa9C35e660cE5"
-    chainName: fraxtal
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0xBb2eBD68b2FEEe450dce91509897F9AE02211421"
-    chainName: ink
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3"
-    chainName: lisk
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0x0071740Bf129b05C4684abfbBeD248D80971cce2"
-    chainName: mode
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0x1D833D392379929f15d03d212DbF8c17001c27e3"
-    chainName: optimism
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0xA895A9e1D3A2269F57544A8F7E697300626F0900"
-    chainName: soneium
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6"
-    chainName: superseed
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0x7189A511D4312148cC0aEf79129417f714e3155E"
-    chainName: unichain
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0xE047cb95FB3b7117989e911c6afb34771183fC35"
-    chainName: worldchain
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-  - addressOrDenom: "0x978a80bC3E97AAD6F71acF9013A015690E77010a"
-    chainName: metal
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -318,74 +32,126 @@ tokens:
     connections:
       - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
       - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
       - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
       - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
-  - addressOrDenom: "0x200183De44bf765ECB73cD62A74010EaaBC43146"
-    chainName: ronin
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+  - addressOrDenom: "0x78a2D1891e7D1259695b4795e04285C478E068E6"
+    chainName: celo
+    collateralAddressOrDenom: "0x9a3D8d7E931679374448FB2B661F664D42d05057"
     connections:
       - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
       - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
       - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20Lockbox
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0x8a60E4aC11C2Fac40Dc936E048e05145547A4356"
+    chainName: ethereum
+    collateralAddressOrDenom: "0x935EAaAb78B491Cd9281f438E413767893913983"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
       - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
       - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
       - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
       - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20Lockbox
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0x086dE790943c23c42176236c392Fa9C35e660cE5"
+    chainName: fraxtal
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
       - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
-  - addressOrDenom: "0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5"
-    chainName: metis
+  - addressOrDenom: "0xBb2eBD68b2FEEe450dce91509897F9AE02211421"
+    chainName: ink
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
     connections:
       - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
       - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
       - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -395,23 +161,49 @@ tokens:
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
     connections:
       - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
       - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
       - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
       - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3"
+    chainName: lisk
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
       - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
       - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -421,23 +213,179 @@ tokens:
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
     connections:
       - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
       - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
       - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
       - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0x978a80bC3E97AAD6F71acF9013A015690E77010a"
+    chainName: metal
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
       - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
       - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5"
+    chainName: metis
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0x0071740Bf129b05C4684abfbBeD248D80971cce2"
+    chainName: mode
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0x1D833D392379929f15d03d212DbF8c17001c27e3"
+    chainName: optimism
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0x200183De44bf765ECB73cD62A74010EaaBC43146"
+    chainName: ronin
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0xA895A9e1D3A2269F57544A8F7E697300626F0900"
+    chainName: soneium
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -447,50 +395,102 @@ tokens:
     collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
     connections:
       - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
       - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
       - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
       - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
-  - addressOrDenom: "0x8a60E4aC11C2Fac40Dc936E048e05145547A4356"
-    chainName: ethereum
-    collateralAddressOrDenom: "0x935EAaAb78B491Cd9281f438E413767893913983"
+  - addressOrDenom: "0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6"
+    chainName: superseed
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
     connections:
       - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
       - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
       - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
       - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
       - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
       - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
       - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
       - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
-      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
-      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
-      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
-      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
-      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
     decimals: 6
     name: OpenUSDT
-    standard: EvmHypVSXERC20Lockbox
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0x7189A511D4312148cC0aEf79129417f714e3155E"
+    chainName: unichain
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|worldchain|0xE047cb95FB3b7117989e911c6afb34771183fC35
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
+    symbol: oUSDTSTAGE
+  - addressOrDenom: "0xE047cb95FB3b7117989e911c6afb34771183fC35"
+    chainName: worldchain
+    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+    connections:
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bitlayer|0x41Cccb0fbFe77ce4d11a3FF13b84cD01b62e8732
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|linea|0xeE80ab5B563cB3825133f29502bA34eD3707cb8C
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|mantle|0x9f5cF636b4F2DC6D83c9d21c8911876C235DbC9f
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|metis|0xFaFF40A2e1F2fFb4bCc629Ce0F69fd5805043Df5
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|ronin|0x200183De44bf765ECB73cD62A74010EaaBC43146
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|sonic|0x3362648c789d28b3b85b50b5AB07e3ee5c8bdd78
+      - token: ethereum|superseed|0xf6C7d380F61ac5494e1a682f88BC609979A8bAE6
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+    decimals: 6
+    name: OpenUSDT
+    standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE

--- a/deployments/warp_routes/WBTC/coti-ethereum-config.yaml
+++ b/deployments/warp_routes/WBTC/coti-ethereum-config.yaml
@@ -1,4 +1,13 @@
 tokens:
+  - addressOrDenom: "0x8C39B1fD0e6260fdf20652Fc436d25026832bfEA"
+    chainName: coti
+    connections:
+      - token: ethereum|ethereum|0x5c43f06EF93bb0a2cd3C0f7b832AbA1F4d6575Ea
+    decimals: 8
+    logoURI: /deployments/warp_routes/WBTC/logo.svg
+    name: Wrapped BTC
+    standard: EvmHypSynthetic
+    symbol: WBTC
   - addressOrDenom: "0x5c43f06EF93bb0a2cd3C0f7b832AbA1F4d6575Ea"
     chainName: ethereum
     coinGeckoId: wrapped-bitcoin
@@ -9,13 +18,4 @@ tokens:
     logoURI: /deployments/warp_routes/WBTC/logo.svg
     name: Wrapped BTC
     standard: EvmHypCollateral
-    symbol: WBTC
-  - addressOrDenom: "0x8C39B1fD0e6260fdf20652Fc436d25026832bfEA"
-    chainName: coti
-    connections:
-      - token: ethereum|ethereum|0x5c43f06EF93bb0a2cd3C0f7b832AbA1F4d6575Ea
-    decimals: 8
-    logoURI: /deployments/warp_routes/WBTC/logo.svg
-    name: Wrapped BTC
-    standard: EvmHypSynthetic
     symbol: WBTC

--- a/deployments/warp_routes/WBTC/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/WBTC/eclipsemainnet-ethereum-config.yaml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: A7EGCDYFw5R7Jfm6cYtKvY8dmkrYMgwRCJFkyQwpHTYu
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: 7UTjr1VC6Z9DPsWD6mh5wPzNtufN17VnzpKS3ASpfAji
+    connections:
+      - token: ethereum|ethereum|0x5B4e223DE74ef8c3218e66EEcC541003CAB3121A
+    decimals: 8
+    logoURI: /deployments/warp_routes/WBTC/logo.svg
+    name: WBTC
+    standard: SealevelHypSynthetic
+    symbol: WBTC
   - addressOrDenom: "0x5B4e223DE74ef8c3218e66EEcC541003CAB3121A"
     chainName: ethereum
     coinGeckoId: wrapped-bitcoin
@@ -10,14 +20,4 @@ tokens:
     logoURI: /deployments/warp_routes/WBTC/logo.svg
     name: Wrapped BTC
     standard: EvmHypCollateral
-    symbol: WBTC
-  - addressOrDenom: A7EGCDYFw5R7Jfm6cYtKvY8dmkrYMgwRCJFkyQwpHTYu
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: 7UTjr1VC6Z9DPsWD6mh5wPzNtufN17VnzpKS3ASpfAji
-    connections:
-      - token: ethereum|ethereum|0x5B4e223DE74ef8c3218e66EEcC541003CAB3121A
-    decimals: 8
-    logoURI: /deployments/warp_routes/WBTC/logo.svg
-    name: WBTC
-    standard: SealevelHypSynthetic
     symbol: WBTC

--- a/deployments/warp_routes/WBTC/ethereum-form-config.yaml
+++ b/deployments/warp_routes/WBTC/ethereum-form-config.yaml
@@ -1,14 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x0dc95Af5156fb0cC34a8c9BD646B748B9989A956"
-    chainName: form
-    connections:
-      - token: ethereum|ethereum|0xd0d5271926f352c0161b0365a4156E2Bc0f99FAD
-    decimals: 8
-    logoURI: /deployments/warp_routes/WBTC/logo.svg
-    name: Wrapped BTC
-    standard: EvmHypSynthetic
-    symbol: WBTC
   - addressOrDenom: "0xd0d5271926f352c0161b0365a4156E2Bc0f99FAD"
     chainName: ethereum
     coinGeckoId: wrapped-bitcoin
@@ -19,4 +10,13 @@ tokens:
     logoURI: /deployments/warp_routes/WBTC/logo.svg
     name: Wrapped BTC
     standard: EvmHypCollateral
+    symbol: WBTC
+  - addressOrDenom: "0x0dc95Af5156fb0cC34a8c9BD646B748B9989A956"
+    chainName: form
+    connections:
+      - token: ethereum|ethereum|0xd0d5271926f352c0161b0365a4156E2Bc0f99FAD
+    decimals: 8
+    logoURI: /deployments/warp_routes/WBTC/logo.svg
+    name: Wrapped BTC
+    standard: EvmHypSynthetic
     symbol: WBTC

--- a/deployments/warp_routes/WIF/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/WIF/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: HzP6KbL7fVAwqVgix4eJhijGMFeyg7mhHkQs7kBwrGPQ
-    chainName: soon
-    collateralAddressOrDenom: 4LamGFWF36vfBCVtWrZv17wDkbBSkJ8vSJhGFzui4wkZ
-    connections:
-      - token: sealevel|solanamainnet|BJkD7PFuMKRFPdc8H3pxL5u4KuQ2HWGkQgbvP3hw26AF
-    decimals: 6
-    logoURI: /deployments/warp_routes/WIF/logo.jpg
-    name: dogwifhat
-    standard: SealevelHypSynthetic
-    symbol: WIF
   - addressOrDenom: BJkD7PFuMKRFPdc8H3pxL5u4KuQ2HWGkQgbvP3hw26AF
     chainName: solanamainnet
     coinGeckoId: dogwifcoin
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/WIF/logo.jpg
     name: dogwifhat
     standard: SealevelHypCollateral
+    symbol: WIF
+  - addressOrDenom: HzP6KbL7fVAwqVgix4eJhijGMFeyg7mhHkQs7kBwrGPQ
+    chainName: soon
+    collateralAddressOrDenom: 4LamGFWF36vfBCVtWrZv17wDkbBSkJ8vSJhGFzui4wkZ
+    connections:
+      - token: sealevel|solanamainnet|BJkD7PFuMKRFPdc8H3pxL5u4KuQ2HWGkQgbvP3hw26AF
+    decimals: 6
+    logoURI: /deployments/warp_routes/WIF/logo.jpg
+    name: dogwifhat
+    standard: SealevelHypSynthetic
     symbol: WIF

--- a/deployments/warp_routes/WSTETH/ethereum-form-config.yaml
+++ b/deployments/warp_routes/WSTETH/ethereum-form-config.yaml
@@ -1,14 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x5CBD4c5f9CD55747285652f815Cc7b9A2Ef6c586"
-    chainName: form
-    connections:
-      - token: ethereum|ethereum|0x9c7e8dc6b35E66873dA683aF2dE1BaB4cabc98B5
-    decimals: 18
-    logoURI: /deployments/warp_routes/WSTETH/logo.svg
-    name: Wrapped liquid staked Ether 2.0
-    standard: EvmHypSynthetic
-    symbol: wstETH
   - addressOrDenom: "0x9c7e8dc6b35E66873dA683aF2dE1BaB4cabc98B5"
     chainName: ethereum
     coinGeckoId: wrapped-steth
@@ -19,4 +10,13 @@ tokens:
     logoURI: /deployments/warp_routes/WSTETH/logo.svg
     name: Wrapped liquid staked Ether 2.0
     standard: EvmHypCollateral
+    symbol: wstETH
+  - addressOrDenom: "0x5CBD4c5f9CD55747285652f815Cc7b9A2Ef6c586"
+    chainName: form
+    connections:
+      - token: ethereum|ethereum|0x9c7e8dc6b35E66873dA683aF2dE1BaB4cabc98B5
+    decimals: 18
+    logoURI: /deployments/warp_routes/WSTETH/logo.svg
+    name: Wrapped liquid staked Ether 2.0
+    standard: EvmHypSynthetic
     symbol: wstETH

--- a/deployments/warp_routes/ai16z/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/ai16z/solanamainnet-soon-config.yaml
@@ -1,15 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: BrJbX9a9bi9hvV5WesfbuXudQP49G8jnKEqAutRNMYK5
-    chainName: soon
-    collateralAddressOrDenom: Hc3feJHN3S7Kh2TorCKTFQWFx7jgznjzKNG37ufPmp2r
-    connections:
-      - token: sealevel|solanamainnet|9TxKLb6RBo4hEfFNN6up6obvebnEUcm2gkBXrzQFq8s8
-    decimals: 9
-    logoURI: /deployments/warp_routes/ai16z/logo.png
-    name: ai16z
-    standard: SealevelHypSynthetic
-    symbol: ai16z
   - addressOrDenom: 9TxKLb6RBo4hEfFNN6up6obvebnEUcm2gkBXrzQFq8s8
     chainName: solanamainnet
     coinGeckoId: ai16z
@@ -20,4 +10,14 @@ tokens:
     logoURI: /deployments/warp_routes/ai16z/logo.png
     name: ai16z
     standard: SealevelHypCollateral
+    symbol: ai16z
+  - addressOrDenom: BrJbX9a9bi9hvV5WesfbuXudQP49G8jnKEqAutRNMYK5
+    chainName: soon
+    collateralAddressOrDenom: Hc3feJHN3S7Kh2TorCKTFQWFx7jgznjzKNG37ufPmp2r
+    connections:
+      - token: sealevel|solanamainnet|9TxKLb6RBo4hEfFNN6up6obvebnEUcm2gkBXrzQFq8s8
+    decimals: 9
+    logoURI: /deployments/warp_routes/ai16z/logo.png
+    name: ai16z
+    standard: SealevelHypSynthetic
     symbol: ai16z

--- a/deployments/warp_routes/milkTIA/mantapacific-osmosis-config.yaml
+++ b/deployments/warp_routes/milkTIA/mantapacific-osmosis-config.yaml
@@ -6,6 +6,14 @@ options:
       destination: mantapacific
       origin: osmosis
 tokens:
+  - addressOrDenom: "0x32474653127048d9fC20000e21dEd396b47968E8"
+    chainName: mantapacific
+    connections:
+      - token: cosmos|osmosis|osmo17xuecsykqw2xcxwv8cau7uy4hgdwqt0u4qxflyc2yshhggpazfjs6kfqd3
+    decimals: 6
+    name: milkTIA.o
+    standard: EvmHypSynthetic
+    symbol: milkTIA.o
   - addressOrDenom: osmo17xuecsykqw2xcxwv8cau7uy4hgdwqt0u4qxflyc2yshhggpazfjs6kfqd3
     chainName: osmosis
     collateralAddressOrDenom: factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA
@@ -14,12 +22,4 @@ tokens:
     decimals: 6
     name: milkTIA.o
     standard: CwHypCollateral
-    symbol: milkTIA.o
-  - addressOrDenom: "0x32474653127048d9fC20000e21dEd396b47968E8"
-    chainName: mantapacific
-    connections:
-      - token: cosmos|osmosis|osmo17xuecsykqw2xcxwv8cau7uy4hgdwqt0u4qxflyc2yshhggpazfjs6kfqd3
-    decimals: 6
-    name: milkTIA.o
-    standard: EvmHypSynthetic
     symbol: milkTIA.o

--- a/deployments/warp_routes/stTIA/eclipsemainnet-stride-config.yaml
+++ b/deployments/warp_routes/stTIA/eclipsemainnet-stride-config.yaml
@@ -6,6 +6,17 @@ options:
       destination: eclipsemainnet
       origin: stride
 tokens:
+  # stTIA on Eclipsemainnet to Stride
+  - addressOrDenom: tKUHyJ5NxhnwU94JUmzh1ekukDcHHX8mZF6fqxbMwX6
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: V5m1Cc9VK61mKL8xVYrjR7bjD2BC5VpADLa6ws3G8KM
+    connections:
+      - token: cosmos|stride|stride134axwdlam929m3mar3wv95nvkyep7mr87ravkqcpf8dfe3v0pjlqwrw6ee
+    decimals: 6
+    logoURI: /deployments/warp_routes/stTIA/logo.svg
+    name: Stride Staked TIA
+    standard: SealevelHypSynthetic
+    symbol: stTIA
   # stTIA on Stride to Eclipsemainnet
   - addressOrDenom: stride134axwdlam929m3mar3wv95nvkyep7mr87ravkqcpf8dfe3v0pjlqwrw6ee
     chainName: stride
@@ -17,17 +28,6 @@ tokens:
     logoURI: /deployments/warp_routes/stTIA/logo.svg
     name: Stride Staked TIA
     standard: CwHypCollateral
-    symbol: stTIA
-  # stTIA on Eclipsemainnet to Stride
-  - addressOrDenom: tKUHyJ5NxhnwU94JUmzh1ekukDcHHX8mZF6fqxbMwX6
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: V5m1Cc9VK61mKL8xVYrjR7bjD2BC5VpADLa6ws3G8KM
-    connections:
-      - token: cosmos|stride|stride134axwdlam929m3mar3wv95nvkyep7mr87ravkqcpf8dfe3v0pjlqwrw6ee
-    decimals: 6
-    logoURI: /deployments/warp_routes/stTIA/logo.svg
-    name: Stride Staked TIA
-    standard: SealevelHypSynthetic
     symbol: stTIA
   # TIA, required for the IGP payment but not connected to any other chain
   - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801

--- a/deployments/warp_routes/stTIA/ethereum-stride-config.yaml
+++ b/deployments/warp_routes/stTIA/ethereum-stride-config.yaml
@@ -6,6 +6,16 @@ options:
       destination: ethereum
       origin: stride
 tokens:
+  # stTIA on Ethereum to Stride
+  - addressOrDenom: "0x48A612A6da945205a221E94BB9F40B0550Cd2C4e"
+    chainName: ethereum
+    connections:
+      - token: cosmos|stride|stride1z3lz9n0549v95q6yllghezugdra6ezm68jtf4ve5hsz8k867k9cq3pc2f8
+    decimals: 6
+    logoURI: /deployments/warp_routes/stTIA/logo.svg
+    name: stTIA
+    standard: EvmHypSynthetic
+    symbol: stTIA
   # stTIA on Stride to Ethereum
   - addressOrDenom: stride1z3lz9n0549v95q6yllghezugdra6ezm68jtf4ve5hsz8k867k9cq3pc2f8
     chainName: stride
@@ -16,14 +26,4 @@ tokens:
     logoURI: /deployments/warp_routes/stTIA/logo.svg
     name: stTIA
     standard: CwHypCollateral
-    symbol: stTIA
-  # stTIA on Ethereum to Stride
-  - addressOrDenom: "0x48A612A6da945205a221E94BB9F40B0550Cd2C4e"
-    chainName: ethereum
-    connections:
-      - token: cosmos|stride|stride1z3lz9n0549v95q6yllghezugdra6ezm68jtf4ve5hsz8k867k9cq3pc2f8
-    decimals: 6
-    logoURI: /deployments/warp_routes/stTIA/logo.svg
-    name: stTIA
-    standard: EvmHypSynthetic
     symbol: stTIA

--- a/deployments/warp_routes/tETH/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/tETH/eclipsemainnet-ethereum-config.yaml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: 6GM7hy6M6LjhadG1xuKXPQ3jPC1eieEszR8DforoRzUp
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: GU7NS9xCwgNPiAdJ69iusFrRfawjDDPjeMBovhV1d4kn
+    connections:
+      - token: ethereum|ethereum|0xc2495f3183F043627CAECD56dAaa726e3B2D9c09
+    decimals: 9
+    logoURI: /deployments/warp_routes/tETH/logo.svg
+    name: tETH
+    standard: SealevelHypSynthetic
+    symbol: tETH
   - addressOrDenom: "0xc2495f3183F043627CAECD56dAaa726e3B2D9c09"
     chainName: ethereum
     # tETH is not yet on Coingecko, and at the current rate is close to the price of ETH
@@ -11,14 +21,4 @@ tokens:
     logoURI: /deployments/warp_routes/tETH/logo.svg
     name: Eclipse Turbo ETH
     standard: EvmHypCollateral
-    symbol: tETH
-  - addressOrDenom: 6GM7hy6M6LjhadG1xuKXPQ3jPC1eieEszR8DforoRzUp
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: GU7NS9xCwgNPiAdJ69iusFrRfawjDDPjeMBovhV1d4kn
-    connections:
-      - token: ethereum|ethereum|0xc2495f3183F043627CAECD56dAaa726e3B2D9c09
-    decimals: 9
-    logoURI: /deployments/warp_routes/tETH/logo.svg
-    name: tETH
-    standard: SealevelHypSynthetic
     symbol: tETH

--- a/deployments/warp_routes/weETHs/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/weETHs/eclipsemainnet-ethereum-config.yaml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: 7Zx4wU1QAw98MfvnPFqRh1oyumek7G5VAX6TKB3U1tcn
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: F72PqK74jc28zjC7kWDk6ykJ2ZAbjNzn2jaAY9v9M6om
+    connections:
+      - token: ethereum|ethereum|0xef899e92DA472E014bE795Ecce948308958E25A2
+    decimals: 9
+    logoURI: /deployments/warp_routes/weETHs/logo.svg
+    name: Super Symbiotic LRT
+    standard: SealevelHypSynthetic
+    symbol: weETHs
   - addressOrDenom: "0xef899e92DA472E014bE795Ecce948308958E25A2"
     chainName: ethereum
     coinGeckoId: etherfi-weeths
@@ -10,14 +20,4 @@ tokens:
     logoURI: /deployments/warp_routes/weETHs/logo.svg
     name: Super Symbiotic LRT
     standard: EvmHypCollateral
-    symbol: weETHs
-  - addressOrDenom: 7Zx4wU1QAw98MfvnPFqRh1oyumek7G5VAX6TKB3U1tcn
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: F72PqK74jc28zjC7kWDk6ykJ2ZAbjNzn2jaAY9v9M6om
-    connections:
-      - token: ethereum|ethereum|0xef899e92DA472E014bE795Ecce948308958E25A2
-    decimals: 9
-    logoURI: /deployments/warp_routes/weETHs/logo.svg
-    name: Super Symbiotic LRT
-    standard: SealevelHypSynthetic
     symbol: weETHs

--- a/deployments/warp_routes/wfragJTO/eclipsemainnet-solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/wfragJTO/eclipsemainnet-solanamainnet-soon-config.yaml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: 4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: HqDHrCWhdELCf21AAzhpAYTtKLtkqVzGfHTz7fo1yNxy
+    connections:
+      - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
+      - token: sealevel|soon|A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
+    decimals: 9
+    logoURI: /deployments/warp_routes/wfragJTO/logo.svg
+    name: Wrapped Fragmetric Restaked JTO
+    standard: SealevelHypSynthetic
+    symbol: wfragJTO
   - addressOrDenom: 21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
     chainName: solanamainnet
     coinGeckoId: wrapped-fragjto
@@ -12,23 +23,12 @@ tokens:
     name: Wrapped Fragmetric Restaked JTO
     standard: SealevelHypCollateral
     symbol: wfragJTO
-  - addressOrDenom: 4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: HqDHrCWhdELCf21AAzhpAYTtKLtkqVzGfHTz7fo1yNxy
-    connections:
-      - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
-      - token: sealevel|soon|A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
-    decimals: 9
-    logoURI: /deployments/warp_routes/wfragJTO/logo.svg
-    name: Wrapped Fragmetric Restaked JTO
-    standard: SealevelHypSynthetic
-    symbol: wfragJTO
   - addressOrDenom: A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
     chainName: soon
     collateralAddressOrDenom: 6vrMyHTVQvmGzCjphMZxnfYV7R8C9tDWAQsWDTgCq1mE
     connections:
-      - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
       - token: sealevel|eclipsemainnet|4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
+      - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
     decimals: 9
     logoURI: /deployments/warp_routes/wfragJTO/logo.svg
     name: Wrapped Fragmetric Restaked JTO

--- a/deployments/warp_routes/wfragSOL/eclipsemainnet-solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/wfragSOL/eclipsemainnet-solanamainnet-soon-config.yaml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: 97UNrMjduqbHhnZ5T5w3DifYnxwM2LAEpYxfoMcMjXK1
+    connections:
+      - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
+      - token: sealevel|soon|6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
+    decimals: 9
+    logoURI: /deployments/warp_routes/wfragSOL/logo.svg
+    name: Wrapped Fragmetric Restaked SOL
+    standard: SealevelHypSynthetic
+    symbol: wfragSOL
   - addressOrDenom: 22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
     chainName: solanamainnet
     coinGeckoId: wrapped-fragsol
@@ -12,23 +23,12 @@ tokens:
     name: Wrapped Fragmetric Restaked SOL
     standard: SealevelHypCollateral
     symbol: wfragSOL
-  - addressOrDenom: FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
-    chainName: eclipsemainnet
-    collateralAddressOrDenom: 97UNrMjduqbHhnZ5T5w3DifYnxwM2LAEpYxfoMcMjXK1
-    connections:
-      - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
-      - token: sealevel|soon|6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
-    decimals: 9
-    logoURI: /deployments/warp_routes/wfragSOL/logo.svg
-    name: Wrapped Fragmetric Restaked SOL
-    standard: SealevelHypSynthetic
-    symbol: wfragSOL
   - addressOrDenom: 6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
     chainName: soon
     collateralAddressOrDenom: 7T9sawCGJAV4wC49CjHpw8TGL3ZuPAbZipNq86YXGecy
     connections:
-      - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
       - token: sealevel|eclipsemainnet|FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
+      - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
     decimals: 9
     logoURI: /deployments/warp_routes/wfragSOL/logo.svg
     name: Wrapped Fragmetric Restaked SOL

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import tsparser from '@typescript-eslint/parser';
 import eslintPluginYml from 'eslint-plugin-yml';
 import yamlParser from 'yaml-eslint-parser';
 import importPlugin from 'eslint-plugin-import';
+import { sortYamlArraysPlugin } from '@hyperlane-xyz/utils/eslint-rules';
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -51,6 +52,32 @@ export default tseslint.config(
     rules: {
       'yml/sort-keys': ['error'],
       'yml/flow-mapping-curly-spacing': ['error', 'always'],
+      'yml/sort-sequence-values': [
+        'error',
+        {
+          pathPattern: '.*',
+          order: {
+            type: 'asc',
+            caseSensitive: true,
+            natural: false,
+          },
+          minValues: 2,
+        },
+      ],
+      'custom/sort-yaml-arrays': [
+        'error',
+        {
+          arrays: [
+            { path: 'tokens', sortKey: 'chainName' },
+            { path: 'tokens[].connections', sortKey: 'token' },
+            { path: '*.interchainSecurityModule.modules', sortKey: 'type' },
+            { path: '*.interchainSecurityModule.modules[].domains.*.modules', sortKey: 'type' },
+          ],
+        },
+      ],
+    },
+    plugins: {
+      custom: sortYamlArraysPlugin,
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@eslint/js": "^9.1.1",
     "@faker-js/faker": "^9.6.0",
     "@hyperlane-xyz/sdk": "13.0.0",
+    "@hyperlane-xyz/utils": "^13.1.1",
     "@types/chai-as-promised": "^8",
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,6 +2240,7 @@ __metadata:
     "@eslint/js": "npm:^9.1.1"
     "@faker-js/faker": "npm:^9.6.0"
     "@hyperlane-xyz/sdk": "npm:13.0.0"
+    "@hyperlane-xyz/utils": "npm:^13.1.1"
     "@types/chai-as-promised": "npm:^8"
     "@types/mocha": "npm:^10.0.1"
     "@types/node": "npm:^16.9.1"
@@ -2323,6 +2324,22 @@ __metadata:
     starknet: "npm:^6.24.1"
     yaml: "npm:2.4.5"
   checksum: 10/d5fd706758891b7e8475b15886d9d9b2fe46eab6ad9df721a4927319b4a22fd8ae2ed3a475cdb040b84f361faf354d2bf1f6ebde3fc881d8e9832ba54d25113e
+  languageName: node
+  linkType: hard
+
+"@hyperlane-xyz/utils@npm:^13.1.1":
+  version: 13.1.1
+  resolution: "@hyperlane-xyz/utils@npm:13.1.1"
+  dependencies:
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@solana/web3.js": "npm:^1.95.4"
+    bignumber.js: "npm:^9.1.1"
+    ethers: "npm:^5.7.2"
+    lodash-es: "npm:^4.17.21"
+    pino: "npm:^8.19.0"
+    starknet: "npm:^6.24.1"
+    yaml: "npm:2.4.5"
+  checksum: 10/3f085982672e918f2069e053a03b84994f721856048939ca26d1f23cdc91255892d51575f466a1b30e0c4546362c3e9ba3c6eaca25f0817d19771c74e88a4277
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Added custom YAML sorting rules to ensure consistent ordering of arrays in YAML files, including sorting tokens by chainName, token connections, and ISM modules by type. The custom sorting functionality comes from `@hyperlane-xyz/utils/eslint-rules` which has been added as a dependency.

### Backward compatibility

Yes

### Testing

The custom sorting rules have been tested with the linter to ensure proper YAML array ordering in the registry configuration files.