### PR TITLE
Remove file exists, then throw logic for addWarpRoute

### DIFF
--- a/.changeset/cyan-phones-greet.md
+++ b/.changeset/cyan-phones-greet.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Updates the FileSystemRegistry to not throw when adding a warp route configuration. This essentially removes the need for an update function.

--- a/src/fs/FileSystemRegistry.ts
+++ b/src/fs/FileSystemRegistry.ts
@@ -129,7 +129,6 @@ export class FileSystemRegistry extends SynchronousRegistry implements IRegistry
 
   addWarpRouteConfig(warpConfig: WarpRouteDeployConfig, options: AddWarpRouteConfigOptions): void {
     const filePath = path.join(this.uri, this.getWarpRouteDeployConfigPath(warpConfig, options));
-    if (fs.existsSync(filePath)) throw Error(`Warp deploy config already exists for: ${filePath}.`);
 
     this.createFile({
       filePath,


### PR DESCRIPTION
### Description

This pull request updates the `FileSystemRegistry` to not throw when adding a warp route configuration. This essentially removes the need for an update function.

### Backward compatibility
Yes

### Testing
- tested through `yarn tsx ./scripts/warp-routes/export-warp-configs.ts -e mainnet3`