### PR TITLE
chore(starknet): add IGP (zero address) to starknet addresses

### DIFF
--- a/.changeset/thin-falcons-walk.md
+++ b/.changeset/thin-falcons-walk.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added IGP (zero address - doesn't exist yet)


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
