### PR TITLE
feat: add bbSOL-solanamainnet-soon warp route

### DIFF
--- a/.changeset/bright-pots-marry.md
+++ b/.changeset/bright-pots-marry.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Added bbSOL/solanamainnet-soon warp route

--- a/deployments/warp_routes/bbSOL/solanamainnet-soon-config.yaml
+++ b/deployments/warp_routes/bbSOL/solanamainnet-soon-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: 5mzc5Sv61721Xr44Uw7Kb9txoMWLz8XYLrgCewe1sj2B
+    chainName: soon
+    collateralAddressOrDenom: GxV545AqavAEnu6HbUQGy2DQQpwuY5wAxwrq5F3yG3Mh
+    connections:
+      - token: sealevel|solanamainnet|8rodtMgnpCboxNiaQozdCTGiCEkK6BDXmFuoJ9qhTxfh
+    decimals: 9
+    logoURI: /deployments/warp_routes/bbSOL/logo.png
+    name: Bybit Staked SOL
+    standard: SealevelHypSynthetic
+    symbol: bbSOL
+  - addressOrDenom: 8rodtMgnpCboxNiaQozdCTGiCEkK6BDXmFuoJ9qhTxfh
+    chainName: solanamainnet
+    coinGeckoId: bybit-staked-sol
+    collateralAddressOrDenom: Bybit2vBJGhPF52GBdNaQfUJ6ZpThSgHBobjWZpLPb4B
+    connections:
+      - token: sealevel|soon|5mzc5Sv61721Xr44Uw7Kb9txoMWLz8XYLrgCewe1sj2B
+    decimals: 9
+    logoURI: /deployments/warp_routes/bbSOL/logo.png
+    name: Bybit Staked SOL
+    standard: SealevelHypCollateral
+    symbol: bbSOL


### PR DESCRIPTION
### Description

This PR adds the new warp route for Bybit Staked SOL from Solana to SOON.

### Backward compatibility

Yes

### Testing

- check-deploy.sh
- CLI testing via `cargo run`
