### PR TITLE
chore: update GithubRegistry - getWarpRoutes

### DIFF
--- a/.changeset/bright-lamps-give.md
+++ b/.changeset/bright-lamps-give.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Update GithubRegistry getWarpRoutes to fetch combined warpRouteConfigs.yaml file

--- a/src/registry/BaseRegistry.ts
+++ b/src/registry/BaseRegistry.ts
@@ -37,6 +37,8 @@ export abstract class BaseRegistry implements IRegistry {
   protected isMetadataCacheFull: boolean = false;
   protected addressCache?: ChainMap<ChainAddresses>;
   protected isAddressCacheFull: boolean = false;
+  protected warpRouteCache?: WarpRouteConfigMap;
+  protected isWarpRouteCacheFull: boolean = false;
 
   constructor({ uri, logger }: { uri: string; logger?: Logger }) {
     this.uri = uri;

--- a/src/registry/GithubRegistry.ts
+++ b/src/registry/GithubRegistry.ts
@@ -118,9 +118,8 @@ export class GithubRegistry extends BaseRegistry implements IRegistry {
     this.branch = options.branch ?? repoBranch ?? 'main';
     this.proxyUrl = options.proxyUrl;
     this.authToken = options.authToken;
-    this.isBrowser = options.isBrowser !== undefined
-      ? options.isBrowser
-      : typeof window !== 'undefined';
+    this.isBrowser =
+      options.isBrowser !== undefined ? options.isBrowser : typeof window !== 'undefined';
   }
 
   getUri(itemPath?: string): string {
@@ -228,9 +227,18 @@ export class GithubRegistry extends BaseRegistry implements IRegistry {
   }
 
   async getWarpRoutes(filter?: WarpRouteFilterParams): Promise<WarpRouteConfigMap> {
-    const { warpRoutes } = (await this.listRegistryContent()).deployments;
-    const { ids: routeIds, values: routeConfigUrls } = filterWarpRoutesIds(warpRoutes, filter);
-    return this.readConfigs(routeIds, routeConfigUrls);
+    if (this.warpRouteCache && this.isWarpRouteCacheFull) {
+      const { idMap: filteredWarpRouteConfigs } = filterWarpRoutesIds(this.warpRouteCache, filter);
+      return filteredWarpRouteConfigs;
+    }
+    const combinedDataUrl = this.getRawContentUrl(
+      `${this.getWarpRoutesPath}/warpRouteConfigs.yaml`,
+    );
+    const warpRouteConfigs = await this.fetchYamlFile<WarpRouteConfigMap>(combinedDataUrl);
+    this.isWarpRouteCacheFull = true;
+    this.warpRouteCache = warpRouteConfigs;
+    const { idMap: filteredWarpRouteConfigs } = filterWarpRoutesIds(warpRouteConfigs, filter);
+    return filteredWarpRouteConfigs;
   }
 
   async getWarpDeployConfigs(filter?: WarpRouteFilterParams): Promise<WarpDeployConfigMap> {


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

- Update GithubRegistry getWarpRoutes to fetch combined warpRouteConfigs.yaml file instead

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
