### PR TITLE
fix(metadata): switch from STRK to ETH

### DIFF
--- a/chains/starknet/metadata.yaml
+++ b/chains/starknet/metadata.yaml
@@ -19,9 +19,9 @@ gasCurrencyCoinGeckoId: starknet
 name: starknet
 nativeToken:
   decimals: 18
-  denom: "0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D"
-  name: Starknet Token
-  symbol: STRK
+  denom: "0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7"
+  name: Ether
+  symbol: ETH
 protocol: starknet
 rpcUrls:
   - http: https://starknet-mainnet.public.blastapi.io


### PR DESCRIPTION
### Description

- the protocol fee token is using STRK but we've been use ETH in the relayer operations so far (should upgrade soon)

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
