### PR TITLE
chore: Add TGT coingecko

### DIFF
--- a/.changeset/strange-dots-grin.md
+++ b/.changeset/strange-dots-grin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add TGT coingeckoId

--- a/deployments/warp_routes/TGT/bsc-immutablezkevmmainnet-config.yaml
+++ b/deployments/warp_routes/TGT/bsc-immutablezkevmmainnet-config.yaml
@@ -11,6 +11,7 @@ tokens:
     symbol: TGT
   - addressOrDenom: "0x4d9D942010eB2411fF16a9d910Badbc8520a9BfF"
     chainName: immutablezkevmmainnet
+    coinGeckoId: tokyo-games-token
     collateralAddressOrDenom: "0x0FA1d8Ffa9B414ABF0F47183e088bddC32e084F3"
     connections:
       - token: ethereum|bsc|0x6c58E4a513D3A8062E57f41a1442e003aF14eBb5


### PR DESCRIPTION
This pull request includes a minor update to the `bsc-immutablezkevmmainnet-config.yaml` file for the TGT token configuration. The change adds a `coinGeckoId` field to specify the token's identifier on CoinGecko.