### PR TITLE
chore: add logoURI to missing routes

### DIFF
--- a/.changeset/cyan-flies-lie.md
+++ b/.changeset/cyan-flies-lie.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add logoURI to missing ETH routes

--- a/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet-config.yaml
@@ -18,6 +18,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -39,6 +40,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -60,6 +62,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -82,6 +85,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypCollateral
     symbol: ETH
@@ -103,6 +107,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -125,6 +130,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypCollateral
     symbol: ETH
@@ -147,6 +153,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypCollateral
     symbol: ETH
@@ -168,6 +175,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -189,6 +197,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -211,6 +220,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypCollateral
     symbol: ETH
@@ -232,6 +242,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -253,6 +264,7 @@ tokens:
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -274,6 +286,7 @@ tokens:
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|lisk|0x85E9ae52B10f35e3D15264F1E906895B1D7Da1a0
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -294,6 +307,7 @@ tokens:
       - token: ethereum|zeronetwork|0x2E2c9BeE342398E26156Da12769262087de6EdDC
       - token: ethereum|zoramainnet|0xA900858116D7605a01AfC7595450d8D78555Bc83
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypSynthetic
     symbol: ETH

--- a/deployments/warp_routes/ETH/arbitrum-bsc-kalychain-polygon-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-bsc-kalychain-polygon-config.yaml
@@ -7,6 +7,7 @@ tokens:
       - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
       - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypNative
     symbol: ETH
@@ -18,6 +19,7 @@ tokens:
       - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
       - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypCollateral
     symbol: ETH
@@ -28,6 +30,7 @@ tokens:
       - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
       - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypSynthetic
     symbol: ETH
@@ -39,6 +42,7 @@ tokens:
       - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
       - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
     decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
     name: Ether
     standard: EvmHypCollateral
     symbol: ETH


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Add logoURI to missing ETH warp routes
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
