### PR TITLE
chore: Update build.ts to generate warpRouteConfigs.yaml

### DIFF
--- a/.changeset/odd-cameras-unite.md
+++ b/.changeset/odd-cameras-unite.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update build.ts to create the correct warpRouteConfigs.yaml (without the shortnames)

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -1,5 +1,5 @@
 # AUTO-GENERATED; DO NOT EDIT MANUALLY
-AIXBT/form:
+AIXBT/base-form:
   tokens:
     - addressOrDenom: "0x40Ca4155c0334F7e0F6d7F80536B59EF8831c9fb"
       chainName: form
@@ -21,6 +21,63 @@ AIXBT/form:
       name: aixbt by Virtuals
       standard: EvmHypCollateral
       symbol: AIXBT
+AMPHRETH/arbitrum-ethereum-zircuit:
+  tokens:
+    - addressOrDenom: "0x6D251aADfc6Ff69031e01eA39bE3cb5BABf8438f"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|ethereum|0xdc89990a6fdC1C922b841f1d977835628A24Ed57
+        - token: ethereum|zircuit|0x7D5a79539d7B1c9aE5e54d18EEE188840f1Fe4CC
+      decimals: 18
+      logoURI: /deployments/warp_routes/AMPHRETH/logo.svg
+      name: Amphor Restaked ETH
+      standard: EvmHypSynthetic
+      symbol: amphrETH
+    - addressOrDenom: "0xdc89990a6fdC1C922b841f1d977835628A24Ed57"
+      chainName: ethereum
+      coinGeckoId: ethereum
+      collateralAddressOrDenom: "0x5fD13359Ba15A84B76f7F87568309040176167cd"
+      connections:
+        - token: ethereum|arbitrum|0x6D251aADfc6Ff69031e01eA39bE3cb5BABf8438f
+        - token: ethereum|zircuit|0x7D5a79539d7B1c9aE5e54d18EEE188840f1Fe4CC
+      decimals: 18
+      logoURI: /deployments/warp_routes/AMPHRETH/logo.svg
+      name: Amphor Restaked ETH
+      standard: EvmHypCollateral
+      symbol: amphrETH
+    - addressOrDenom: "0x7D5a79539d7B1c9aE5e54d18EEE188840f1Fe4CC"
+      chainName: zircuit
+      connections:
+        - token: ethereum|arbitrum|0x6D251aADfc6Ff69031e01eA39bE3cb5BABf8438f
+        - token: ethereum|ethereum|0xdc89990a6fdC1C922b841f1d977835628A24Ed57
+      decimals: 18
+      logoURI: /deployments/warp_routes/AMPHRETH/logo.svg
+      name: Amphor Restaked ETH
+      standard: EvmHypSynthetic
+      symbol: amphrETH
+APXETH/eclipsemainnet-ethereum:
+  tokens:
+    - addressOrDenom: "0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c"
+      chainName: ethereum
+      coinGeckoId: ethereum
+      collateralAddressOrDenom: "0x9ba021b0a9b958b5e75ce9f6dff97c7ee52cb3e6"
+      connections:
+        - token: sealevel|eclipsemainnet|9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
+      decimals: 18
+      logoURI: /deployments/warp_routes/APXETH/logo.svg
+      name: Autocompounding Pirex Ether
+      standard: EvmHypCollateral
+      symbol: apxETH
+    - addressOrDenom: 9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: 6AjQBsySS1FtQmA7a4oYc6GYpHBTDqtSswptsVSTz3Tv
+      connections:
+        - token: ethereum|ethereum|0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c
+      decimals: 9
+      logoURI: /deployments/warp_routes/APXETH/logo.svg
+      name: Autocompounding Pirex Ether
+      standard: SealevelHypSynthetic
+      symbol: apxETH
 ART/artela-base-solanamainnet:
   tokens:
     - addressOrDenom: "0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484"
@@ -55,7 +112,7 @@ ART/artela-base-solanamainnet:
       name: Artela
       standard: SealevelHypSynthetic
       symbol: ART
-ATN/holesky:
+ATN/holesky-piccadilly:
   tokens:
     - addressOrDenom: "0x123B520fDd5De936bd94A73a2D6225C1276771c9"
       chainName: holesky
@@ -73,7 +130,7 @@ ATN/holesky:
       name: Auton
       standard: EvmHypNative
       symbol: ATN
-BNB/kalychain:
+BNB/bsc-kalychain:
   tokens:
     - addressOrDenom: "0x8d0e034611B691683377d2fC9958122a30F7DAab"
       chainName: bsc
@@ -91,7 +148,7 @@ BNB/kalychain:
       name: BNB
       standard: EvmHypSynthetic
       symbol: BNB
-BNB/zeronetwork:
+BNB/bsc-zeronetwork:
   tokens:
     - addressOrDenom: "0xb11d99AD37872068B14b5b9eeb3CE1A4E2244744"
       chainName: bsc
@@ -112,7 +169,7 @@ BNB/zeronetwork:
       name: BNB
       standard: EvmHypSynthetic
       symbol: BNB
-BRETT/zeronetwork:
+BRETT/base-zeronetwork:
   tokens:
     - addressOrDenom: "0x9Fe693789E93319cc0F8A00FB4597Ea4fD4b08cA"
       chainName: base
@@ -134,7 +191,7 @@ BRETT/zeronetwork:
       name: Brett
       standard: EvmHypSynthetic
       symbol: BRETT
-Bonk/soon:
+Bonk/solanamainnet-soon:
   tokens:
     - addressOrDenom: BMjPo9Yz9bdiLuKVfHfjuAEE6JgmnMWYaVEv1ehFYnd7
       chainName: soon
@@ -157,7 +214,7 @@ Bonk/soon:
       name: Bonk
       standard: SealevelHypCollateral
       symbol: Bonk
-Boop/apechain:
+Boop/apechain-arbitrum:
   tokens:
     - addressOrDenom: "0x1BBBd56299717A9eAf90393157137Ca4A308d965"
       chainName: apechain
@@ -179,6 +236,85 @@ Boop/apechain:
       name: Boop
       standard: EvmHypCollateral
       symbol: Boop
+CBBTC/base-ethereum-superseed:
+  tokens:
+    - addressOrDenom: "0x7710d2FC9A2E0452b28a2cBf550429b579347199"
+      chainName: ethereum
+      coinGeckoId: coinbase-wrapped-btc
+      collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
+      connections:
+        - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
+      decimals: 8
+      logoURI: /deployments/warp_routes/CBBTC/logo.svg
+      name: Coinbase Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: cbBTC
+    - addressOrDenom: "0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484"
+      chainName: superseed
+      collateralAddressOrDenom: "0x6f36dbd829de9b7e077db8a35b480d4329ceb331"
+      connections:
+        - token: ethereum|ethereum|0x7710d2FC9A2E0452b28a2cBf550429b579347199
+        - token: ethereum|base|0x66477F84bd21697c7781fc3992b3163463e3B224
+      decimals: 8
+      logoURI: /deployments/warp_routes/CBBTC/logo.svg
+      name: Coinbase Wrapped BTC
+      standard: EvmHypCollateralFiat
+      symbol: cbBTC
+    - addressOrDenom: "0x66477F84bd21697c7781fc3992b3163463e3B224"
+      chainName: base
+      coinGeckoId: coinbase-wrapped-btc
+      collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+      connections:
+        - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
+      decimals: 8
+      logoURI: /deployments/warp_routes/CBBTC/logo.svg
+      name: Coinbase Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: cbBTC
+CBBTC/base-zeronetwork:
+  tokens:
+    - addressOrDenom: "0x2A872Ae01375A5ca7e044cb0e75cb97621Ca954A"
+      chainName: base
+      coinGeckoId: coinbase-wrapped-btc
+      collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+      connections:
+        - token: ethereum|zeronetwork|0x3f7F02453518A55C0c6F89F0A6A8ab6c22Da01Df
+      decimals: 8
+      logoURI: /deployments/warp_routes/CBBTC/logo.svg
+      name: Coinbase Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: cbBTC
+    - addressOrDenom: "0x3f7F02453518A55C0c6F89F0A6A8ab6c22Da01Df"
+      chainName: zeronetwork
+      connections:
+        - token: ethereum|base|0x2A872Ae01375A5ca7e044cb0e75cb97621Ca954A
+      decimals: 8
+      logoURI: /deployments/warp_routes/CBBTC/logo.svg
+      name: Coinbase Wrapped BTC
+      standard: EvmHypSynthetic
+      symbol: cbBTC
+CBBTC/ethereum-flowmainnet:
+  tokens:
+    - addressOrDenom: "0xfF5C22ea202258143557f6cc3bDe174dde6E8fE1"
+      chainName: ethereum
+      coinGeckoId: coinbase-wrapped-btc
+      collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
+      connections:
+        - token: ethereum|flowmainnet|0xA0197b2044D28b08Be34d98b23c9312158Ea9A18
+      decimals: 8
+      logoURI: /deployments/warp_routes/CBBTC/logo.svg
+      name: Coinbase Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: cbBTC
+    - addressOrDenom: "0xA0197b2044D28b08Be34d98b23c9312158Ea9A18"
+      chainName: flowmainnet
+      connections:
+        - token: ethereum|ethereum|0xfF5C22ea202258143557f6cc3bDe174dde6E8fE1
+      decimals: 8
+      logoURI: /deployments/warp_routes/CBBTC/logo.svg
+      name: Coinbase Wrapped BTC
+      standard: EvmHypSynthetic
+      symbol: cbBTC
 CDX/base-solanamainnet-sophon:
   tokens:
     - addressOrDenom: "0x22Fd11F93F0303346c9b9070cc67C4Bc7aB2dABB"
@@ -214,7 +350,7 @@ CDX/base-solanamainnet-sophon:
       name: Cod3x Token
       standard: EvmHypSynthetic
       symbol: CDX
-CHILL/solanamainnet:
+CHILL/solanamainnet-sonicsvm:
   tokens:
     - addressOrDenom: 5Ez7qqsT9GXVWWB9a5B4yKhvzns3hatc3ZwKHiL5Pmuv
       chainName: solanamainnet
@@ -236,7 +372,7 @@ CHILL/solanamainnet:
       name: CHILL
       standard: SealevelHypCollateral
       symbol: CHILL
-DAI/kalychain:
+DAI/arbitrum-bsc-kalychain-polygon:
   tokens:
     - addressOrDenom: "0x1e59F72de6c00c456f7F42708FE8b6b0782E84C6"
       chainName: arbitrum
@@ -284,7 +420,7 @@ DAI/kalychain:
       name: Dai Stablecoin
       standard: EvmHypCollateral
       symbol: DAI
-DAI/linea:
+DAI/arbitrum-bsc-linea-polygon:
   tokens:
     - addressOrDenom: "0xEb881635A2Dd87d2b7C0F7B206810fa2A1956552"
       chainName: arbitrum
@@ -333,7 +469,7 @@ DAI/linea:
       name: Dai Stablecoin
       standard: EvmHypCollateral
       symbol: DAI
-DOG/optimism:
+DOG/base-optimism:
   tokens:
     - addressOrDenom: "0x91f016B43A73DFF60f5D910c530338f69Fa3FD0b"
       chainName: base
@@ -354,7 +490,7 @@ DOG/optimism:
       name: The Doge NFT
       standard: EvmHypSynthetic
       symbol: DOG
-EAURA/storyodysseytestnet:
+EAURA/euphoriatestnet-storyodysseytestnet:
   tokens:
     - addressOrDenom: "0x17Ba7b7D6110DE065C10321D64cdfbAFAb6De255"
       chainName: euphoriatestnet
@@ -372,7 +508,7 @@ EAURA/storyodysseytestnet:
       name: Euphoria Aura
       standard: EvmHypSynthetic
       symbol: EAURA
-EAURA/storytestnet:
+EAURA/euphoriatestnet-storytestnet:
   tokens:
     - addressOrDenom: "0x4BD4B868D23d1dB8181c1913C331d7AB1CeA8B24"
       chainName: euphoriatestnet
@@ -390,7 +526,7 @@ EAURA/storytestnet:
       name: Euphoria Aura
       standard: EvmHypSynthetic
       symbol: EAURA
-ECLIP/arbitrum:
+ECLIP/arbitrum-neutron:
   tokens:
     - addressOrDenom: neutron1dvzvf870mx9uf65uqhx40yzx9gu4xlqqq2pnx362a0ndmustww3smumrf5
       chainName: neutron
@@ -420,7 +556,7 @@ ECLIP/arbitrum:
       name: TIA.n
       standard: CosmosIbc
       symbol: TIA.n
-ELIZA/soon:
+ELIZA/solanamainnet-soon:
   tokens:
     - addressOrDenom: 8f8C12h7b3HfYDbU9YWrf5q1K7jTVYYan2MgjzVWpynE
       chainName: soon
@@ -443,7 +579,7 @@ ELIZA/soon:
       name: Eliza
       standard: SealevelHypCollateral
       symbol: ELIZA
-ES/eclipsemainnet:
+ES/eclipsemainnet-ethereum:
   tokens:
     - addressOrDenom: "0x3eE1BEA3A10f7508b76219f109eBe19419b3dd85"
       chainName: ethereum
@@ -465,7 +601,7 @@ ES/eclipsemainnet:
       name: Eclipse
       standard: SealevelHypSynthetic
       symbol: ES
-ETH/alfajores:
+ETH/alfajores-sepolia:
   tokens:
     - addressOrDenom: "0x78fe869f19f917fde4192c51c446Fbd3721788ee"
       chainName: alfajores
@@ -485,97 +621,7 @@ ETH/alfajores:
       name: Ether
       standard: EvmHypNative
       symbol: ETH
-ETH/coti:
-  tokens:
-    - addressOrDenom: "0x07C747b0D99aBE8132f771cf6D2365D19ED1FfbA"
-      chainName: ethereum
-      coinGeckoId: ethereum
-      connections:
-        - token: ethereum|coti|0x639aCc80569c5FC83c6FBf2319A6Cc38bBfe26d1
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypNative
-      symbol: ETH
-    - addressOrDenom: "0x639aCc80569c5FC83c6FBf2319A6Cc38bBfe26d1"
-      chainName: coti
-      connections:
-        - token: ethereum|ethereum|0x07C747b0D99aBE8132f771cf6D2365D19ED1FfbA
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypSynthetic
-      symbol: ETH
-ETH/hyperevm:
-  tokens:
-    - addressOrDenom: "0x9a3BeED38441e8fF8E033043a88B49E035F5a2da"
-      chainName: ethereum
-      coinGeckoId: ethereum
-      connections:
-        - token: ethereum|hyperevm|0x1fbcCdc677c10671eE50b46C61F0f7d135112450
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypNative
-      symbol: ETH
-    - addressOrDenom: "0x1fbcCdc677c10671eE50b46C61F0f7d135112450"
-      chainName: hyperevm
-      connections:
-        - token: ethereum|ethereum|0x9a3BeED38441e8fF8E033043a88B49E035F5a2da
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypSynthetic
-      symbol: ETH
-ETH/kalychain:
-  tokens:
-    - addressOrDenom: "0x14CFC15Da10d5cfC6A494E183c795067573C7F51"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
-        - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
-        - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypNative
-      symbol: ETH
-    - addressOrDenom: "0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3"
-      chainName: bsc
-      collateralAddressOrDenom: "0x2170Ed0880ac9A755fd29B2688956BD959F933F8"
-      connections:
-        - token: ethereum|arbitrum|0x14CFC15Da10d5cfC6A494E183c795067573C7F51
-        - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
-        - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypCollateral
-      symbol: ETH
-    - addressOrDenom: "0xfdbB253753dDE60b11211B169dC872AaE672879b"
-      chainName: kalychain
-      connections:
-        - token: ethereum|arbitrum|0x14CFC15Da10d5cfC6A494E183c795067573C7F51
-        - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
-        - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypSynthetic
-      symbol: ETH
-    - addressOrDenom: "0xb974461a9ef2Ff3F408798f551929647ceaB13b4"
-      chainName: polygon
-      collateralAddressOrDenom: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
-      connections:
-        - token: ethereum|arbitrum|0x14CFC15Da10d5cfC6A494E183c795067573C7F51
-        - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
-        - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
-      decimals: 18
-      logoURI: /deployments/warp_routes/ETH/logo.svg
-      name: Ether
-      standard: EvmHypCollateral
-      symbol: ETH
-ETH/lisk:
+ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet:
   tokens:
     - addressOrDenom: "0x6B8D1F18819DACA1fB966CF8Cff12feb4c00EB88"
       chainName: arbitrum
@@ -888,7 +934,7 @@ ETH/lisk:
       name: Ether
       standard: EvmHypSynthetic
       symbol: ETH
-ETH/lumiaprism:
+ETH/arbitrum-base-ethereum-lumiaprism-optimism-polygon:
   tokens:
     - addressOrDenom: "0xE4A9622Bf50025fE99A576D484AEf16280A5304f"
       chainName: base
@@ -942,27 +988,105 @@ ETH/lumiaprism:
       name: Ether
       standard: EvmHypCollateral
       symbol: ETH
-ETH/piccadilly:
+ETH/arbitrum-bsc-kalychain-polygon:
   tokens:
-    - addressOrDenom: "0x7f8C02dA6A2f56bD5ae52524717477B7d79F8D5C"
-      chainName: holesky
+    - addressOrDenom: "0x14CFC15Da10d5cfC6A494E183c795067573C7F51"
+      chainName: arbitrum
       connections:
-        - token: ethereum|piccadilly|0x49195E6251aFa947319F29351be4bDfA617C6720
+        - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
+        - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
+        - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
       decimals: 18
       logoURI: /deployments/warp_routes/ETH/logo.svg
       name: Ether
       standard: EvmHypNative
       symbol: ETH
-    - addressOrDenom: "0x49195E6251aFa947319F29351be4bDfA617C6720"
-      chainName: piccadilly
+    - addressOrDenom: "0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3"
+      chainName: bsc
+      collateralAddressOrDenom: "0x2170Ed0880ac9A755fd29B2688956BD959F933F8"
       connections:
-        - token: ethereum|holesky|0x7f8C02dA6A2f56bD5ae52524717477B7d79F8D5C
+        - token: ethereum|arbitrum|0x14CFC15Da10d5cfC6A494E183c795067573C7F51
+        - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
+        - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
+      decimals: 18
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
+      standard: EvmHypCollateral
+      symbol: ETH
+    - addressOrDenom: "0xfdbB253753dDE60b11211B169dC872AaE672879b"
+      chainName: kalychain
+      connections:
+        - token: ethereum|arbitrum|0x14CFC15Da10d5cfC6A494E183c795067573C7F51
+        - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
+        - token: ethereum|polygon|0xb974461a9ef2Ff3F408798f551929647ceaB13b4
       decimals: 18
       logoURI: /deployments/warp_routes/ETH/logo.svg
       name: Ether
       standard: EvmHypSynthetic
       symbol: ETH
-ETH/vana:
+    - addressOrDenom: "0xb974461a9ef2Ff3F408798f551929647ceaB13b4"
+      chainName: polygon
+      collateralAddressOrDenom: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
+      connections:
+        - token: ethereum|arbitrum|0x14CFC15Da10d5cfC6A494E183c795067573C7F51
+        - token: ethereum|bsc|0xF29AD0640731c50d0c7C999D1f8d5Ffb9E2A3da3
+        - token: ethereum|kalychain|0xfdbB253753dDE60b11211B169dC872AaE672879b
+      decimals: 18
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
+      standard: EvmHypCollateral
+      symbol: ETH
+ETH/base:
+  tokens:
+    - addressOrDenom: "0x35e272671e26745C4f081CBe9ddd99d42eBC9E88"
+      chainName: base
+      decimals: 18
+      name: Ether
+      standard: EvmHypNative
+      symbol: ETH
+ETH/coti-ethereum:
+  tokens:
+    - addressOrDenom: "0x07C747b0D99aBE8132f771cf6D2365D19ED1FfbA"
+      chainName: ethereum
+      coinGeckoId: ethereum
+      connections:
+        - token: ethereum|coti|0x639aCc80569c5FC83c6FBf2319A6Cc38bBfe26d1
+      decimals: 18
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
+      standard: EvmHypNative
+      symbol: ETH
+    - addressOrDenom: "0x639aCc80569c5FC83c6FBf2319A6Cc38bBfe26d1"
+      chainName: coti
+      connections:
+        - token: ethereum|ethereum|0x07C747b0D99aBE8132f771cf6D2365D19ED1FfbA
+      decimals: 18
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
+      standard: EvmHypSynthetic
+      symbol: ETH
+ETH/ethereum-hyperevm:
+  tokens:
+    - addressOrDenom: "0x9a3BeED38441e8fF8E033043a88B49E035F5a2da"
+      chainName: ethereum
+      coinGeckoId: ethereum
+      connections:
+        - token: ethereum|hyperevm|0x1fbcCdc677c10671eE50b46C61F0f7d135112450
+      decimals: 18
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
+      standard: EvmHypNative
+      symbol: ETH
+    - addressOrDenom: "0x1fbcCdc677c10671eE50b46C61F0f7d135112450"
+      chainName: hyperevm
+      connections:
+        - token: ethereum|ethereum|0x9a3BeED38441e8fF8E033043a88B49E035F5a2da
+      decimals: 18
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
+      standard: EvmHypSynthetic
+      symbol: ETH
+ETH/ethereum-vana:
   tokens:
     - addressOrDenom: "0x3e6Dba802d62aba2361Dd632fbC9f547AA6789aE"
       chainName: ethereum
@@ -983,7 +1107,7 @@ ETH/vana:
       name: Ethereum
       standard: EvmHypSynthetic
       symbol: ETH
-ETH/viction:
+ETH/ethereum-viction:
   tokens:
     - addressOrDenom: "0x15b5D6B614242B118AA404528A7f3E2Ad241e4A4"
       chainName: ethereum
@@ -1004,4068 +1128,27 @@ ETH/viction:
       name: Ethereum
       standard: EvmHypSynthetic
       symbol: ETH
-EZETHSTAGE/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit:
+ETH/holesky-piccadilly:
   tokens:
-    - addressOrDenom: "0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5"
-      chainName: arbitrum
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5"
-      chainName: base
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA"
-      chainName: berachain
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x89E3530137aD51743536443a3EC838b502E72eb7"
-      chainName: blast
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x01bFbc80b32469c36DB4C7fc564E75475dfC278C"
-      chainName: bsc
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x74c8290836612e6251E49e8f3198fdD80C4DbEB8"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20Lockbox
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC"
-      chainName: fraxtal
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x9E3075E067932d744119e583B34d11b144CE1e4A"
-      chainName: linea
-      collateralAddressOrDenom: "0x5EA461E19ba6C002b7024E4A2e9CeFe79a47d3bB"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D"
-      chainName: mode
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326"
-      chainName: optimism
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0xdD313D475f8A9d81CBE2eA953a357f52e10BA357"
-      chainName: sei
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2"
-      chainName: swell
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x652e2F475Af7b1154817E09f5408f9011037492a"
-      chainName: taiko
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
-      chainName: unichain
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0xa2656c131A9F204F73944D7B60DDB17565E71292"
-      chainName: zircuit
-      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-    - addressOrDenom: "0x04A0B8355EF40C6F15e203D582Ad66c717E1D247"
-      chainName: worldchain
-      collateralAddressOrDenom: "0xC33DdE0a44e3Bed87cc3Ff0325D3fcbA5279930E"
-      connections:
-        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
-        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
-        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
-        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
-        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
-        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
-        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
-        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
-        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
-        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
-        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
-        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
-        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
-      decimals: 18
-      name: Renzo Restaked ETH Stage 9
-      standard: EvmHypXERC20
-      symbol: EZETHSTAGE
-FORM/form:
-  tokens:
-    - addressOrDenom: "0xEa35E107fB64Ff8C3c8c37DB2d23A7179f31D8EC"
-      chainName: ethereum
-      coinGeckoId: form
-      collateralAddressOrDenom: "0xE7deE4823EE18F1347F1Cf7997f70B94eFDe2E1F"
-      connections:
-        - token: ethereum|form|0x688da80Dfe2916c0a0Aa360323E52Aa5881AdB78
-      decimals: 18
-      logoURI: /deployments/warp_routes/FORM/logo.svg
-      name: Form
-      standard: EvmHypCollateral
-      symbol: FORM
-    - addressOrDenom: "0x688da80Dfe2916c0a0Aa360323E52Aa5881AdB78"
-      chainName: form
-      connections:
-        - token: ethereum|ethereum|0xEa35E107fB64Ff8C3c8c37DB2d23A7179f31D8EC
-      decimals: 18
-      logoURI: /deployments/warp_routes/FORM/logo.svg
-      name: Form
-      standard: EvmHypSynthetic
-      symbol: FORM
-FUEL/base-bsc-ethereum:
-  tokens:
-    - addressOrDenom: "0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634"
-      chainName: base
-      connections:
-        - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
-        - token: ethereum|bsc|0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5
-      decimals: 9
-      logoURI: /deployments/warp_routes/FUEL/logo.svg
-      name: FUEL
-      standard: EvmHypSynthetic
-      symbol: FUEL
-    - addressOrDenom: "0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5"
-      chainName: bsc
-      connections:
-        - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
-        - token: ethereum|base|0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634
-      decimals: 9
-      logoURI: /deployments/warp_routes/FUEL/logo.svg
-      name: FUEL
-      standard: EvmHypSynthetic
-      symbol: FUEL
-    - addressOrDenom: "0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C"
-      chainName: ethereum
-      coinGeckoId: fuel-network
-      collateralAddressOrDenom: "0x675B68AA4d9c2d3BB3F0397048e62E6B7192079c"
-      connections:
-        - token: ethereum|bsc|0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5
-        - token: ethereum|base|0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634
-      decimals: 9
-      logoURI: /deployments/warp_routes/FUEL/logo.svg
-      name: FUEL
-      standard: EvmHypCollateral
-      symbol: FUEL
-Fartcoin/apechain:
-  tokens:
-    - addressOrDenom: "0x5FC9b323013DAcF2d56046F9ff0f61c95c6A466B"
-      chainName: apechain
-      coinGeckoId: fartcoin
-      connections:
-        - token: sealevel|solanamainnet|4YGKdefcJMUVnzZFu124t7epCNWnAjmXbKXyC13HiAFR
-      decimals: 6
-      logoURI: /deployments/warp_routes/Fartcoin/logo.svg
-      name: Fartcoin
-      standard: EvmHypSynthetic
-      symbol: Fartcoin
-    - addressOrDenom: 4YGKdefcJMUVnzZFu124t7epCNWnAjmXbKXyC13HiAFR
-      chainName: solanamainnet
-      coinGeckoId: fartcoin
-      collateralAddressOrDenom: 9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump
-      connections:
-        - token: ethereum|apechain|0x5FC9b323013DAcF2d56046F9ff0f61c95c6A466B
-      decimals: 6
-      logoURI: /deployments/warp_routes/Fartcoin/logo.svg
-      name: Fartcoin
-      standard: SealevelHypCollateral
-      symbol: Fartcoin
-GAME/form:
-  tokens:
-    - addressOrDenom: "0x96D51cc3f7500d501bAeB1A2a62BB96fa03532F8"
-      chainName: form
-      connections:
-        - token: ethereum|base|0x6a5579ABECE07b73d4d92a8bBFF51aF827bB21f1
-      decimals: 18
-      logoURI: /deployments/warp_routes/GAME/logo.svg
-      name: GAME by Virtuals
-      standard: EvmHypSynthetic
-      symbol: GAME
-    - addressOrDenom: "0x6a5579ABECE07b73d4d92a8bBFF51aF827bB21f1"
-      chainName: base
-      coinGeckoId: game-by-virtuals
-      collateralAddressOrDenom: "0x1C4CcA7C5DB003824208aDDA61Bd749e55F463a3"
-      connections:
-        - token: ethereum|form|0x96D51cc3f7500d501bAeB1A2a62BB96fa03532F8
-      decimals: 18
-      logoURI: /deployments/warp_routes/GAME/logo.svg
-      name: GAME by Virtuals
-      standard: EvmHypCollateral
-      symbol: GAME
-GG/apechain:
-  tokens:
-    - addressOrDenom: "0x0bb999f106C1246810686891f97Bbc22C53E4850"
-      chainName: apechain
-      connections:
-        - token: ethereum|arbitrum|0x0bb999f106C1246810686891f97Bbc22C53E4850
-      decimals: 18
-      logoURI: /deployments/warp_routes/GG/logo.svg
-      name: GG
-      standard: EvmHypSynthetic
-      symbol: GG
-    - addressOrDenom: "0x0bb999f106C1246810686891f97Bbc22C53E4850"
-      chainName: arbitrum
-      coinGeckoId: reboot
-      collateralAddressOrDenom: "0x000000000026839b3f4181f2cF69336af6153b99"
-      connections:
-        - token: ethereum|apechain|0x0bb999f106C1246810686891f97Bbc22C53E4850
-      decimals: 18
-      logoURI: /deployments/warp_routes/GG/logo.svg
-      name: GG
-      standard: EvmHypCollateral
-      symbol: GG
-GIGA/soon:
-  tokens:
-    - addressOrDenom: GHcg7qY2cXQ4Ej9xQqjnLdYUV41bt2ncaPuo5AxN5eTy
-      chainName: soon
-      collateralAddressOrDenom: 5msdLukGrv3nkRH8Nwz6LELahbMB5yzmaM6xGhUfcysm
-      connections:
-        - token: sealevel|solanamainnet|CjP8N5L2KV4iWobXoVV1dhftRdfQ7S3rKVrT7Lja9Jku
-      decimals: 5
-      logoURI: /deployments/warp_routes/GIGA/logo.svg
-      name: GIGACHAD
-      standard: SealevelHypSynthetic
-      symbol: GIGA
-    - addressOrDenom: CjP8N5L2KV4iWobXoVV1dhftRdfQ7S3rKVrT7Lja9Jku
-      chainName: solanamainnet
-      coinGeckoId: gigachad-2
-      collateralAddressOrDenom: 63LfDmNb3MQ8mw9MtZ2To9bEA2M71kZUUGq5tiJxcqj9
-      connections:
-        - token: sealevel|soon|GHcg7qY2cXQ4Ej9xQqjnLdYUV41bt2ncaPuo5AxN5eTy
-      decimals: 5
-      logoURI: /deployments/warp_routes/GIGA/logo.svg
-      name: GIGACHAD
-      standard: SealevelHypCollateral
-      symbol: GIGA
-GOAT/soon:
-  tokens:
-    - addressOrDenom: 9NhiDziXERQUsb3NxRNdamR6ivfeF8GanUJvBffQbyBF
-      chainName: soon
-      collateralAddressOrDenom: 6ABPSb8Pj7B6waFjcPf8JgosQnghqqqiL9kAL3ykatk4
-      connections:
-        - token: sealevel|solanamainnet|HM4qABV4C6KPYhZQmJnQXJ9Q9Syo5waPcxFWLQNiDq2e
-      decimals: 6
-      logoURI: /deployments/warp_routes/GOAT/logo.svg
-      name: Goatseus Maximus
-      standard: SealevelHypSynthetic
-      symbol: GOAT
-    - addressOrDenom: HM4qABV4C6KPYhZQmJnQXJ9Q9Syo5waPcxFWLQNiDq2e
-      chainName: solanamainnet
-      coinGeckoId: goatseus-maximus
-      collateralAddressOrDenom: CzLSujWBLFsSjncfkh59rUFqvafWcY5tzedWJSuypump
-      connections:
-        - token: sealevel|soon|9NhiDziXERQUsb3NxRNdamR6ivfeF8GanUJvBffQbyBF
-      decimals: 6
-      logoURI: /deployments/warp_routes/GOAT/logo.svg
-      name: Goatseus Maximus
-      standard: SealevelHypCollateral
-      symbol: GOAT
-GPS/bsc:
-  tokens:
-    - addressOrDenom: "0x01efc19badCAC4EDaE0d75c5F344AcD0F7311722"
-      chainName: base
-      coinGeckoId: goplus-security
-      collateralAddressOrDenom: "0x0c1dc73159e30c4b06170f2593d3118968a0dca5"
-      connections:
-        - token: ethereum|bsc|0x9A4a67721573f2c9209DfFf972c52Be4E3F6642e
-      decimals: 18
-      logoURI: /deployments/warp_routes/GPS/logo.svg
-      name: GoPlus Security
-      standard: EvmHypCollateral
-      symbol: GPS
-    - addressOrDenom: "0x9A4a67721573f2c9209DfFf972c52Be4E3F6642e"
-      chainName: bsc
-      connections:
-        - token: ethereum|base|0x01efc19badCAC4EDaE0d75c5F344AcD0F7311722
-      decimals: 18
-      logoURI: /deployments/warp_routes/GPS/logo.svg
-      name: GoPlus Security
-      standard: EvmHypSynthetic
-      symbol: GPS
-HYPER/arbitrum-base-bsc-ethereum-optimism:
-  tokens:
-    - addressOrDenom: "0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
-        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
-      decimals: 18
-      logoURI: /deployments/warp_routes/HYPER/logo.svg
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPER
-    - addressOrDenom: "0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4"
-      chainName: base
-      connections:
-        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
-        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
-      decimals: 18
-      logoURI: /deployments/warp_routes/HYPER/logo.svg
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPER
-    - addressOrDenom: "0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4"
-      chainName: bsc
-      connections:
-        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
-        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
-      decimals: 18
-      logoURI: /deployments/warp_routes/HYPER/logo.svg
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPER
-    - addressOrDenom: "0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5"
-      chainName: ethereum
-      coinGeckoId: hyperlane
-      connections:
-        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
-      decimals: 18
-      logoURI: /deployments/warp_routes/HYPER/logo.svg
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPER
-    - addressOrDenom: "0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979"
-      chainName: optimism
-      connections:
-        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
-        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
-      decimals: 18
-      logoURI: /deployments/warp_routes/HYPER/logo.svg
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPER
-HYPERSTAGE/arbitrum-base-bsc-ethereum-optimism:
-  tokens:
-    - addressOrDenom: "0xF80dcED2488Add147E60561F8137338F7f3976e1"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
-        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
-        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
-        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
-      decimals: 18
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPERSTAGE
-    - addressOrDenom: "0x830B15a1986C75EaF8e048442a13715693CBD8bD"
-      chainName: base
-      connections:
-        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
-        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
-        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
-        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
-      decimals: 18
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPERSTAGE
-    - addressOrDenom: "0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D"
-      chainName: bsc
-      connections:
-        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
-        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
-        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
-        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
-      decimals: 18
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPERSTAGE
-    - addressOrDenom: "0xC10c27afcb915439C27cAe54F5F46Da48cd71190"
-      chainName: ethereum
-      connections:
-        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
-        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
-        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
-        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
-      decimals: 18
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPERSTAGE
-    - addressOrDenom: "0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8"
-      chainName: optimism
-      connections:
-        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
-        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
-        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
-        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
-      decimals: 18
-      name: Hyperlane
-      standard: EvmHypSynthetic
-      symbol: HYPERSTAGE
-INJ/inevm-injective:
-  options:
-    interchainFeeConstants:
-      - addressOrDenom: inj
-        amount: "30000000000000000"
-        destination: inevm
-        origin: injective
-    localFeeConstants:
-      - addressOrDenom: inj
-        amount: "1000000000000000"
-        destination: inevm
-        origin: injective
-  tokens:
-    - addressOrDenom: inj1mv9tjvkaw7x8w8y9vds8pkfq46g2vcfkjehc6k
-      chainName: injective
-      coinGeckoId: injective-protocol
-      connections:
-        - token: ethereum|inevm|0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4
-      decimals: 18
-      logoURI: /deployments/warp_routes/INJ/logo.svg
-      name: Injective Coin
-      standard: CwHypNative
-      symbol: INJ
-    - addressOrDenom: "0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4"
-      chainName: inevm
-      connections:
-        - token: cosmos|injective|inj1mv9tjvkaw7x8w8y9vds8pkfq46g2vcfkjehc6k
-      decimals: 18
-      logoURI: /deployments/warp_routes/INJ/logo.svg
-      name: Injective Coin
-      standard: EvmHypNative
-      symbol: INJ
-INTERN/inevm:
-  tokens:
-    - addressOrDenom: "0xEad0F28bDCEdb19698C4D9f64fd69c70d24ec0D5"
-      chainName: echos
-      collateralAddressOrDenom: "0x7cd386bd75f2a5d7706c39da56bc5d52544b5617"
-      connections:
-        - token: ethereum|inevm|0xFd2fCfee83bDB31c6f9bee4013FAEe0c675f2Dd5
-      decimals: 18
-      logoURI: /deployments/warp_routes/INTERN/logo.png
-      name: Injective Intern
-      standard: EvmHypCollateral
-      symbol: INTERN
-    - addressOrDenom: "0xFd2fCfee83bDB31c6f9bee4013FAEe0c675f2Dd5"
-      chainName: inevm
-      connections:
-        - token: ethereum|echos|0xEad0F28bDCEdb19698C4D9f64fd69c70d24ec0D5
-      decimals: 18
-      logoURI: /deployments/warp_routes/INTERN/logo.png
-      name: Injective Intern
-      standard: EvmHypSynthetic
-      symbol: INTERN
-JC/zeronetwork:
-  tokens:
-    - addressOrDenom: "0xa7ec41980E9871e1FCA7131D05427b15A8c95E9F"
-      chainName: base
-      collateralAddressOrDenom: "0x93aC8f81e799c3b76112A649715DD86CEa655BDF"
-      connections:
-        - token: ethereum|zeronetwork|0x7d6dF201ed9fD35146F89aE98818843eDdadc053
-      decimals: 18
-      logoURI: /deployments/warp_routes/JC/logo.svg
-      name: JACKIE CHAIN
-      standard: EvmHypCollateral
-      symbol: JC
-    - addressOrDenom: "0x7d6dF201ed9fD35146F89aE98818843eDdadc053"
-      chainName: zeronetwork
-      connections:
-        - token: ethereum|base|0xa7ec41980E9871e1FCA7131D05427b15A8c95E9F
-      decimals: 18
-      logoURI: /deployments/warp_routes/JC/logo.svg
-      name: JACKIE CHAIN
-      standard: EvmHypSynthetic
-      symbol: JC
-JitoSOL/eclipsemainnet:
-  tokens:
-    - addressOrDenom: G3hWozA3c4iK5oSX9rTWFFDo5rS9W49bjhWDgg3gDPk8
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: JAh5pFYn1Kbh7kCuqZab8viVFdNgTmpS6hzFstSGNBvG
-      connections:
-        - token: sealevel|solanamainnet|8EMWCPyv6AxgRtMFEZxmxKfhmLmLvi3XbHHendLAUKUF
-      decimals: 9
-      logoURI: /deployments/warp_routes/jitoSOL/logo.svg
-      name: Jito Staked SOL
-      standard: SealevelHypSynthetic
-      symbol: JitoSOL
-    - addressOrDenom: 8EMWCPyv6AxgRtMFEZxmxKfhmLmLvi3XbHHendLAUKUF
-      chainName: solanamainnet
-      coinGeckoId: jito-staked-sol
-      collateralAddressOrDenom: J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn
-      connections:
-        - token: sealevel|eclipsemainnet|G3hWozA3c4iK5oSX9rTWFFDo5rS9W49bjhWDgg3gDPk8
-      decimals: 9
-      logoURI: /deployments/warp_routes/jitoSOL/logo.svg
-      name: Jito Staked SOL
-      standard: SealevelHypCollateral
-      symbol: JitoSOL
-KLC/arbitrum-bsc-kalychain-polygon:
-  tokens:
-    - addressOrDenom: "0x7542c62565f48520A34Cf79884656efDEdD38176"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|bsc|0x02CF1778c07584D92b610E0C03fA285DfD00c354
-        - token: ethereum|kalychain|0x8A1ABbB167b149F2493C8141091028fD812Da6E4
-        - token: ethereum|polygon|0x285C14145EB75A1918B48f93E126139ea1a0f294
-      decimals: 18
-      name: KalyCoin
-      standard: EvmHypSynthetic
-      symbol: KLC
-    - addressOrDenom: "0x02CF1778c07584D92b610E0C03fA285DfD00c354"
-      chainName: bsc
-      connections:
-        - token: ethereum|arbitrum|0x7542c62565f48520A34Cf79884656efDEdD38176
-        - token: ethereum|kalychain|0x8A1ABbB167b149F2493C8141091028fD812Da6E4
-        - token: ethereum|polygon|0x285C14145EB75A1918B48f93E126139ea1a0f294
-      decimals: 18
-      name: KalyCoin
-      standard: EvmHypSynthetic
-      symbol: KLC
-    - addressOrDenom: "0x8A1ABbB167b149F2493C8141091028fD812Da6E4"
-      chainName: kalychain
-      connections:
-        - token: ethereum|arbitrum|0x7542c62565f48520A34Cf79884656efDEdD38176
-        - token: ethereum|bsc|0x02CF1778c07584D92b610E0C03fA285DfD00c354
-        - token: ethereum|polygon|0x285C14145EB75A1918B48f93E126139ea1a0f294
-      decimals: 18
-      name: KalyCoin
-      standard: EvmHypNative
-      symbol: KLC
-    - addressOrDenom: "0x285C14145EB75A1918B48f93E126139ea1a0f294"
-      chainName: polygon
-      connections:
-        - token: ethereum|arbitrum|0x7542c62565f48520A34Cf79884656efDEdD38176
-        - token: ethereum|bsc|0x02CF1778c07584D92b610E0C03fA285DfD00c354
-        - token: ethereum|kalychain|0x8A1ABbB167b149F2493C8141091028fD812Da6E4
-      decimals: 18
-      name: KalyCoin
-      standard: EvmHypSynthetic
-      symbol: KLC
-KYVE/base:
-  tokens:
-    - addressOrDenom: "0xAD13BcE42394Add02e6c215a40e582309B7975C7"
-      chainName: base
-      coinGeckoId: kyve-network
-      connections:
-        - token: cosmosnative|kyve|0x726f757465725f61707000000000000000000000000000010000000000000000
-      decimals: 6
-      logoURI: /deployments/warp_routes/KYVE/logo.svg
-      name: KYVE Network
-      standard: EvmHypSynthetic
-      symbol: KYVE
-    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
-      chainName: kyve
-      coinGeckoId: kyve-network
-      connections:
-        - token: ethereum|base|0xAD13BcE42394Add02e6c215a40e582309B7975C7
-      decimals: 6
-      logoURI: /deployments/warp_routes/KYVE/logo.svg
-      name: KYVE Network
-      standard: CosmosNativeHypCollateral
-      symbol: KYVE
-LESS/celo:
-  tokens:
-    - addressOrDenom: "0xa6D019ea6D132FF091d5bef0B077EC1e045c9461"
-      chainName: arthera
-      collateralAddressOrDenom: "0xdc93F137EdfB14133686e90de9C845A7c7Fca3De"
-      connections:
-        - token: ethereum|celo|0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D
-      decimals: 18
-      logoURI: /deployments/warp_routes/LESS/logo.svg
-      name: Lessgas
-      standard: EvmHypCollateral
-      symbol: LESS
-    - addressOrDenom: "0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D"
-      chainName: celo
-      connections:
-        - token: ethereum|arthera|0xa6D019ea6D132FF091d5bef0B077EC1e045c9461
-      decimals: 18
-      logoURI: /deployments/warp_routes/LESS/logo.svg
-      name: Lessgas
-      standard: EvmHypSynthetic
-      symbol: LESS
-LESS/holesky:
-  tokens:
-    - addressOrDenom: "0x48867511B5c9c6A0E28b36553cd0DC9A0A95A6D2"
-      chainName: artheratestnet
-      collateralAddressOrDenom: "0xcae706200441f8D3f8E880B7C977c57f0c4747d5"
-      connections:
-        - token: ethereum|holesky|0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D
-      decimals: 18
-      logoURI: /deployments/warp_routes/LESS/logo.svg
-      name: Lessgas
-      standard: EvmHypCollateral
-      symbol: LESS
-    - addressOrDenom: "0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D"
+    - addressOrDenom: "0x7f8C02dA6A2f56bD5ae52524717477B7d79F8D5C"
       chainName: holesky
       connections:
-        - token: ethereum|artheratestnet|0x48867511B5c9c6A0E28b36553cd0DC9A0A95A6D2
+        - token: ethereum|piccadilly|0x49195E6251aFa947319F29351be4bDfA617C6720
       decimals: 18
-      logoURI: /deployments/warp_routes/LESS/logo.svg
-      name: Lessgas
-      standard: EvmHypSynthetic
-      symbol: LESS
-LOGX/solanamainnet:
-  tokens:
-    - addressOrDenom: "0x79EdA6DAfB2B9531930CbD9240A73B5eF0e8c9E2"
-      chainName: arbitrum
-      coinGeckoId: logx
-      collateralAddressOrDenom: "0x59062301Fb510F4ea2417B67404CB16D31E604BA"
-      connections:
-        - token: sealevel|solanamainnet|975wpF9KmWTVnh398Qs6VcnDtYZsXVWtKiSkXfWH22GP
-      decimals: 18
-      logoURI: /deployments/warp_routes/LOGX/logo.png
-      name: LogX Network
-      standard: EvmHypCollateral
-      symbol: LOGX
-    - addressOrDenom: 975wpF9KmWTVnh398Qs6VcnDtYZsXVWtKiSkXfWH22GP
-      chainName: solanamainnet
-      collateralAddressOrDenom: 7cHJTPkhnCKesVFijmMXVFVY4HjpkLd9qYjg6neb74yD
-      connections:
-        - token: ethereum|arbitrum|0x79EdA6DAfB2B9531930CbD9240A73B5eF0e8c9E2
-      decimals: 9
-      logoURI: /deployments/warp_routes/LOGX/logo.png
-      name: LogX Network
-      standard: SealevelHypSynthetic
-      symbol: LOGX
-LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon:
-  tokens:
-    - addressOrDenom: "0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047"
-      chainName: bsc
-      connections:
-        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
-      standard: EvmHypSynthetic
-      symbol: LUMIA
-    - addressOrDenom: "0xdD313D475f8A9d81CBE2eA953a357f52e10BA357"
-      chainName: ethereum
-      coinGeckoId: lumia
-      collateralAddressOrDenom: "0xD9343a049D5DBd89CD19DC6BcA8c48fB3a0a42a7"
-      connections:
-        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
-      standard: EvmHypCollateral
-      symbol: LUMIA
-    - addressOrDenom: "0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B"
-      chainName: lumiaprism
-      coinGeckoId: lumia
-      connections:
-        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
       standard: EvmHypNative
-      symbol: LUMIA
-    - addressOrDenom: "0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
-      standard: EvmHypSynthetic
-      symbol: LUMIA
-    - addressOrDenom: "0x02EB40D41676F20eDcF95f9110f00412ca53a85F"
-      chainName: avalanche
-      connections:
-        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
-      standard: EvmHypSynthetic
-      symbol: LUMIA
-    - addressOrDenom: "0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4"
-      chainName: base
-      connections:
-        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
-      standard: EvmHypSynthetic
-      symbol: LUMIA
-    - addressOrDenom: "0x978B9dE4D8A41b023408383e3B4F760932AaDdc1"
-      chainName: optimism
-      connections:
-        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
-      standard: EvmHypSynthetic
-      symbol: LUMIA
-    - addressOrDenom: "0x72749806df5A6BBb72032039bbE9a3f1b17D1936"
-      chainName: polygon
-      connections:
-        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
-        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
-        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
-        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
-        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
-        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
-        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
-      decimals: 18
-      logoURI: /deployments/warp_routes/LUMIA/logo.svg
-      name: Lumia Token
-      standard: EvmHypSynthetic
-      symbol: LUMIA
-MAGIC/arbitrum-treasure:
-  tokens:
-    - addressOrDenom: "0x240d04a70B038369C8DF703B78B3b47332EeE116"
-      chainName: arbitrum
-      coinGeckoId: magic
-      collateralAddressOrDenom: "0x539bdE0d7Dbd336b79148AA742883198BBF60342"
-      connections:
-        - token: ethereum|treasure|0x01c94f24F8D72BB9C3f61c4ED0b9b86BfC23BADd
-      decimals: 18
-      name: MAGIC
-      standard: EvmHypCollateral
-      symbol: MAGIC
-    - addressOrDenom: "0x01c94f24F8D72BB9C3f61c4ED0b9b86BfC23BADd"
-      chainName: treasure
-      connections:
-        - token: ethereum|arbitrum|0x240d04a70B038369C8DF703B78B3b47332EeE116
-      decimals: 18
-      name: MAGIC
-      standard: EvmHypNative
-      symbol: MAGIC
-MEW/soon:
-  tokens:
-    - addressOrDenom: 9JcBcd9bRDQjRtkZq7sWfNF4DRFRA24KsuhV9rTemUgC
-      chainName: soon
-      collateralAddressOrDenom: GvW8my8MggjKf8m3LAds4bpL4GgQRmRaDhbWUon7ZzF3
-      connections:
-        - token: sealevel|solanamainnet|BEzLRBDBJyRrzZN2CfGJB3bedBj3HwHqj6MB8BQn1mdL
-      decimals: 5
-      logoURI: /deployments/warp_routes/MEW/logo.svg
-      name: MEW
-      standard: SealevelHypSynthetic
-      symbol: MEW
-    - addressOrDenom: BEzLRBDBJyRrzZN2CfGJB3bedBj3HwHqj6MB8BQn1mdL
-      chainName: solanamainnet
-      coinGeckoId: mew
-      collateralAddressOrDenom: MEW1gQWJ3nEXg2qgERiKu7FAFj79PHvQVREQUzScPP5
-      connections:
-        - token: sealevel|soon|9JcBcd9bRDQjRtkZq7sWfNF4DRFRA24KsuhV9rTemUgC
-      decimals: 5
-      logoURI: /deployments/warp_routes/MEW/logo.svg
-      name: MEW
-      standard: SealevelHypCollateral
-      symbol: MEW
-MIGGLES/zeronetwork:
-  tokens:
-    - addressOrDenom: "0x9C417D68dE6Acb6a9b0fBeD56767F1f3548A48a1"
-      chainName: base
-      coinGeckoId: mister-miggles
-      collateralAddressOrDenom: "0xB1a03EdA10342529bBF8EB700a06C60441fEf25d"
-      connections:
-        - token: ethereum|zeronetwork|0xEE7bF7bB7575163edd413e36E9f06a124b51B9fa
-      decimals: 18
-      logoURI: /deployments/warp_routes/MIGGLES/logo.svg
-      name: Mister Miggles
-      standard: EvmHypCollateral
-      symbol: MIGGLES
-    - addressOrDenom: "0xEE7bF7bB7575163edd413e36E9f06a124b51B9fa"
-      chainName: zeronetwork
-      connections:
-        - token: ethereum|base|0x9C417D68dE6Acb6a9b0fBeD56767F1f3548A48a1
-      decimals: 18
-      logoURI: /deployments/warp_routes/MIGGLES/logo.svg
-      name: Mister Miggles
-      standard: EvmHypSynthetic
-      symbol: MIGGLES
-MILK/bsc:
-  tokens:
-    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
-      chainName: milkyway
-      coinGeckoId: milkyway-2
-      connections:
-        - token: ethereum|bsc|0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD
-      decimals: 6
-      logoURI: /deployments/warp_routes/MILK/logo.svg
-      name: MilkyWay
-      standard: CosmosNativeHypCollateral
-      symbol: MILK
-    - addressOrDenom: "0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD"
-      chainName: bsc
-      connections:
-        - token: cosmosnative|milkyway|0x726f757465725f61707000000000000000000000000000010000000000000000
-      decimals: 6
-      logoURI: /deployments/warp_routes/MILK/logo.svg
-      name: MilkyWay
-      standard: EvmHypSynthetic
-      symbol: MILK
-MINT/solanamainnet:
-  tokens:
-    - addressOrDenom: "0x787561C5131d9328a28Ef810867299176a5b66C4"
-      chainName: mint
-      coinGeckoId: usdc
-      collateralAddressOrDenom: "0x8511138208529fe1b9a37b863c7EEE3Fe234b7Ab"
-      connections:
-        - token: sealevel|solanamainnet|DTp6yLfHyGo46Zu7xrbXwUF3YZSaYV2W7UhQb8q9QN5Q
-      decimals: 18
-      logoURI: /deployments/warp_routes/MINT/logo.svg
-      name: Mint
-      standard: EvmHypCollateral
-      symbol: MINT
-    - addressOrDenom: DTp6yLfHyGo46Zu7xrbXwUF3YZSaYV2W7UhQb8q9QN5Q
-      chainName: solanamainnet
-      collateralAddressOrDenom: HwmvBfZP6SUgaQSYtLicvLqY4UepKw2J1LLkqFxiLB7L
-      connections:
-        - token: ethereum|mint|0x787561C5131d9328a28Ef810867299176a5b66C4
-      decimals: 9
-      logoURI: /deployments/warp_routes/MINT/logo.svg
-      name: Mint
-      standard: SealevelHypSynthetic
-      symbol: MINT
-MIRAI/abstract-bsc-solanamainnet:
-  tokens:
-    - addressOrDenom: "0xbCdA9Ae6A148Bc4fb411979fFA883c9D1DF08F43"
-      chainName: abstract
-      connections:
-        - token: ethereum|bsc|0xcb508877ffe5a085B2474641dD3B28F8Bc22A57c
-        - token: sealevel|solanamainnet|27CK2NMbkSTTddgbBDvujccpqNrfGztr9WggXusNmnD1
-      decimals: 6
-      logoURI: /deployments/warp_routes/MIRAI/logo.jpg
-      name: Project Mirai
-      standard: EvmHypSynthetic
-      symbol: MIRAI
-    - addressOrDenom: "0xcb508877ffe5a085B2474641dD3B28F8Bc22A57c"
-      chainName: bsc
-      connections:
-        - token: ethereum|abstract|0xbCdA9Ae6A148Bc4fb411979fFA883c9D1DF08F43
-        - token: sealevel|solanamainnet|27CK2NMbkSTTddgbBDvujccpqNrfGztr9WggXusNmnD1
-      decimals: 6
-      logoURI: /deployments/warp_routes/MIRAI/logo.jpg
-      name: Project Mirai
-      standard: EvmHypSynthetic
-      symbol: MIRAI
-    - addressOrDenom: 27CK2NMbkSTTddgbBDvujccpqNrfGztr9WggXusNmnD1
-      chainName: solanamainnet
-      collateralAddressOrDenom: 5evN2exivZXJfLaA1KhHfiJKWfwH8znqyH36w1SFz89Y
-      connections:
-        - token: ethereum|abstract|0xbCdA9Ae6A148Bc4fb411979fFA883c9D1DF08F43
-        - token: ethereum|bsc|0xcb508877ffe5a085B2474641dD3B28F8Bc22A57c
-      decimals: 6
-      logoURI: /deployments/warp_routes/MIRAI/logo.jpg
-      name: Project Mirai
-      standard: SealevelHypCollateral
-      symbol: MIRAI
-NTN/holesky:
-  tokens:
-    - addressOrDenom: "0xdF73856d44C1f7b3B14Fd0DaD8B0792fCf1c3f68"
-      chainName: holesky
-      connections:
-        - token: ethereum|piccadilly|0xB671973E737c1793eE5AbCaA97769d7a81445704
-      decimals: 18
-      name: Newton
-      standard: EvmHypSynthetic
-      symbol: NTN
-    - addressOrDenom: "0xB671973E737c1793eE5AbCaA97769d7a81445704"
+      symbol: ETH
+    - addressOrDenom: "0x49195E6251aFa947319F29351be4bDfA617C6720"
       chainName: piccadilly
-      collateralAddressOrDenom: "0xBd770416a3345F91E4B34576cb804a576fa48EB1"
       connections:
-        - token: ethereum|holesky|0xdF73856d44C1f7b3B14Fd0DaD8B0792fCf1c3f68
+        - token: ethereum|holesky|0x7f8C02dA6A2f56bD5ae52524717477B7d79F8D5C
       decimals: 18
-      name: Newton
-      standard: EvmHypCollateral
-      symbol: NTN
-OORT/bsc-ethereum-oortmainnet:
-  tokens:
-    - addressOrDenom: "0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B"
-      chainName: bsc
-      collateralAddressOrDenom: "0x5651fA7a726B9Ec0cAd00Ee140179912B6E73599"
-      connections:
-        - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
-        - token: ethereum|ethereum|0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697
-      decimals: 18
-      logoURI: /deployments/warp_routes/OORT/logo.svg
-      name: OORT
-      standard: EvmHypCollateral
-      symbol: OORT
-    - addressOrDenom: "0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B"
-      chainName: oortmainnet
-      connections:
-        - token: ethereum|bsc|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
-        - token: ethereum|ethereum|0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697
-      decimals: 18
-      logoURI: /deployments/warp_routes/OORT/logo.svg
-      name: OORT
-      standard: EvmHypNative
-      symbol: OORT
-    - addressOrDenom: "0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x5651fA7a726B9Ec0cAd00Ee140179912B6E73599"
-      connections:
-        - token: ethereum|bsc|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
-        - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
-      decimals: 18
-      logoURI: /deployments/warp_routes/OORT/logo.svg
-      name: OORT
-      standard: EvmHypCollateral
-      symbol: OORT
-OP/superseed:
-  tokens:
-    - addressOrDenom: "0x0Ea3C23A4dC198c289D5443ac302335aBc86E6b1"
-      chainName: optimism
-      coinGeckoId: optimism
-      collateralAddressOrDenom: "0x4200000000000000000000000000000000000042"
-      connections:
-        - token: ethereum|superseed|0x4e128A1b613A9C9Ecf650FeE461c353612559fcf
-      decimals: 18
-      logoURI: /deployments/warp_routes/OP/logo.svg
-      name: Optimism
-      standard: EvmHypCollateral
-      symbol: OP
-    - addressOrDenom: "0x4e128A1b613A9C9Ecf650FeE461c353612559fcf"
-      chainName: superseed
-      connections:
-        - token: ethereum|optimism|0x0Ea3C23A4dC198c289D5443ac302335aBc86E6b1
-      decimals: 18
-      logoURI: /deployments/warp_routes/OP/logo.svg
-      name: Optimism
-      standard: EvmHypSynthetic
-      symbol: OP
-ORCA/eclipsemainnet:
-  tokens:
-    - addressOrDenom: 8CvWJS7SPtauAXinJUURkBDLsGUXWiiTdENkEFUPjQ9j
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: 2tGbYEm4nuPFyS6zjDTELzEhvVKizgKewi6xT7AaSKzn
-      connections:
-        - token: sealevel|solanamainnet|8acihSm2QTGswniKgdgr4JBvJihZ1cakfvbqWCPBLoSp
-      decimals: 6
-      logoURI: /deployments/warp_routes/ORCA/logo.svg
-      name: Orca
-      standard: SealevelHypSynthetic
-      symbol: ORCA
-    - addressOrDenom: 8acihSm2QTGswniKgdgr4JBvJihZ1cakfvbqWCPBLoSp
-      chainName: solanamainnet
-      coinGeckoId: orca
-      collateralAddressOrDenom: orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE
-      connections:
-        - token: sealevel|eclipsemainnet|8CvWJS7SPtauAXinJUURkBDLsGUXWiiTdENkEFUPjQ9j
-      decimals: 6
-      logoURI: /deployments/warp_routes/ORCA/logo.svg
-      name: Orca
-      standard: SealevelHypCollateral
-      symbol: ORCA
-PAXG/arbitrum:
-  tokens:
-    - addressOrDenom: "0x68A593C7F42e0f6616F9356dCb1CFd130e4e7694"
-      chainName: ethereum
-      coinGeckoId: pax-gold
-      collateralAddressOrDenom: "0x45804880de22913dafe09f4980848ece6ecbaf78"
-      connections:
-        - token: ethereum|arbitrum|0xE7eFb127249Ec17B484B5Bb0Ea5f79A14A6d0721
-      decimals: 18
-      logoURI: /deployments/warp_routes/PAXG/logo.svg
-      name: Paxos Gold
-      standard: EvmHypCollateral
-      symbol: PAXG
-    - addressOrDenom: "0xE7eFb127249Ec17B484B5Bb0Ea5f79A14A6d0721"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|ethereum|0x68A593C7F42e0f6616F9356dCb1CFd130e4e7694
-      decimals: 18
-      logoURI: /deployments/warp_routes/PAXG/logo.svg
-      name: Paxos Gold
-      standard: EvmHypSynthetic
-      symbol: PAXG
-PENGU/apechain:
-  tokens:
-    - addressOrDenom: "0x9Eaf39A97d56119236a356225B339fE7383549B3"
-      chainName: apechain
-      coinGeckoId: pudgy-penguins
-      connections:
-        - token: sealevel|solanamainnet|C7a43nYF9atxgJhfqoP2vc95exJcEQhvJqYbtCNkDf8f
-      decimals: 6
-      logoURI: /deployments/warp_routes/PENGU/logo.svg
-      name: Pudgy Penguins
-      standard: EvmHypSynthetic
-      symbol: PENGU
-    - addressOrDenom: C7a43nYF9atxgJhfqoP2vc95exJcEQhvJqYbtCNkDf8f
-      chainName: solanamainnet
-      coinGeckoId: pudgy-penguins
-      collateralAddressOrDenom: 2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv
-      connections:
-        - token: ethereum|apechain|0x9Eaf39A97d56119236a356225B339fE7383549B3
-      decimals: 6
-      logoURI: /deployments/warp_routes/PENGU/logo.svg
-      name: Pudgy Penguins
-      standard: SealevelHypCollateral
-      symbol: PENGU
-PEPE/apechain:
-  tokens:
-    - addressOrDenom: "0x46C41c67471bF859A4453512a7dc1B2431b45993"
-      chainName: apechain
-      connections:
-        - token: ethereum|arbitrum|0x46C41c67471bF859A4453512a7dc1B2431b45993
-      decimals: 18
-      logoURI: /deployments/warp_routes/PEPE/logo.svg
-      name: Pepe
-      standard: EvmHypSynthetic
-      symbol: PEPE
-    - addressOrDenom: "0x46C41c67471bF859A4453512a7dc1B2431b45993"
-      chainName: arbitrum
-      coinGeckoId: pepe
-      collateralAddressOrDenom: "0x25d887ce7a35172c62febfd67a1856f20faebb00"
-      connections:
-        - token: ethereum|apechain|0x46C41c67471bF859A4453512a7dc1B2431b45993
-      decimals: 18
-      logoURI: /deployments/warp_routes/PEPE/logo.svg
-      name: Pepe
-      standard: EvmHypCollateral
-      symbol: PEPE
-PNDR/bsc-ethereum-lumiaprism:
-  tokens:
-    - addressOrDenom: "0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a"
-      chainName: ethereum
-      coinGeckoId: ponder-one
-      collateralAddressOrDenom: "0x73624d2dEF952C77a1f3B5AD995eef53E49639EC"
-      connections:
-        - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
-        - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
-      decimals: 18
-      logoURI: /deployments/warp_routes/PNDR/logo.jpeg
-      name: Ponder
-      standard: EvmHypCollateral
-      symbol: PNDR
-    - addressOrDenom: "0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1"
-      chainName: bsc
-      connections:
-        - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
-        - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
-      decimals: 18
-      logoURI: /deployments/warp_routes/PNDR/logo.jpeg
-      name: Ponder
-      standard: EvmHypSynthetic
-      symbol: PNDR
-    - addressOrDenom: "0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1"
-      chainName: lumiaprism
-      connections:
-        - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
-        - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
-      decimals: 18
-      logoURI: /deployments/warp_routes/PNDR/logo.jpeg
-      name: Ponder
-      standard: EvmHypSynthetic
-      symbol: PNDR
-POL/kalychain:
-  tokens:
-    - addressOrDenom: "0x706C9a63d7c8b7Aaf85DDCca52654645f470E8Ac"
-      chainName: kalychain
-      connections:
-        - token: ethereum|polygon|0x0a6364152EA7a487C697a36Eb2522f48bC62fB4c
-      decimals: 18
-      name: Polygon Ecosystem Token
-      standard: EvmHypSynthetic
-      symbol: POL
-    - addressOrDenom: "0x0a6364152EA7a487C697a36Eb2522f48bC62fB4c"
-      chainName: polygon
-      connections:
-        - token: ethereum|kalychain|0x706C9a63d7c8b7Aaf85DDCca52654645f470E8Ac
-      decimals: 18
-      name: Polygon Ecosystem Token
-      standard: EvmHypNative
-      symbol: POL
-POL/zeronetwork:
-  tokens:
-    - addressOrDenom: "0x76Af114f7Ebe96C02a3e4AB10f1511a7A66057A1"
-      chainName: polygon
-      coinGeckoId: polygon-ecosystem-token
-      connections:
-        - token: ethereum|zeronetwork|0x3d7dBc3dab88C0e3c3Dcb6901a6163bb02417e6B
-      decimals: 18
-      logoURI: /deployments/warp_routes/POL/logo.svg
-      name: Polygon Ecosystem Token
-      standard: EvmHypNative
-      symbol: POL
-    - addressOrDenom: "0x3d7dBc3dab88C0e3c3Dcb6901a6163bb02417e6B"
-      chainName: zeronetwork
-      connections:
-        - token: ethereum|polygon|0x76Af114f7Ebe96C02a3e4AB10f1511a7A66057A1
-      decimals: 18
-      logoURI: /deployments/warp_routes/POL/logo.svg
-      name: Polygon Ecosystem Token
-      standard: EvmHypSynthetic
-      symbol: POL
-POPCAT/soon:
-  tokens:
-    - addressOrDenom: 2CPGmQCNdGrh45n6BgTG98G7AkQfEKPZCcYW2reju2kn
-      chainName: soon
-      collateralAddressOrDenom: Hxf93wyFCRi4Je5R1dYc4xAtPug48YdC6vuorUJFW5dv
-      connections:
-        - token: sealevel|solanamainnet|BSrwJNiHM88XRYX93CRXGSTR4GfnZfxn3kTa4rvanPKr
-      decimals: 9
-      logoURI: /deployments/warp_routes/POPCAT/logo.svg
-      name: POPCAT
-      standard: SealevelHypSynthetic
-      symbol: POPCAT
-    - addressOrDenom: BSrwJNiHM88XRYX93CRXGSTR4GfnZfxn3kTa4rvanPKr
-      chainName: solanamainnet
-      coinGeckoId: popcat
-      collateralAddressOrDenom: 7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr
-      connections:
-        - token: sealevel|soon|2CPGmQCNdGrh45n6BgTG98G7AkQfEKPZCcYW2reju2kn
-      decimals: 9
-      logoURI: /deployments/warp_routes/POPCAT/logo.svg
-      name: POPCAT
-      standard: SealevelHypCollateral
-      symbol: POPCAT
-PROM/polygon:
-  tokens:
-    - addressOrDenom: "0x700b9322F6Cce0c8EFF4754bE9AcE88Ce6582821"
-      chainName: bsc
-      collateralAddressOrDenom: "0xaf53d56ff99f1322515e54fdde93ff8b3b7dafd5"
-      connections:
-        - token: ethereum|polygon|0x23Ae469604E3c1b581ADabf07c035472FbdB5Ee1
-        - token: ethereum|prom|0xc1f4b896B94bd57dEfB7b6e630Bb91995b86CbAC
-      decimals: 18
-      logoURI: /deployments/warp_routes/PROM/logo.svg
-      name: Prometeus
-      standard: EvmHypCollateral
-      symbol: PROM
-    - addressOrDenom: "0x23Ae469604E3c1b581ADabf07c035472FbdB5Ee1"
-      chainName: polygon
-      connections:
-        - token: ethereum|bsc|0x700b9322F6Cce0c8EFF4754bE9AcE88Ce6582821
-        - token: ethereum|prom|0xc1f4b896B94bd57dEfB7b6e630Bb91995b86CbAC
-      decimals: 18
-      logoURI: /deployments/warp_routes/PROM/logo.svg
-      name: Prometeus
-      standard: EvmHypSynthetic
-      symbol: PROM
-    - addressOrDenom: "0xc1f4b896B94bd57dEfB7b6e630Bb91995b86CbAC"
-      chainName: prom
-      connections:
-        - token: ethereum|bsc|0x700b9322F6Cce0c8EFF4754bE9AcE88Ce6582821
-        - token: ethereum|polygon|0x23Ae469604E3c1b581ADabf07c035472FbdB5Ee1
-      decimals: 18
-      logoURI: /deployments/warp_routes/PROM/logo.svg
-      name: Prometeus
-      standard: EvmHypNative
-      symbol: PROM
-PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit:
-  tokens:
-    - addressOrDenom: "0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x9E1a2b6de93164b77Fc5CA11e647EECB38BB463D"
-      connections:
-        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
-        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
-        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
-        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
-      decimals: 18
-      name: Renzo Restaked LST Stage
-      standard: EvmHypXERC20Lockbox
-      symbol: PZETHSTAGE
-    - addressOrDenom: "0xCBC928268870F216A510c207C456544660ec8566"
-      chainName: swell
-      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
-      connections:
-        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
-        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
-        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
-        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
-      decimals: 18
-      name: Renzo Restaked LST Stage
-      standard: EvmHypXERC20
-      symbol: PZETHSTAGE
-    - addressOrDenom: "0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6"
-      chainName: zircuit
-      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
-      connections:
-        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
-        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
-        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
-        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
-      decimals: 18
-      name: Renzo Restaked LST Stage
-      standard: EvmHypXERC20
-      symbol: PZETHSTAGE
-    - addressOrDenom: "0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74"
-      chainName: berachain
-      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
-      connections:
-        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
-        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
-        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
-        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
-      decimals: 18
-      name: Renzo Restaked LST Stage
-      standard: EvmHypXERC20
-      symbol: PZETHSTAGE
-    - addressOrDenom: "0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4"
-      chainName: unichain
-      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
-      connections:
-        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
-        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
-        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
-        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
-      decimals: 18
-      name: Renzo Restaked LST Stage
-      standard: EvmHypXERC20
-      symbol: PZETHSTAGE
-Pnut/soon:
-  tokens:
-    - addressOrDenom: 5WHM6rm9HpFqNY8hye9ZY9vrgCCM7M5YnCeKcq29FpXz
-      chainName: soon
-      collateralAddressOrDenom: HHJDLRYkp2SPdo2Wv7F62ccKeqVcgEzowaEctUP2r2Cu
-      connections:
-        - token: sealevel|solanamainnet|J8fVLBiLMniYxaBYhfpGmqDpf2qtgaiDAPuznfRMhLs6
-      decimals: 6
-      logoURI: /deployments/warp_routes/Pnut/logo.svg
-      name: Peanut the Squirrel
-      standard: SealevelHypSynthetic
-      symbol: Pnut
-    - addressOrDenom: J8fVLBiLMniYxaBYhfpGmqDpf2qtgaiDAPuznfRMhLs6
-      chainName: solanamainnet
-      coinGeckoId: Pnut
-      collateralAddressOrDenom: 2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump
-      connections:
-        - token: sealevel|soon|5WHM6rm9HpFqNY8hye9ZY9vrgCCM7M5YnCeKcq29FpXz
-      decimals: 6
-      logoURI: /deployments/warp_routes/Pnut/logo.svg
-      name: Peanut the Squirrel
-      standard: SealevelHypCollateral
-      symbol: Pnut
-RDO/bsc:
-  tokens:
-    - addressOrDenom: "0xd86E6ef14b96D942eF0AbF0720C549197EA8c528"
-      chainName: ethereum
-      coinGeckoId: reddio
-      collateralAddressOrDenom: "0x57240C3E140f98abe315CA8E0213c7a77F34A334"
-      connections:
-        - token: ethereum|bsc|0xd86E6ef14b96D942eF0AbF0720C549197EA8c528
-      decimals: 18
-      logoURI: /deployments/warp_routes/RDO/logo.svg
-      name: RDO Token
-      standard: EvmHypCollateral
-      symbol: RDO
-    - addressOrDenom: "0xd86E6ef14b96D942eF0AbF0720C549197EA8c528"
-      chainName: bsc
-      coinGeckoId: reddio
-      connections:
-        - token: ethereum|ethereum|0xd86E6ef14b96D942eF0AbF0720C549197EA8c528
-      decimals: 18
-      logoURI: /deployments/warp_routes/RDO/logo.svg
-      name: RDO Token
-      standard: EvmHypSynthetic
-      symbol: RDO
-REZ/base-ethereum-unichain:
-  tokens:
-    - addressOrDenom: "0xD23f3de954eeF59752DF0ca614403B1377F9302A"
-      chainName: base
-      collateralAddressOrDenom: "0x19c5C2316171A2cff8773435a9A5F3f0e3eaB14B"
-      connections:
-        - token: ethereum|ethereum|0x9c48903a8b95d7a208dC45a1905da271108dD56a
-        - token: ethereum|unichain|0x644bD9f172a890d769F7A82D533f799051E1A07f
-      decimals: 18
-      name: REZ
-      standard: EvmHypXERC20
-      symbol: REZ
-    - addressOrDenom: "0x9c48903a8b95d7a208dC45a1905da271108dD56a"
-      chainName: ethereum
-      collateralAddressOrDenom: "0xc693943eACc1Cb74b748Cf1B953946970b239279"
-      connections:
-        - token: ethereum|base|0xD23f3de954eeF59752DF0ca614403B1377F9302A
-        - token: ethereum|unichain|0x644bD9f172a890d769F7A82D533f799051E1A07f
-      decimals: 18
-      name: REZ
-      standard: EvmHypXERC20Lockbox
-      symbol: REZ
-    - addressOrDenom: "0x644bD9f172a890d769F7A82D533f799051E1A07f"
-      chainName: unichain
-      collateralAddressOrDenom: "0x19c5C2316171A2cff8773435a9A5F3f0e3eaB14B"
-      connections:
-        - token: ethereum|base|0xD23f3de954eeF59752DF0ca614403B1377F9302A
-        - token: ethereum|ethereum|0x9c48903a8b95d7a208dC45a1905da271108dD56a
-      decimals: 18
-      name: REZ
-      standard: EvmHypXERC20
-      symbol: REZ
-Re7LRT/zircuit:
-  tokens:
-    - addressOrDenom: "0x7D77702f1c7A1662923FD654f904127988Caa3fD"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x84631c0d0081FDe56DeB72F6DE77abBbF6A9f93a"
-      connections:
-        - token: ethereum|zircuit|0x4d08A785212Ce848cFc35e198E86F5ebcb388c86
-      decimals: 18
-      name: Re7 Labs LRT
-      standard: EvmHypCollateral
-      symbol: Re7LRT
-    - addressOrDenom: "0x4d08A785212Ce848cFc35e198E86F5ebcb388c86"
-      chainName: zircuit
-      connections:
-        - token: ethereum|ethereum|0x7D77702f1c7A1662923FD654f904127988Caa3fD
-      decimals: 18
-      name: Re7 Labs LRT
-      standard: EvmHypSynthetic
-      symbol: Re7LRT
-SMOL/arbitrum-ethereum-solanamainnet-treasure:
-  tokens:
-    - addressOrDenom: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
-      chainName: arbitrum
-      collateralAddressOrDenom: "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5"
-      connections:
-        - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
-        - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
-      decimals: 18
-      logoURI: /deployments/warp_routes/SMOL/logo.svg
-      name: SMOL
-      standard: EvmHypCollateral
-      symbol: SMOL
-    - addressOrDenom: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
-      chainName: ethereum
-      connections:
-        - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
-        - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
-        - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
-      decimals: 18
-      logoURI: /deployments/warp_routes/SMOL/logo.svg
-      name: SMOL
-      standard: EvmHypSynthetic
-      symbol: SMOL
-    - addressOrDenom: 7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
-      chainName: solanamainnet
-      collateralAddressOrDenom: 5KHQeeQvM4qBtmX3WnaCMGpM3Th7jYpqcHf3c6qzPodM
-      connections:
-        - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
-        - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
-      decimals: 9
-      logoURI: /deployments/warp_routes/SMOL/logo.svg
-      name: SMOL
-      standard: SealevelHypSynthetic
-      symbol: SMOL
-    - addressOrDenom: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
-      chainName: treasure
-      connections:
-        - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
-        - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
-        - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
-      decimals: 18
-      logoURI: /deployments/warp_routes/SMOL/logo.svg
-      name: SMOL
-      standard: EvmHypSynthetic
-      symbol: SMOL
-SOL/apechain:
-  tokens:
-    - addressOrDenom: "0x16eE589E237f2c70aBE91F87a6C0712C836941bb"
-      chainName: apechain
-      connections:
-        - token: sealevel|solanamainnet|BwD1LvMvofVZAAWyG318S17zqKMXXeeNeVHQimaWG6qt
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: EvmHypSynthetic
-      symbol: SOL
-    - addressOrDenom: BwD1LvMvofVZAAWyG318S17zqKMXXeeNeVHQimaWG6qt
-      chainName: solanamainnet
-      coinGeckoId: solana
-      connections:
-        - token: ethereum|apechain|0x16eE589E237f2c70aBE91F87a6C0712C836941bb
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypNative
-      symbol: SOL
-SOL/eclipsemainnet:
-  tokens:
-    - addressOrDenom: FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: BeRUj3h7BqkbdfFU7FBNYbodgf8GCHodzKvF9aVjNNfL
-      connections:
-        - token: sealevel|solanamainnet|8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypSynthetic
-      symbol: SOL
-    - addressOrDenom: 8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
-      chainName: solanamainnet
-      coinGeckoId: solana
-      connections:
-        - token: sealevel|eclipsemainnet|FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypNative
-      symbol: SOL
-SOL/hyperevm:
-  tokens:
-    - addressOrDenom: "0x96029bcf706FAC4176492F4a05f63f7d23cE78fb"
-      chainName: hyperevm
-      connections:
-        - token: sealevel|solanamainnet|4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: EvmHypSynthetic
-      symbol: SOL
-    - addressOrDenom: 4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
-      chainName: solanamainnet
-      coinGeckoId: solana
-      connections:
-        - token: ethereum|hyperevm|0x96029bcf706FAC4176492F4a05f63f7d23cE78fb
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypNative
-      symbol: SOL
-SOL/solanamainnet-sonicsvm:
-  tokens:
-    - addressOrDenom: 7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY
-      chainName: sonicsvm
-      connections:
-        - token: sealevel|solanamainnet|BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypNative
-      symbol: SOL
-    - addressOrDenom: BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
-      chainName: solanamainnet
-      coinGeckoId: solana
-      connections:
-        - token: sealevel|sonicsvm|7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypNative
-      symbol: SOL
-SOL/soon:
-  tokens:
-    - addressOrDenom: 6SGK4PnHefm4egyUUeVro8wKBkuPexVehsjuUK8auJ8b
-      chainName: soon
-      collateralAddressOrDenom: ERFzpDteGNo8LTDKW1WwVGrkRMmA2y9WZHXNHxMA6BSV
-      connections:
-        - token: sealevel|solanamainnet|GPFwRQ5Cw6dTWnmappUKJt76DD8yawxPx28QugfCaGaA
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypSynthetic
-      symbol: SOL
-    - addressOrDenom: GPFwRQ5Cw6dTWnmappUKJt76DD8yawxPx28QugfCaGaA
-      chainName: solanamainnet
-      coinGeckoId: solana
-      connections:
-        - token: sealevel|soon|6SGK4PnHefm4egyUUeVro8wKBkuPexVehsjuUK8auJ8b
-      decimals: 9
-      logoURI: /deployments/warp_routes/SOL/logo.svg
-      name: Solana
-      standard: SealevelHypNative
-      symbol: SOL
-SONIC/sonicsvm:
-  tokens:
-    - addressOrDenom: 2e6hyJbUpbhqbJzorDZ1m4QVTj5oPhsn2H3KBaMFVXAz
-      chainName: solanamainnet
-      coinGeckoId: sonic-svm
-      collateralAddressOrDenom: SonicxvLud67EceaEzCLRnMTBqzYUUYNr93DBkBdDES
-      connections:
-        - token: sealevel|sonicsvm|5sPRiRLfmohVmtkgiGV6scrzy2C6qEZRGRUiePZf1Fs2
-      decimals: 9
-      logoURI: /deployments/warp_routes/SONIC/logo.svg
-      name: Sonic SVM
-      standard: SealevelHypCollateral
-      symbol: SONIC
-    - addressOrDenom: 5sPRiRLfmohVmtkgiGV6scrzy2C6qEZRGRUiePZf1Fs2
-      chainName: sonicsvm
-      collateralAddressOrDenom: mrujEYaN1oyQXDHeYNxBYpxWKVkQ2XsGxfznpifu4aL
-      connections:
-        - token: sealevel|solanamainnet|2e6hyJbUpbhqbJzorDZ1m4QVTj5oPhsn2H3KBaMFVXAz
-      decimals: 9
-      logoURI: /deployments/warp_routes/SONIC/logo.svg
-      name: Sonic SVM
-      standard: SealevelHypSynthetic
-      symbol: SONIC
-SPICE/sonicsvm:
-  tokens:
-    - addressOrDenom: 7XYiQwKkHDgALca91sCj7sRBQbgDNB9zANX11UzP3Wt8
-      chainName: solanamainnet
-      coinGeckoId: spice
-      collateralAddressOrDenom: SPQkEcsdALLLn4MqCb3XH64hYTmdD4fZZk9CF5LiQV8
-      connections:
-        - token: sealevel|sonicsvm|CDCcn2156JBN5RvUXKvgpxzk9Yt8NbcG5DqGnoKzQu21
-      decimals: 6
-      logoURI: /deployments/warp_routes/SPICE/logo.svg
-      name: SPICE
-      standard: SealevelHypCollateral
-      symbol: SPICE
-    - addressOrDenom: CDCcn2156JBN5RvUXKvgpxzk9Yt8NbcG5DqGnoKzQu21
-      chainName: sonicsvm
-      collateralAddressOrDenom: 6sBvZHs9u5HRt25c3bQKLij8gYPheFJCaKnSagz1Nn9N
-      connections:
-        - token: sealevel|solanamainnet|7XYiQwKkHDgALca91sCj7sRBQbgDNB9zANX11UzP3Wt8
-      decimals: 6
-      logoURI: /deployments/warp_routes/SPICE/logo.svg
-      name: SPICE
-      standard: SealevelHypSynthetic
-      symbol: SPICE
-SPORE/soon:
-  tokens:
-    - addressOrDenom: JDnjXhoucA9HwTk1s7piyoCLvwQSKdnaRitdkpXsRgtj
-      chainName: soon
-      collateralAddressOrDenom: 4zCFfTv26uUgo9APJcbCuGEwx5hhyb9HMgbM35gnsQ6B
-      connections:
-        - token: sealevel|solanamainnet|34V29ar8oahnZVnnQqEfd9pUE3MBrAxpgMtQf1Xccs1A
-      decimals: 6
-      logoURI: /deployments/warp_routes/SPORE/logo.svg
-      name: SPORE
-      standard: SealevelHypSynthetic
-      symbol: SPORE
-    - addressOrDenom: 34V29ar8oahnZVnnQqEfd9pUE3MBrAxpgMtQf1Xccs1A
-      chainName: solanamainnet
-      coinGeckoId: spore-2
-      collateralAddressOrDenom: 8bdhP1UQMevciC9oJ7NrvgDfoW8XPXPfbkkm6vKtMS7N
-      connections:
-        - token: sealevel|soon|JDnjXhoucA9HwTk1s7piyoCLvwQSKdnaRitdkpXsRgtj
-      decimals: 6
-      logoURI: /deployments/warp_routes/SPORE/logo.svg
-      name: SPORE
-      standard: SealevelHypCollateral
-      symbol: SPORE
-SUPR/base-ethereum-ink-optimism-superseed:
-  tokens:
-    - addressOrDenom: "0x458BDDd0793fe4f70912535f172466a5473f2e77"
-      chainName: base
-      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
-      connections:
-        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
-        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
-        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
-        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
-      decimals: 18
-      logoURI: /deployments/warp_routes/SUPR/logo.svg
-      name: Superseed
-      standard: EvmHypXERC20
-      symbol: SUPR
-    - addressOrDenom: "0xbc808c98beA0a097346273A9Fd7a5B231fc2d889"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
-      connections:
-        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
-        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
-        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
-        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
-      decimals: 18
-      logoURI: /deployments/warp_routes/SUPR/logo.svg
-      name: Superseed
-      standard: EvmHypXERC20
-      symbol: SUPR
-    - addressOrDenom: "0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0"
-      chainName: ink
-      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
-      connections:
-        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
-        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
-        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
-        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
-      decimals: 18
-      logoURI: /deployments/warp_routes/SUPR/logo.svg
-      name: Superseed
-      standard: EvmHypXERC20
-      symbol: SUPR
-    - addressOrDenom: "0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97"
-      chainName: optimism
-      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
-      connections:
-        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
-        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
-        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
-        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
-      decimals: 18
-      logoURI: /deployments/warp_routes/SUPR/logo.svg
-      name: Superseed
-      standard: EvmHypXERC20
-      symbol: SUPR
-    - addressOrDenom: "0xA1863B4b02b7DCd7429F62C775816328D63020F4"
-      chainName: superseed
-      collateralAddressOrDenom: "0xEe64bC3f4A58D638D0845b24e2f51534d01b6549"
-      connections:
-        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
-        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
-        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
-        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
-      decimals: 18
-      logoURI: /deployments/warp_routes/SUPR/logo.svg
-      name: Superseed
-      standard: EvmHypXERC20Lockbox
-      symbol: SUPR
-TGT/bsc:
-  tokens:
-    - addressOrDenom: "0x6c58E4a513D3A8062E57f41a1442e003aF14eBb5"
-      chainName: bsc
-      connections:
-        - token: ethereum|immutablezkevmmainnet|0x4d9D942010eB2411fF16a9d910Badbc8520a9BfF
-      decimals: 18
-      logoURI: /deployments/warp_routes/TGT/logo.svg
-      name: TGT
-      standard: EvmHypSynthetic
-      symbol: TGT
-    - addressOrDenom: "0x4d9D942010eB2411fF16a9d910Badbc8520a9BfF"
-      chainName: immutablezkevmmainnet
-      coinGeckoId: tokyo-games-token
-      collateralAddressOrDenom: "0x0FA1d8Ffa9B414ABF0F47183e088bddC32e084F3"
-      connections:
-        - token: ethereum|bsc|0x6c58E4a513D3A8062E57f41a1442e003aF14eBb5
-      decimals: 18
-      logoURI: /deployments/warp_routes/TGT/logo.svg
-      name: TGT
-      standard: EvmHypCollateral
-      symbol: TGT
-TIA.n/arbitrum:
-  options:
-    interchainFeeConstants:
-      - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-        amount: 270000
-        destination: arbitrum
-        origin: neutron
-  tokens:
-    - addressOrDenom: neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
-      chainName: neutron
-      coinGeckoId: celestia
-      collateralAddressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-      connections:
-        - token: ethereum|arbitrum|0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.n
-      standard: CwHypCollateral
-      symbol: TIA.n
-    - addressOrDenom: "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C"
-      chainName: arbitrum
-      connections:
-        - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.n
-      standard: EvmHypSynthetic
-      symbol: TIA.n
-    - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-      chainName: neutron
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.n
-      standard: CosmosIbc
-      symbol: TIA.n
-TIA.n/mantapacific:
-  options:
-    interchainFeeConstants:
-      - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-        amount: 270000
-        destination: mantapacific
-        origin: neutron
-  tokens:
-    - addressOrDenom: neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
-      chainName: neutron
-      coinGeckoId: celestia
-      collateralAddressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-      connections:
-        - token: ethereum|mantapacific|0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.n
-      standard: CwHypCollateral
-      symbol: TIA.n
-    - addressOrDenom: "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa"
-      chainName: mantapacific
-      connections:
-        - token: cosmos|neutron|neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.n
-      standard: EvmHypSynthetic
-      symbol: TIA.n
-    - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-      chainName: neutron
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.n
-      standard: CosmosIbc
-      symbol: TIA.n
-TIA.o/mantapacific:
-  options:
-    interchainFeeConstants:
-      - addressOrDenom: ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877
-        amount: 840000
-        destination: mantapacific
-        origin: osmosis
-  tokens:
-    - addressOrDenom: osmo1h4y9xjcvs8lrx4z8ha48uq9a338w74dpl2ly3tf74fzvugp2kj4q9l0jkw
-      chainName: osmosis
-      collateralAddressOrDenom: ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877
-      connections:
-        - token: ethereum|mantapacific|0x88410F3D8135b4D23b98dC37C4652C6969a5B1a8
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.o
-      standard: CwHypCollateral
-      symbol: TIA.o
-    - addressOrDenom: "0x88410F3D8135b4D23b98dC37C4652C6969a5B1a8"
-      chainName: mantapacific
-      connections:
-        - token: cosmos|osmosis|osmo1h4y9xjcvs8lrx4z8ha48uq9a338w74dpl2ly3tf74fzvugp2kj4q9l0jkw
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA.o
-      standard: EvmHypSynthetic
-      symbol: TIA.o
-TIA/celestia-forma-stride-stride:
-  options:
-    interchainFeeConstants:
-      - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-        amount: 500000
-        destination: forma
-        origin: stride
-      - addressOrDenom: utia
-        amount: 20000
-        destination: forma
-        origin: celestia
-      - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
-        amount: 20000000000000000
-        destination: stride
-        origin: forma
-      - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
-        amount: 20000000000000000
-        destination: celestia
-        origin: forma
-  tokens:
-    - addressOrDenom: utia
-      chainName: celestia
-      connections:
-        - intermediateChainName: stride
-          intermediateIbcDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-          intermediateRouterAddress: stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
-          sourceChannel: channel-4
-          sourcePort: transfer
-          token: ethereum|forma|0x832d26B6904BA7539248Db4D58614251FD63dC05
-          type: ibc-hyperlane
-        - sourceChannel: channel-4
-          sourcePort: transfer
-          token: cosmos|stride|ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-          type: ibc
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA
-      standard: CosmosIbc
-      symbol: TIA
-    - addressOrDenom: stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
-      chainName: stride
-      collateralAddressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-      connections:
-        - token: ethereum|forma|0x832d26B6904BA7539248Db4D58614251FD63dC05
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA
-      standard: CwHypCollateral
-      symbol: TIA
-    - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
-      chainName: forma
-      connections:
-        - token: cosmos|stride|stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
-      decimals: 18
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA
-      standard: EvmNative
-      symbol: TIA
-    - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-      chainName: stride
-      connections:
-        - sourceChannel: channel-4
-          sourcePort: transfer
-          token: cosmos|celestia|utia
-          type: ibc
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: TIA
-      standard: CosmosIbc
-      symbol: TIA
-TIA/eclipsemainnet:
-  options:
-    interchainFeeConstants:
-      - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-        amount: 500000
-        destination: eclipsemainnet
-        origin: stride
-  tokens:
-    - addressOrDenom: stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6
-      chainName: stride
-      coinGeckoId: celestia
-      collateralAddressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-      connections:
-        - token: sealevel|eclipsemainnet|BpXHAiktwjx7fN6M9ST9wr6qKAsH27wZFhdHEhReJsR6
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: Celestia
-      standard: CwHypCollateral
-      symbol: TIA
-    - addressOrDenom: BpXHAiktwjx7fN6M9ST9wr6qKAsH27wZFhdHEhReJsR6
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: 9RryNMhAVJpAwAGjCAMKbbTFwgjapqPkzpGMfTQhEjf8
-      connections:
-        - token: cosmos|stride|stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: Celestia
-      standard: SealevelHypSynthetic
-      symbol: TIA
-    - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
-      chainName: stride
-      decimals: 6
-      logoURI: /deployments/warp_routes/TIA/logo.svg
-      name: Celestia
-      standard: CosmosIbc
-      symbol: TIA
-TOBY/optimism:
-  tokens:
-    - addressOrDenom: "0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B"
-      chainName: base
-      collateralAddressOrDenom: "0xb8d98a102b0079b69ffbc760c8d857a31653e56e"
-      connections:
-        - token: ethereum|optimism|0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B
-      decimals: 18
-      logoURI: /deployments/warp_routes/TOBY/logo.svg
-      name: Toby ToadGod
-      standard: EvmHypCollateral
-      symbol: TOBY
-    - addressOrDenom: "0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B"
-      chainName: optimism
-      connections:
-        - token: ethereum|base|0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B
-      decimals: 18
-      logoURI: /deployments/warp_routes/TOBY/logo.svg
-      name: Toby ToadGod
-      standard: EvmHypSynthetic
-      symbol: TOBY
-TONY/solanamainnet:
-  tokens:
-    - addressOrDenom: "0xcc9EcE816641c8350Db06af375811107B1Aa0b9d"
-      chainName: base
-      coinGeckoId: bonk
-      collateralAddressOrDenom: "0xb22a793a81ff5b6ad37f40d5fe1e0ac4184d52f3"
-      connections:
-        - token: sealevel|solanamainnet|Fa4zQJCH7id5KL1eFJt2mHyFpUNfCCSkHgtMrLvrRJBN
-      decimals: 18
-      logoURI: /deployments/warp_routes/TONY/logo.png
-      name: Big Tony
-      standard: EvmHypCollateral
-      symbol: TONY
-    - addressOrDenom: Fa4zQJCH7id5KL1eFJt2mHyFpUNfCCSkHgtMrLvrRJBN
-      chainName: solanamainnet
-      collateralAddressOrDenom: 3SboFTm5xF3VGcduCP6CPue3ZTh8qKXNcNSXR74YDaw1
-      connections:
-        - token: ethereum|base|0xcc9EcE816641c8350Db06af375811107B1Aa0b9d
-      decimals: 9
-      logoURI: /deployments/warp_routes/TONY/logo.png
-      name: Big Tony
-      standard: SealevelHypSynthetic
-      symbol: TONY
-TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain:
-  tokens:
-    - addressOrDenom: "0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8"
-      chainName: base
-      connections:
-        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypSynthetic
-      symbol: TRUMP
-    - addressOrDenom: "0x5155EB1bcD30189915cF84717550Acfa537068bF"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypSynthetic
-      symbol: TRUMP
-    - addressOrDenom: "0x0e2A546a53678ee8F8605748193a8c114fA0317F"
-      chainName: avalanche
-      connections:
-        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypSynthetic
-      symbol: TRUMP
-    - addressOrDenom: "0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760"
-      chainName: flowmainnet
-      connections:
-        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypSynthetic
-      symbol: TRUMP
-    - addressOrDenom: "0x8528bAa7d1d386E7967603e480fa2B558a23644c"
-      chainName: form
-      connections:
-        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypSynthetic
-      symbol: TRUMP
-    - addressOrDenom: "0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922"
-      chainName: worldchain
-      connections:
-        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypSynthetic
-      symbol: TRUMP
-    - addressOrDenom: "0xe36c02471e708a9f16da58168da744b059a1c6fe"
-      chainName: optimism
-      connections:
-        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypSynthetic
-      symbol: TRUMP
-    - addressOrDenom: 21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-      chainName: solanamainnet
-      coinGeckoId: official-trump
-      collateralAddressOrDenom: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
-      connections:
-        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
-        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
-        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-      decimals: 6
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: SealevelHypCollateral
-      symbol: TRUMP
-TRUMP/solanamainnet-trumpchain:
-  tokens:
-    - addressOrDenom: "0xD84981Ecd4c411A86E1Ccda77F944c8f3D9737ab"
-      chainName: trumpchain
-      connections:
-        - token: sealevel|solanamainnet|AyJk3V2SjswRv1ppDazVofXnFgjCTeydNEDSyA2UyVNX
-      decimals: 18
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: EvmHypNative
-      symbol: TRUMP
-    - addressOrDenom: AyJk3V2SjswRv1ppDazVofXnFgjCTeydNEDSyA2UyVNX
-      chainName: solanamainnet
-      coinGeckoId: official-trump
-      collateralAddressOrDenom: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
-      connections:
-        - token: ethereum|trumpchain|0xD84981Ecd4c411A86E1Ccda77F944c8f3D9737ab
-      decimals: 6
-      logoURI: /deployments/warp_routes/TRUMP/logo.png
-      name: OFFICIAL TRUMP
-      standard: SealevelHypCollateral
-      symbol: TRUMP
-TURTLE/linea:
-  tokens:
-    - addressOrDenom: "0x15dE2C58FCF168bf9bB8860ab6EA10e1670C5D4c"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x2BE3be1D8A556954320c2252dF4f891F64699d50"
-      connections:
-        - token: ethereum|linea|0xB88F86E0c403B02d4cCF893Fc37312A18Fa2Fe1B
-      decimals: 18
-      logoURI: /deployments/warp_routes/TURTLE/logo.png
-      name: Turtle
-      standard: EvmHypCollateral
-      symbol: TURTLE
-    - addressOrDenom: "0xB88F86E0c403B02d4cCF893Fc37312A18Fa2Fe1B"
-      chainName: linea
-      connections:
-        - token: ethereum|ethereum|0x15dE2C58FCF168bf9bB8860ab6EA10e1670C5D4c
-      decimals: 18
-      logoURI: /deployments/warp_routes/TURTLE/logo.png
-      name: Turtle
-      standard: EvmHypSynthetic
-      symbol: TURTLE
-UFD/apechain:
-  tokens:
-    - addressOrDenom: "0xC58eeC72352b04358b0b6979ba10462190f0d54C"
-      chainName: apechain
-      connections:
-        - token: sealevel|solanamainnet|DTNQ9T9KYbB2rpnJxdwcZbnxB17G9jAiiSqU8fAf6uSS
-      decimals: 6
-      logoURI: /deployments/warp_routes/UFD/logo.svg
-      name: Unicorn Fart Dust
-      standard: EvmHypSynthetic
-      symbol: UFD
-    - addressOrDenom: DTNQ9T9KYbB2rpnJxdwcZbnxB17G9jAiiSqU8fAf6uSS
-      chainName: solanamainnet
-      coinGeckoId: unicorn-fart-dust
-      collateralAddressOrDenom: eL5fUxj2J4CiQsmW85k5FG9DvuQjjUoBHoQBi2Kpump
-      connections:
-        - token: ethereum|apechain|0xC58eeC72352b04358b0b6979ba10462190f0d54C
-      decimals: 6
-      logoURI: /deployments/warp_routes/UFD/logo.svg
-      name: Unicorn Fart Dust
-      standard: SealevelHypCollateral
-      symbol: UFD
-USD*/sonicsvm:
-  tokens:
-    - addressOrDenom: FRPTWpmnNPm4LS2a5NUL1QenUrzGDAuifZBUi1mTWTdt
-      chainName: solanamainnet
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: BenJy1n3WTx9mTjEvy63e8Q1j4RqUc6E4VBMz3ir4Wo6
-      connections:
-        - token: sealevel|sonicsvm|68g96Cq16vKAqyG79BFVeJCgitjK9fQ1NRCRmcPkJtDB
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDStar/logo.svg
-      name: USD Star
-      standard: SealevelHypCollateral
-      symbol: USD*
-    - addressOrDenom: 68g96Cq16vKAqyG79BFVeJCgitjK9fQ1NRCRmcPkJtDB
-      chainName: sonicsvm
-      collateralAddressOrDenom: BhaUtuAuuv8B5BiPx4LZyaPhY8CCtJsGNAic24pZzV78
-      connections:
-        - token: sealevel|solanamainnet|FRPTWpmnNPm4LS2a5NUL1QenUrzGDAuifZBUi1mTWTdt
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDStar/logo.svg
-      name: USD Star
-      standard: SealevelHypSynthetic
-      symbol: USD*
-USDB/zeronetwork:
-  tokens:
-    - addressOrDenom: "0x1CF975C9bF2DF76c43a14405066007f8393142E9"
-      chainName: blast
-      coinGeckoId: usdb
-      collateralAddressOrDenom: "0x4300000000000000000000000000000000000003"
-      connections:
-        - token: ethereum|zeronetwork|0xB11a9606f3e470abD00b1bbB28AffAC3126c2Acb
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDB/logo.svg
-      name: USDB
-      standard: EvmHypCollateral
-      symbol: USDB
-    - addressOrDenom: "0xB11a9606f3e470abD00b1bbB28AffAC3126c2Acb"
-      chainName: zeronetwork
-      connections:
-        - token: ethereum|blast|0x1CF975C9bF2DF76c43a14405066007f8393142E9
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDB/logo.svg
-      name: USDB
-      standard: EvmHypSynthetic
-      symbol: USDB
-USDC.a/artela:
-  tokens:
-    - addressOrDenom: "0x8d9Bd7E9ec3cd799a659EE650DfF6C799309fA91"
-      chainName: artela
-      connections:
-        - token: ethereum|base|0x01348F639D6e418A5a9673c08c0dDf6ecCB80F37
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC.a
-    - addressOrDenom: "0x01348F639D6e418A5a9673c08c0dDf6ecCB80F37"
-      chainName: base
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-      connections:
-        - token: ethereum|artela|0x8d9Bd7E9ec3cd799a659EE650DfF6C799309fA91
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-USDC/ancient8:
-  tokens:
-    - addressOrDenom: "0x8b4192B9Ad1fCa440A5808641261e5289e6de95D"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|ancient8|0x97423A68BAe94b5De52d767a17aBCc54c157c0E5
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x97423A68BAe94b5De52d767a17aBCc54c157c0E5"
-      chainName: ancient8
-      connections:
-        - token: ethereum|ethereum|0x8b4192B9Ad1fCa440A5808641261e5289e6de95D
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-USDC/appchain:
-  tokens:
-    - addressOrDenom: "0x675C3ce7F43b00045a4Dab954AF36160fb57cB45"
-      chainName: appchain
-      connections:
-        - token: ethereum|base|0xF6B933267d0aC9e08c4904FB39fa047eD7b6a814
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-    - addressOrDenom: "0xF6B933267d0aC9e08c4904FB39fa047eD7b6a814"
-      chainName: base
-      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-      connections:
-        - token: ethereum|appchain|0x675C3ce7F43b00045a4Dab954AF36160fb57cB45
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-USDC/arbitrum-base-endurance:
-  tokens:
-    - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
-      chainName: arbitrum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
-      connections:
-        - token: ethereum|endurance|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
-      chainName: base
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-      connections:
-        - token: ethereum|endurance|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
-      chainName: endurance
-      connections:
-        - token: ethereum|arbitrum|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
-        - token: ethereum|base|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateralFiat
-      symbol: USDC
-USDC/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed:
-  tokens:
-    - addressOrDenom: "0xc927767CF7bddc5e8b996A0f957e5F22250A2F67"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xa7D6042eEf06E81168e640b5C41632eE5295227D"
-      chainName: superseed
-      collateralAddressOrDenom: "0xc316c8252b5f2176d0135ebb0999e99296998f2e"
-      connections:
-        - token: ethereum|arbitrum|0x2cB0E5AbE11346679749063d3FBfC1f390e6e70A
-        - token: ethereum|base|0x955132016f9B6376B1392aA7BFF50538d21Ababc
-        - token: ethereum|ethereum|0xc927767CF7bddc5e8b996A0f957e5F22250A2F67
-        - token: ethereum|ink|0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC
-        - token: ethereum|optimism|0x741B077c69FA219CEdb11364706a3880A792423e
-        - token: sealevel|solanamainnet|7aM3itqXToHXhdR97EwJjZc7fay6uBszhUs1rzJm3tto
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateralFiat
-      symbol: USDC
-    - addressOrDenom: "0x2cB0E5AbE11346679749063d3FBfC1f390e6e70A"
-      chainName: arbitrum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
-      connections:
-        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x955132016f9B6376B1392aA7BFF50538d21Ababc"
-      chainName: base
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-      connections:
-        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC"
-      chainName: ink
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xF1815bd50389c46847f0Bda824eC8da914045D14"
-      connections:
-        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x741B077c69FA219CEdb11364706a3880A792423e"
-      chainName: optimism
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
-      connections:
-        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: 7aM3itqXToHXhdR97EwJjZc7fay6uBszhUs1rzJm3tto
-      chainName: solanamainnet
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-      connections:
-        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: SealevelHypCollateral
-      symbol: USDC
-USDC/cheesechain:
-  tokens:
-    - addressOrDenom: "0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41"
-      chainName: cheesechain
-      connections:
-        - token: ethereum|arbitrum|0xC9e048011E4A47584CE5b91AbD8695338A640648
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: EvmHypSynthetic
-      symbol: USDC
-    - addressOrDenom: "0xC9e048011E4A47584CE5b91AbD8695338A640648"
-      chainName: arbitrum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xa8E5800AEf846A38a5814A28bcB851Ed626a0053"
-      connections:
-        - token: ethereum|cheesechain|0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: EvmHypOwnerCollateral
-      symbol: USDC
-USDC/coti-ethereum:
-  tokens:
-    - addressOrDenom: "0xEE2e85Df244e32d95d9f327D7a35Ba3d2d412225"
-      chainName: coti
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xf1Feebc4376c68B7003450ae66343Ae59AB37D3C"
-      connections:
-        - token: ethereum|ethereum|0x6de5FaBC6B4663BD6BdBc064Bbb183E61aF1daDE
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateralFiat
-      symbol: USDC
-    - addressOrDenom: "0x6de5FaBC6B4663BD6BdBc064Bbb183E61aF1daDE"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-      connections:
-        - token: ethereum|coti|0xEE2e85Df244e32d95d9f327D7a35Ba3d2d412225
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-USDC/eclipsemainnet:
-  tokens:
-    - addressOrDenom: "0xe1De9910fe71cC216490AC7FCF019e13a34481D7"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-      connections:
-        - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: AKEWE7Bgh87GPp171b4cJPSSZfmZwQ3KaqYqXoKLNAEE
-      connections:
-        - token: ethereum|ethereum|0xe1De9910fe71cC216490AC7FCF019e13a34481D7
-        - token: sealevel|solanamainnet|3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: SealevelHypSynthetic
-      symbol: USDC
-    - addressOrDenom: 3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
-      chainName: solanamainnet
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-      connections:
-        - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: SealevelHypCollateral
-      symbol: USDC
-USDC/ethereum-form:
-  tokens:
-    - addressOrDenom: "0x3551011EA5F210981E9C2a8659444011370f41e2"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|form|0xC316C8252B5F2176d0135Ebb0999E99296998F2e
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xC316C8252B5F2176d0135Ebb0999E99296998F2e"
-      chainName: form
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xFBf489bb4783D4B1B2e7D07ba39873Fb8068507D"
-      connections:
-        - token: ethereum|ethereum|0x3551011EA5F210981E9C2a8659444011370f41e2
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateralFiat
-      symbol: USDC
-USDC/ethereum-lumiaprism:
-  tokens:
-    - addressOrDenom: "0x066abc14c59cF7681b4b66844500733D2258032A"
-      chainName: ethereum
-      coinGeckoId: usdc
-      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-      connections:
-        - token: ethereum|lumiaprism|0x2D0b95BB7eC6A8A3B3229e8FB8bE5848aBEA137a
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x2D0b95BB7eC6A8A3B3229e8FB8bE5848aBEA137a"
-      chainName: lumiaprism
-      coinGeckoId: usdc
-      collateralAddressOrDenom: "0xFF297AC2CB0a236155605EB37cB55cFCAe6D3F01"
-      connections:
-        - token: ethereum|ethereum|0x066abc14c59cF7681b4b66844500733D2258032A
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateralFiat
-      symbol: USDC
-USDC/ethereum-swell:
-  tokens:
-    - addressOrDenom: "0x1fbcc5A3EE1EfC5e920FFF999AE97a0C2DF4A583"
-      chainName: ethereum
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|swell|0x93D41E41cA545a35A81d11b08D2eE8b852C768df
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x93D41E41cA545a35A81d11b08D2eE8b852C768df"
-      chainName: swell
-      collateralAddressOrDenom: "0x99a38322cAF878Ef55AE4d0Eda535535eF8C7960"
-      connections:
-        - token: ethereum|ethereum|0x1fbcc5A3EE1EfC5e920FFF999AE97a0C2DF4A583
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateralFiat
-      symbol: USDC
-USDC/inevm:
-  tokens:
-    - addressOrDenom: "0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-      connections:
-        - token: ethereum|inevm|0x8358d8291e3bedb04804975eea0fe9fe0fafb147
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x8358d8291e3bedb04804975eea0fe9fe0fafb147"
-      chainName: inevm
-      connections:
-        - token: ethereum|ethereum|0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: EvmHypSynthetic
-      symbol: USDC
-USDC/ink:
-  tokens:
-    - addressOrDenom: "0xAf4f3329D271655a4287882310dE25Fb77Dc0a14"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|ink|0x23f63C65c474f2A5BF80ea845Ca496Da3689A2B9
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x23f63C65c474f2A5BF80ea845Ca496Da3689A2B9"
-      chainName: ink
-      connections:
-        - token: ethereum|ethereum|0xAf4f3329D271655a4287882310dE25Fb77Dc0a14
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-USDC/kalychain:
-  tokens:
-    - addressOrDenom: "0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd"
-      chainName: arbitrum
-      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
-      connections:
-        - token: ethereum|bsc|0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0
-        - token: ethereum|kalychain|0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9
-        - token: ethereum|polygon|0xB3dF48224FA257D55e01342592f9A24cefc2628e
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0"
-      chainName: bsc
-      collateralAddressOrDenom: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
-      connections:
-        - token: ethereum|arbitrum|0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd
-        - token: ethereum|kalychain|0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9
-        - token: ethereum|polygon|0xB3dF48224FA257D55e01342592f9A24cefc2628e
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9"
-      chainName: kalychain
-      connections:
-        - token: ethereum|arbitrum|0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd
-        - token: ethereum|bsc|0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0
-        - token: ethereum|polygon|0xB3dF48224FA257D55e01342592f9A24cefc2628e
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-    - addressOrDenom: "0xB3dF48224FA257D55e01342592f9A24cefc2628e"
-      chainName: polygon
-      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
-      connections:
-        - token: ethereum|arbitrum|0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd
-        - token: ethereum|bsc|0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0
-        - token: ethereum|kalychain|0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-USDC/lisk:
-  tokens:
-    - addressOrDenom: "0x14adE09354a20ed23E690afc803E64E60a84e7D3"
-      chainName: arbitrum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
-      connections:
-        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D"
-      chainName: base
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-      connections:
-        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xa6826c7Dd74c4e1B400AEF4a362692f99872F5F5"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
-      chainName: lisk
-      connections:
-        - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
-        - token: ethereum|base|0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D
-        - token: ethereum|ethereum|0xa6826c7Dd74c4e1B400AEF4a362692f99872F5F5
-        - token: ethereum|optimism|0xcA11d580faaE3E6993aA230f437079ac21f3078a
-        - token: ethereum|polygon|0xb805ee88eE76EcE03ba503A2634344804a0Ea59A
-        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-    - addressOrDenom: "0xcA11d580faaE3E6993aA230f437079ac21f3078a"
-      chainName: optimism
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
-      connections:
-        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xb805ee88eE76EcE03ba503A2634344804a0Ea59A"
-      chainName: polygon
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
-      connections:
-        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
-      chainName: zeronetwork
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0x6a6394F47DD0BAF794808F2749C09bd4Ee874E70"
-      connections:
-        - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
-        - token: ethereum|base|0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D
-        - token: ethereum|ethereum|0xa6826c7Dd74c4e1B400AEF4a362692f99872F5F5
-        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|optimism|0xcA11d580faaE3E6993aA230f437079ac21f3078a
-        - token: ethereum|polygon|0xb805ee88eE76EcE03ba503A2634344804a0Ea59A
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-USDC/optimism:
-  tokens:
-    - addressOrDenom: "0x524410b1e64f689eeBa15E7E511110438811B3dC"
-      chainName: base
-      collateralAddressOrDenom: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
-      connections:
-        - token: ethereum|optimism|0x2DBe8c163f080b244D420be781abD37c1bfc51A6
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x2DBe8c163f080b244D420be781abD37c1bfc51A6"
-      chainName: optimism
-      connections:
-        - token: ethereum|base|0x524410b1e64f689eeBa15E7E511110438811B3dC
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-USDC/polygon:
-  tokens:
-    - addressOrDenom: "0x647eeD57dFDd335f9B6f2a9DbDFe09f166b1AdaC"
-      chainName: bsc
-      collateralAddressOrDenom: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
-      connections:
-        - token: ethereum|polygon|0xFDf46770Da4F907c09aEd92299552DC9c7996d99
-        - token: ethereum|prom|0x424712Bec7c94a0F804c50F77B641A24F33A138e
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xFDf46770Da4F907c09aEd92299552DC9c7996d99"
-      chainName: polygon
-      connections:
-        - token: ethereum|bsc|0x647eeD57dFDd335f9B6f2a9DbDFe09f166b1AdaC
-        - token: ethereum|prom|0x424712Bec7c94a0F804c50F77B641A24F33A138e
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-    - addressOrDenom: "0x424712Bec7c94a0F804c50F77B641A24F33A138e"
-      chainName: prom
-      collateralAddressOrDenom: "0xcd1D86a6fDb32e9525C40a1a91892F33A0617E13"
-      connections:
-        - token: ethereum|bsc|0x647eeD57dFDd335f9B6f2a9DbDFe09f166b1AdaC
-        - token: ethereum|polygon|0xFDf46770Da4F907c09aEd92299552DC9c7996d99
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-USDC/prom:
-  tokens:
-    - addressOrDenom: "0xb4aF6757691573f0acAbA35A724a8E0EE049aB5a"
-      chainName: bsc
-      collateralAddressOrDenom: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
-      connections:
-        - token: ethereum|prom|0x451c22b06a5f38a43641f6910834C90f3619cEb9
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x451c22b06a5f38a43641f6910834C90f3619cEb9"
-      chainName: prom
-      connections:
-        - token: ethereum|bsc|0xb4aF6757691573f0acAbA35A724a8E0EE049aB5a
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-USDC/sonicsvm:
-  tokens:
-    - addressOrDenom: 996EsR8a7MC6odE6j7sjsArmDQVqB96qWu84wHdthahm
-      chainName: solanamainnet
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-      connections:
-        - token: sealevel|sonicsvm|BvTEYSqCcfMwpAriC1vDpNhzR1JWzasRFfCPCdgsYaCd
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: SealevelHypCollateral
-      symbol: USDC
-    - addressOrDenom: BvTEYSqCcfMwpAriC1vDpNhzR1JWzasRFfCPCdgsYaCd
-      chainName: sonicsvm
-      collateralAddressOrDenom: HbDgpvHVxeNSRCGEUFvapCYmtYfqxexWcCbxtYecruy8
-      connections:
-        - token: sealevel|solanamainnet|996EsR8a7MC6odE6j7sjsArmDQVqB96qWu84wHdthahm
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: SealevelHypSynthetic
-      symbol: USDC
-USDC/subtensor:
-  tokens:
-    - addressOrDenom: "0x26af973A5b256F9B9bc0B1A3c566de1566568a87"
-      chainName: base
-      coinGeckoId: usdc
-      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-      connections:
-        - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
-        - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
-        - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b"
-      chainName: ethereum
-      coinGeckoId: usdc
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
-        - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
-        - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xB833E8137FEDf80de7E908dc6fea43a029142F20"
-      chainName: subtensor
-      connections:
-        - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
-        - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
-        - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: EvmHypSynthetic
-      symbol: USDC
-    - addressOrDenom: GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
-      chainName: solanamainnet
-      coinGeckoId: usdc
-      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-      connections:
-        - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
-        - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
-        - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USD Coin
-      standard: SealevelHypCollateral
-      symbol: USDC
-USDC/viction:
-  tokens:
-    - addressOrDenom: "0x31Dca7762930f56D81292f85E65c9D67575804fE"
-      chainName: ethereum
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-      connections:
-        - token: ethereum|viction|0xbda330ea8f3005c421c8088e638fbb64fa71b9e0
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: EvmHypCollateral
-      symbol: USDC
-    - addressOrDenom: "0xbda330ea8f3005c421c8088e638fbb64fa71b9e0"
-      chainName: viction
-      connections:
-        - token: ethereum|ethereum|0x31Dca7762930f56D81292f85E65c9D67575804fE
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDC/logo.svg
-      name: USDC
-      standard: EvmHypSynthetic
-      symbol: USDC
-USDCSTAGE/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed:
-  tokens:
-    - addressOrDenom: "0x1d82BC329E5E6CA5CBc41571435824dda7895e92"
-      chainName: ethereum
-      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      connections:
-        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDCSTAGE
-    - addressOrDenom: "0xf728C884De5275a608dEC222dACd0f2BF2E23AB6"
-      chainName: superseed
-      collateralAddressOrDenom: "0x99a38322cAF878Ef55AE4d0Eda535535eF8C7960"
-      connections:
-        - token: ethereum|ethereum|0x1d82BC329E5E6CA5CBc41571435824dda7895e92
-        - token: ethereum|arbitrum|0xD74706A5Be0cb87357EF80b4fAEa709287D4f640
-        - token: ethereum|base|0x23eE98fD566eBae12296d1B111064921143AD6a7
-        - token: ethereum|ink|0x5D71b91B92AAE933cbf85065F49bC14f16c55c55
-        - token: ethereum|optimism|0x2171e985D95eB12451B723b19458A7f1AdEbc086
-        - token: sealevel|solanamainnet|8UUnM8wheNwAf3KM65Yx72Mq8mSAHf33GUwEp3MAyQX1
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateralFiat
-      symbol: USDCSTAGE
-    - addressOrDenom: "0xD74706A5Be0cb87357EF80b4fAEa709287D4f640"
-      chainName: arbitrum
-      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
-      connections:
-        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDCSTAGE
-    - addressOrDenom: "0x23eE98fD566eBae12296d1B111064921143AD6a7"
-      chainName: base
-      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-      connections:
-        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDCSTAGE
-    - addressOrDenom: "0x5D71b91B92AAE933cbf85065F49bC14f16c55c55"
-      chainName: ink
-      collateralAddressOrDenom: "0xF1815bd50389c46847f0Bda824eC8da914045D14"
-      connections:
-        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDCSTAGE
-    - addressOrDenom: "0x2171e985D95eB12451B723b19458A7f1AdEbc086"
-      chainName: optimism
-      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
-      connections:
-        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
-      decimals: 6
-      name: USD Coin
-      standard: EvmHypCollateral
-      symbol: USDCSTAGE
-    - addressOrDenom: 8UUnM8wheNwAf3KM65Yx72Mq8mSAHf33GUwEp3MAyQX1
-      chainName: solanamainnet
-      coinGeckoId: usd-coin
-      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-      connections:
-        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
-      decimals: 6
-      name: USD Coin
-      standard: SealevelHypCollateral
-      symbol: USDCSTAGE
-USDN/auroratestnet:
-  tokens:
-    - addressOrDenom: "0x2d10ad108d26384329Ac879476Ae0F4cc0531DEC"
-      chainName: auroratestnet
-      connections:
-        - token: cosmosnative|nobletestnet|0x726f757465725f61707000000000000000000000000000010000000000000000
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDN/logo.svg
-      name: Noble Dollar
-      standard: EvmHypSynthetic
-      symbol: USDN
-    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
-      chainName: nobletestnet
-      collateralAddressOrDenom: uusdn
-      connections:
-        - token: ethereum|auroratestnet|0x2d10ad108d26384329Ac879476Ae0F4cc0531DEC
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDN/logo.svg
-      name: Noble Dollar
-      standard: CosmosNativeHypCollateral
-      symbol: USDN
-USDT/eclipsemainnet:
-  tokens:
-    - addressOrDenom: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
-      connections:
-        - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: 5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: CEBP3CqAbW4zdZA57H2wfaSG1QNdzQ72GiQEbQXyW9Tm
-      connections:
-        - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
-        - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: SealevelHypSynthetic
-      symbol: USDT
-    - addressOrDenom: Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
-      chainName: solanamainnet
-      coinGeckoId: tether
-      collateralAddressOrDenom: Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
-      connections:
-        - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: SealevelHypCollateral
-      symbol: USDT
-USDT/form:
-  tokens:
-    - addressOrDenom: "0x6435821A260B6A8EcB4ab723B84e1Bc3BC8b5304"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
-      connections:
-        - token: ethereum|form|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0xFA3198ecF05303a6d96E57a45E6c815055D255b1"
-      chainName: form
-      connections:
-        - token: ethereum|ethereum|0x6435821A260B6A8EcB4ab723B84e1Bc3BC8b5304
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/hyperevm:
-  tokens:
-    - addressOrDenom: "0xf6ff77f2dCAD6dbab2142404F7b64C5517587e29"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
-      connections:
-        - token: ethereum|hyperevm|0xbF2D3b1a37D54ce86d0e1455884dA875a97C87a8
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0xbF2D3b1a37D54ce86d0e1455884dA875a97C87a8"
-      chainName: hyperevm
-      connections:
-        - token: ethereum|ethereum|0xf6ff77f2dCAD6dbab2142404F7b64C5517587e29
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/inevm:
-  tokens:
-    - addressOrDenom: "0xab852e67bf03E74C89aF67C4BA97dd1088D3dA19"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-      connections:
-        - token: ethereum|inevm|0x97423a68bae94b5de52d767a17abcc54c157c0e5
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x97423a68bae94b5de52d767a17abcc54c157c0e5"
-      chainName: inevm
-      connections:
-        - token: ethereum|ethereum|0xab852e67bf03E74C89aF67C4BA97dd1088D3dA19
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/kalychain:
-  tokens:
-    - addressOrDenom: "0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9"
-      chainName: arbitrum
-      collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
-      connections:
-        - token: ethereum|bsc|0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101
-        - token: ethereum|kalychain|0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A
-        - token: ethereum|polygon|0x2f7c83FC82A0e39A997c262e5BAB13176C275104
-      decimals: 6
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101"
-      chainName: bsc
-      collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
-      connections:
-        - token: ethereum|arbitrum|0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9
-        - token: ethereum|kalychain|0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A
-        - token: ethereum|polygon|0x2f7c83FC82A0e39A997c262e5BAB13176C275104
-      decimals: 6
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A"
-      chainName: kalychain
-      connections:
-        - token: ethereum|arbitrum|0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9
-        - token: ethereum|bsc|0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101
-        - token: ethereum|polygon|0x2f7c83FC82A0e39A997c262e5BAB13176C275104
-      decimals: 6
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-    - addressOrDenom: "0x2f7c83FC82A0e39A997c262e5BAB13176C275104"
-      chainName: polygon
-      collateralAddressOrDenom: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
-      connections:
-        - token: ethereum|arbitrum|0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9
-        - token: ethereum|bsc|0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101
-        - token: ethereum|kalychain|0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A
-      decimals: 6
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-USDT/lumiaprism:
-  tokens:
-    - addressOrDenom: "0x32fF31FfeB04070e9E34C345965C1bB9B5C1F787"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-      connections:
-        - token: ethereum|lumiaprism|0xee7Fc418f5659a366b548b4E205d374C1F0B46e7
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0xee7Fc418f5659a366b548b4E205d374C1F0B46e7"
-      chainName: lumiaprism
-      connections:
-        - token: ethereum|ethereum|0x32fF31FfeB04070e9E34C345965C1bB9B5C1F787
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/polygon:
-  tokens:
-    - addressOrDenom: "0x74e19D0c1828be422dDCd367a6ADa8CA7003d1a9"
-      chainName: bsc
-      collateralAddressOrDenom: "0x55d398326f99059ff775485246999027b3197955"
-      connections:
-        - token: ethereum|polygon|0xd9765D5fE176493808202e63E6B73b523D6A1C3A
-        - token: ethereum|prom|0xDf6C58ec668daB037373BC49215722c2b0664484
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0xd9765D5fE176493808202e63E6B73b523D6A1C3A"
-      chainName: polygon
-      connections:
-        - token: ethereum|bsc|0x74e19D0c1828be422dDCd367a6ADa8CA7003d1a9
-        - token: ethereum|prom|0xDf6C58ec668daB037373BC49215722c2b0664484
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-    - addressOrDenom: "0xDf6C58ec668daB037373BC49215722c2b0664484"
-      chainName: prom
-      collateralAddressOrDenom: "0x7d7b730CBc9C98cB423a6F206840028036d1DA48"
-      connections:
-        - token: ethereum|bsc|0x74e19D0c1828be422dDCd367a6ADa8CA7003d1a9
-        - token: ethereum|polygon|0xd9765D5fE176493808202e63E6B73b523D6A1C3A
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-USDT/prom:
-  tokens:
-    - addressOrDenom: "0xCf2D543345728da295CC5d3A3d54B117979643f8"
-      chainName: bsc
-      collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
-      connections:
-        - token: ethereum|prom|0x6064C9028d069a7822d30EF17065A57524A5FcAb
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x6064C9028d069a7822d30EF17065A57524A5FcAb"
-      chainName: prom
-      connections:
-        - token: ethereum|bsc|0xCf2D543345728da295CC5d3A3d54B117979643f8
-      decimals: 18
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/sonicsvm:
-  tokens:
-    - addressOrDenom: CKrNt2y1e2H9728mHRVYyF2owy9eKreepRKpTMj2j8JG
-      chainName: solanamainnet
-      coinGeckoId: tether
-      collateralAddressOrDenom: Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
-      connections:
-        - token: sealevel|sonicsvm|BGW8geBw12Yyp4rW7Fp97a3CQRA4Czi8PdtuV2Ec3Vdy
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: SealevelHypCollateral
-      symbol: USDT
-    - addressOrDenom: BGW8geBw12Yyp4rW7Fp97a3CQRA4Czi8PdtuV2Ec3Vdy
-      chainName: sonicsvm
-      collateralAddressOrDenom: qPzdrTCvxK3bxoh2YoTZtDcGVgRUwm37aQcC3abFgBy
-      connections:
-        - token: sealevel|solanamainnet|CKrNt2y1e2H9728mHRVYyF2owy9eKreepRKpTMj2j8JG
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: SealevelHypSynthetic
-      symbol: USDT
-USDT/superseed:
-  tokens:
-    - addressOrDenom: "0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
-      connections:
-        - token: ethereum|superseed|0xc5068BB6803ADbe5600DE5189fe27A4dAcE31170
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0xc5068BB6803ADbe5600DE5189fe27A4dAcE31170"
-      chainName: superseed
-      connections:
-        - token: ethereum|ethereum|0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/swell:
-  tokens:
-    - addressOrDenom: "0x72529594955CeFfc0ac4ECF23C45B9069A24Df14"
-      chainName: ethereum
-      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-      connections:
-        - token: ethereum|swell|0xb89c6ED617f5F46175E41551350725A09110bbCE
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0xb89c6ED617f5F46175E41551350725A09110bbCE"
-      chainName: swell
-      connections:
-        - token: ethereum|ethereum|0x72529594955CeFfc0ac4ECF23C45B9069A24Df14
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/viction:
-  tokens:
-    - addressOrDenom: "0x4221a16A01F61c2b38A03C52d828a7041f6AAA49"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-      connections:
-        - token: ethereum|viction|0x48083c69f5a42c6b69abbad48ae195bd36770ee2
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x48083c69f5a42c6b69abbad48ae195bd36770ee2"
-      chainName: viction
-      connections:
-        - token: ethereum|ethereum|0x4221a16A01F61c2b38A03C52d828a7041f6AAA49
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: USDT
-      standard: EvmHypSynthetic
-      symbol: USDT
-USDT/zeronetwork:
-  tokens:
-    - addressOrDenom: "0x83AF845F002c2dA8748eaB8203D2704BdAE6fB8e"
-      chainName: arbitrum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
-      connections:
-        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec"
-      chainName: mantle
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE"
-      connections:
-        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec"
-      chainName: mode
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xf0F161fDA2712DB8b566946122a5af183995e2eD"
-      connections:
-        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x6701d503369cf6aA9e5EdFfEBFA40A2ffdf3dB21"
-      chainName: polygon
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
-      connections:
-        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
-      chainName: scroll
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df"
-      connections:
-        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-    - addressOrDenom: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
-      chainName: zeronetwork
-      connections:
-        - token: ethereum|arbitrum|0x83AF845F002c2dA8748eaB8203D2704BdAE6fB8e
-        - token: ethereum|mantle|0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec
-        - token: ethereum|mode|0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec
-        - token: ethereum|polygon|0x6701d503369cf6aA9e5EdFfEBFA40A2ffdf3dB21
-        - token: ethereum|scroll|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|ethereum|0x95fBD1037a307A49587174E06a6600fD05c5f58e
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypSynthetic
-      symbol: USDT
-    - addressOrDenom: "0x95fBD1037a307A49587174E06a6600fD05c5f58e"
-      chainName: ethereum
-      coinGeckoId: tether
-      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-      connections:
-        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
-      decimals: 6
-      logoURI: /deployments/warp_routes/USDT/logo.svg
-      name: Tether USD
-      standard: EvmHypCollateral
-      symbol: USDT
-VANA/ethereum:
-  tokens:
-    - addressOrDenom: "0x177778F19E89dD1012BdBe603F144088A95C4B53"
-      chainName: ethereum
-      connections:
-        - token: ethereum|vana|0x96b572D2d880cf2Fa2563651BD23ADE6f5516652
-      decimals: 18
-      name: Vana
-      standard: EvmHypSynthetic
-      symbol: VANA
-    - addressOrDenom: "0x96b572D2d880cf2Fa2563651BD23ADE6f5516652"
-      chainName: vana
-      coinGeckoId: vana
-      connections:
-        - token: ethereum|ethereum|0x177778F19E89dD1012BdBe603F144088A95C4B53
-      decimals: 18
-      name: Vana
-      standard: EvmHypNative
-      symbol: VANA
-WBTC/coti:
-  tokens:
-    - addressOrDenom: "0x5c43f06EF93bb0a2cd3C0f7b832AbA1F4d6575Ea"
-      chainName: ethereum
-      coinGeckoId: wrapped-bitcoin
-      collateralAddressOrDenom: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
-      connections:
-        - token: ethereum|coti|0x8C39B1fD0e6260fdf20652Fc436d25026832bfEA
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: "0x8C39B1fD0e6260fdf20652Fc436d25026832bfEA"
-      chainName: coti
-      connections:
-        - token: ethereum|ethereum|0x5c43f06EF93bb0a2cd3C0f7b832AbA1F4d6575Ea
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypSynthetic
-      symbol: WBTC
-WBTC/eclipsemainnet:
-  tokens:
-    - addressOrDenom: "0x5B4e223DE74ef8c3218e66EEcC541003CAB3121A"
-      chainName: ethereum
-      coinGeckoId: wrapped-bitcoin
-      collateralAddressOrDenom: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
-      connections:
-        - token: sealevel|eclipsemainnet|A7EGCDYFw5R7Jfm6cYtKvY8dmkrYMgwRCJFkyQwpHTYu
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: A7EGCDYFw5R7Jfm6cYtKvY8dmkrYMgwRCJFkyQwpHTYu
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: 7UTjr1VC6Z9DPsWD6mh5wPzNtufN17VnzpKS3ASpfAji
-      connections:
-        - token: ethereum|ethereum|0x5B4e223DE74ef8c3218e66EEcC541003CAB3121A
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: WBTC
-      standard: SealevelHypSynthetic
-      symbol: WBTC
-WBTC/form:
-  tokens:
-    - addressOrDenom: "0x0dc95Af5156fb0cC34a8c9BD646B748B9989A956"
-      chainName: form
-      connections:
-        - token: ethereum|ethereum|0xd0d5271926f352c0161b0365a4156E2Bc0f99FAD
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypSynthetic
-      symbol: WBTC
-    - addressOrDenom: "0xd0d5271926f352c0161b0365a4156E2Bc0f99FAD"
-      chainName: ethereum
-      coinGeckoId: wrapped-bitcoin
-      collateralAddressOrDenom: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
-      connections:
-        - token: ethereum|form|0x0dc95Af5156fb0cC34a8c9BD646B748B9989A956
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-WBTC/hyperevm:
-  tokens:
-    - addressOrDenom: "0x55A66567dFEc91e7Af39e0feb06009F35E8D68a9"
-      chainName: ethereum
-      coinGeckoId: wrapped-bitcoin
-      collateralAddressOrDenom: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
-      connections:
-        - token: ethereum|hyperevm|0xE2B36A37bD98ba81658dC5454F2dB2F98438d140
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: "0xE2B36A37bD98ba81658dC5454F2dB2F98438d140"
-      chainName: hyperevm
-      connections:
-        - token: ethereum|ethereum|0x55A66567dFEc91e7Af39e0feb06009F35E8D68a9
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypSynthetic
-      symbol: WBTC
-WBTC/kalychain:
-  tokens:
-    - addressOrDenom: "0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4"
-      chainName: arbitrum
-      collateralAddressOrDenom: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
-      connections:
-        - token: ethereum|bsc|0xD42Af909d323D88e0E933B6c50D3e91c279004ca
-        - token: ethereum|kalychain|0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455
-        - token: ethereum|polygon|0xfF00e814A0dCB9a614585c212C78Fdc596d02e47
-      decimals: 8
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: "0xD42Af909d323D88e0E933B6c50D3e91c279004ca"
-      chainName: bsc
-      collateralAddressOrDenom: "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c"
-      connections:
-        - token: ethereum|arbitrum|0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4
-        - token: ethereum|kalychain|0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455
-        - token: ethereum|polygon|0xfF00e814A0dCB9a614585c212C78Fdc596d02e47
-      decimals: 8
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: "0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455"
-      chainName: kalychain
-      connections:
-        - token: ethereum|arbitrum|0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4
-        - token: ethereum|bsc|0xD42Af909d323D88e0E933B6c50D3e91c279004ca
-        - token: ethereum|polygon|0xfF00e814A0dCB9a614585c212C78Fdc596d02e47
-      decimals: 8
-      name: Wrapped BTC
-      standard: EvmHypSynthetic
-      symbol: WBTC
-    - addressOrDenom: "0xfF00e814A0dCB9a614585c212C78Fdc596d02e47"
-      chainName: polygon
-      collateralAddressOrDenom: "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6"
-      connections:
-        - token: ethereum|arbitrum|0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4
-        - token: ethereum|bsc|0xD42Af909d323D88e0E933B6c50D3e91c279004ca
-        - token: ethereum|kalychain|0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455
-      decimals: 8
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-WBTC/zeronetwork:
-  tokens:
-    - addressOrDenom: "0x745C75868237F3635c486fe166639Cc4706512A9"
-      chainName: ethereum
-      coinGeckoId: wrapped-bitcoin
-      collateralAddressOrDenom: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
-      connections:
-        - token: ethereum|mode|0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1
-        - token: ethereum|scroll|0x10a5263ACED246fCD0977f1a3C6A238a14183096
-        - token: ethereum|zeronetwork|0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: "0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1"
-      chainName: mode
-      coinGeckoId: wrapped-bitcoin
-      collateralAddressOrDenom: "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF"
-      connections:
-        - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9
-        - token: ethereum|scroll|0x10a5263ACED246fCD0977f1a3C6A238a14183096
-        - token: ethereum|zeronetwork|0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: "0x10a5263ACED246fCD0977f1a3C6A238a14183096"
-      chainName: scroll
-      coinGeckoId: wrapped-bitcoin
-      collateralAddressOrDenom: "0x3C1BCa5a656e69edCD0D4E36BEbb3FcDAcA60Cf1"
-      connections:
-        - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9
-        - token: ethereum|mode|0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1
-        - token: ethereum|zeronetwork|0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: WBTC
-    - addressOrDenom: "0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94"
-      chainName: zeronetwork
-      connections:
-        - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9
-        - token: ethereum|mode|0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1
-        - token: ethereum|scroll|0x10a5263ACED246fCD0977f1a3C6A238a14183096
-      decimals: 8
-      logoURI: /deployments/warp_routes/WBTC/logo.svg
-      name: Wrapped BTC
-      standard: EvmHypSynthetic
-      symbol: WBTC
-WETH.a/artela:
-  tokens:
-    - addressOrDenom: "0xfae4e14D01D9E13FB5db20A0329ED0472A2D96C7"
-      chainName: artela
-      connections:
-        - token: ethereum|base|0x5B4d7FD7E6Cb11170137df1A0dB24645533EC0b5
-      decimals: 18
-      logoURI: /deployments/warp_routes/WETH/logo.svg
-      name: Wrapped Ether
-      standard: EvmHypSynthetic
-      symbol: WETH.a
-    - addressOrDenom: "0x5B4d7FD7E6Cb11170137df1A0dB24645533EC0b5"
-      chainName: base
-      coinGeckoId: l2-standard-bridged-weth-base
-      collateralAddressOrDenom: "0x4200000000000000000000000000000000000006"
-      connections:
-        - token: ethereum|artela|0xfae4e14D01D9E13FB5db20A0329ED0472A2D96C7
-      decimals: 18
-      logoURI: /deployments/warp_routes/WETH/logo.svg
-      name: Wrapped Ether
-      standard: EvmHypCollateral
-      symbol: WETH
-WIF/eclipsemainnet:
-  tokens:
-    - addressOrDenom: 6tBGmKNxirxBYnm9khkaTtcr2fhJ9YviCgRm1RWM8NJv
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: 841P4tebEgNux2jaWSjCoi9LhrVr9eHGjLc758Va3RPH
-      connections:
-        - token: sealevel|solanamainnet|CuQmsT4eSF4dYiiGUGYYQxJ7c58pUAD5ADE3BbFGzQKx
-      decimals: 6
-      logoURI: /deployments/warp_routes/WIF/logo.jpg
-      name: dogwifhat
-      standard: SealevelHypSynthetic
-      symbol: WIF
-    - addressOrDenom: CuQmsT4eSF4dYiiGUGYYQxJ7c58pUAD5ADE3BbFGzQKx
-      chainName: solanamainnet
-      coinGeckoId: dogwifcoin
-      collateralAddressOrDenom: EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm
-      connections:
-        - token: sealevel|eclipsemainnet|6tBGmKNxirxBYnm9khkaTtcr2fhJ9YviCgRm1RWM8NJv
-      decimals: 6
-      logoURI: /deployments/warp_routes/WIF/logo.jpg
-      name: dogwifhat
-      standard: SealevelHypCollateral
-      symbol: WIF
-WIF/soon:
-  tokens:
-    - addressOrDenom: HzP6KbL7fVAwqVgix4eJhijGMFeyg7mhHkQs7kBwrGPQ
-      chainName: soon
-      collateralAddressOrDenom: 4LamGFWF36vfBCVtWrZv17wDkbBSkJ8vSJhGFzui4wkZ
-      connections:
-        - token: sealevel|solanamainnet|BJkD7PFuMKRFPdc8H3pxL5u4KuQ2HWGkQgbvP3hw26AF
-      decimals: 6
-      logoURI: /deployments/warp_routes/WIF/logo.jpg
-      name: dogwifhat
-      standard: SealevelHypSynthetic
-      symbol: WIF
-    - addressOrDenom: BJkD7PFuMKRFPdc8H3pxL5u4KuQ2HWGkQgbvP3hw26AF
-      chainName: solanamainnet
-      coinGeckoId: dogwifcoin
-      collateralAddressOrDenom: EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm
-      connections:
-        - token: sealevel|soon|HzP6KbL7fVAwqVgix4eJhijGMFeyg7mhHkQs7kBwrGPQ
-      decimals: 6
-      logoURI: /deployments/warp_routes/WIF/logo.jpg
-      name: dogwifhat
-      standard: SealevelHypCollateral
-      symbol: WIF
-ai16z/soon:
-  tokens:
-    - addressOrDenom: BrJbX9a9bi9hvV5WesfbuXudQP49G8jnKEqAutRNMYK5
-      chainName: soon
-      collateralAddressOrDenom: Hc3feJHN3S7Kh2TorCKTFQWFx7jgznjzKNG37ufPmp2r
-      connections:
-        - token: sealevel|solanamainnet|9TxKLb6RBo4hEfFNN6up6obvebnEUcm2gkBXrzQFq8s8
-      decimals: 9
-      logoURI: /deployments/warp_routes/ai16z/logo.png
-      name: ai16z
-      standard: SealevelHypSynthetic
-      symbol: ai16z
-    - addressOrDenom: 9TxKLb6RBo4hEfFNN6up6obvebnEUcm2gkBXrzQFq8s8
-      chainName: solanamainnet
-      coinGeckoId: ai16z
-      collateralAddressOrDenom: HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC
-      connections:
-        - token: sealevel|soon|BrJbX9a9bi9hvV5WesfbuXudQP49G8jnKEqAutRNMYK5
-      decimals: 9
-      logoURI: /deployments/warp_routes/ai16z/logo.png
-      name: ai16z
-      standard: SealevelHypCollateral
-      symbol: ai16z
-amphrETH/arbitrum-ethereum-zircuit:
-  tokens:
-    - addressOrDenom: "0x6D251aADfc6Ff69031e01eA39bE3cb5BABf8438f"
-      chainName: arbitrum
-      connections:
-        - token: ethereum|ethereum|0xdc89990a6fdC1C922b841f1d977835628A24Ed57
-        - token: ethereum|zircuit|0x7D5a79539d7B1c9aE5e54d18EEE188840f1Fe4CC
-      decimals: 18
-      logoURI: /deployments/warp_routes/AMPHRETH/logo.svg
-      name: Amphor Restaked ETH
-      standard: EvmHypSynthetic
-      symbol: amphrETH
-    - addressOrDenom: "0xdc89990a6fdC1C922b841f1d977835628A24Ed57"
-      chainName: ethereum
-      coinGeckoId: ethereum
-      collateralAddressOrDenom: "0x5fD13359Ba15A84B76f7F87568309040176167cd"
-      connections:
-        - token: ethereum|arbitrum|0x6D251aADfc6Ff69031e01eA39bE3cb5BABf8438f
-        - token: ethereum|zircuit|0x7D5a79539d7B1c9aE5e54d18EEE188840f1Fe4CC
-      decimals: 18
-      logoURI: /deployments/warp_routes/AMPHRETH/logo.svg
-      name: Amphor Restaked ETH
-      standard: EvmHypCollateral
-      symbol: amphrETH
-    - addressOrDenom: "0x7D5a79539d7B1c9aE5e54d18EEE188840f1Fe4CC"
-      chainName: zircuit
-      connections:
-        - token: ethereum|arbitrum|0x6D251aADfc6Ff69031e01eA39bE3cb5BABf8438f
-        - token: ethereum|ethereum|0xdc89990a6fdC1C922b841f1d977835628A24Ed57
-      decimals: 18
-      logoURI: /deployments/warp_routes/AMPHRETH/logo.svg
-      name: Amphor Restaked ETH
-      standard: EvmHypSynthetic
-      symbol: amphrETH
-apxETH/eclipsemainnet:
-  tokens:
-    - addressOrDenom: "0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c"
-      chainName: ethereum
-      coinGeckoId: ethereum
-      collateralAddressOrDenom: "0x9ba021b0a9b958b5e75ce9f6dff97c7ee52cb3e6"
-      connections:
-        - token: sealevel|eclipsemainnet|9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
-      decimals: 18
-      logoURI: /deployments/warp_routes/APXETH/logo.svg
-      name: Autocompounding Pirex Ether
-      standard: EvmHypCollateral
-      symbol: apxETH
-    - addressOrDenom: 9pEgj7m2VkwLtJHPtTw5d8vbB7kfjzcXXCRgdwruW7C2
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: 6AjQBsySS1FtQmA7a4oYc6GYpHBTDqtSswptsVSTz3Tv
-      connections:
-        - token: ethereum|ethereum|0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c
-      decimals: 9
-      logoURI: /deployments/warp_routes/APXETH/logo.svg
-      name: Autocompounding Pirex Ether
-      standard: SealevelHypSynthetic
-      symbol: apxETH
-bbSOL/soon:
-  tokens:
-    - addressOrDenom: 5mzc5Sv61721Xr44Uw7Kb9txoMWLz8XYLrgCewe1sj2B
-      chainName: soon
-      collateralAddressOrDenom: GxV545AqavAEnu6HbUQGy2DQQpwuY5wAxwrq5F3yG3Mh
-      connections:
-        - token: sealevel|solanamainnet|8rodtMgnpCboxNiaQozdCTGiCEkK6BDXmFuoJ9qhTxfh
-      decimals: 9
-      logoURI: /deployments/warp_routes/bbSOL/logo.png
-      name: Bybit Staked SOL
-      standard: SealevelHypSynthetic
-      symbol: bbSOL
-    - addressOrDenom: 8rodtMgnpCboxNiaQozdCTGiCEkK6BDXmFuoJ9qhTxfh
-      chainName: solanamainnet
-      coinGeckoId: bybit-staked-sol
-      collateralAddressOrDenom: Bybit2vBJGhPF52GBdNaQfUJ6ZpThSgHBobjWZpLPb4B
-      connections:
-        - token: sealevel|soon|5mzc5Sv61721Xr44Uw7Kb9txoMWLz8XYLrgCewe1sj2B
-      decimals: 9
-      logoURI: /deployments/warp_routes/bbSOL/logo.png
-      name: Bybit Staked SOL
-      standard: SealevelHypCollateral
-      symbol: bbSOL
-cbBTC/base-ethereum-superseed:
-  tokens:
-    - addressOrDenom: "0x7710d2FC9A2E0452b28a2cBf550429b579347199"
-      chainName: ethereum
-      coinGeckoId: coinbase-wrapped-btc
-      collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
-      connections:
-        - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
-      decimals: 8
-      logoURI: /deployments/warp_routes/CBBTC/logo.svg
-      name: Coinbase Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: cbBTC
-    - addressOrDenom: "0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484"
-      chainName: superseed
-      collateralAddressOrDenom: "0x6f36dbd829de9b7e077db8a35b480d4329ceb331"
-      connections:
-        - token: ethereum|ethereum|0x7710d2FC9A2E0452b28a2cBf550429b579347199
-        - token: ethereum|base|0x66477F84bd21697c7781fc3992b3163463e3B224
-      decimals: 8
-      logoURI: /deployments/warp_routes/CBBTC/logo.svg
-      name: Coinbase Wrapped BTC
-      standard: EvmHypCollateralFiat
-      symbol: cbBTC
-    - addressOrDenom: "0x66477F84bd21697c7781fc3992b3163463e3B224"
-      chainName: base
-      coinGeckoId: coinbase-wrapped-btc
-      collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
-      connections:
-        - token: ethereum|superseed|0x0a78BC3CBBC79C4C6E5d4e5b2bbD042E58e93484
-      decimals: 8
-      logoURI: /deployments/warp_routes/CBBTC/logo.svg
-      name: Coinbase Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: cbBTC
-cbBTC/flowmainnet:
-  tokens:
-    - addressOrDenom: "0xfF5C22ea202258143557f6cc3bDe174dde6E8fE1"
-      chainName: ethereum
-      coinGeckoId: coinbase-wrapped-btc
-      collateralAddressOrDenom: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
-      connections:
-        - token: ethereum|flowmainnet|0xA0197b2044D28b08Be34d98b23c9312158Ea9A18
-      decimals: 8
-      logoURI: /deployments/warp_routes/CBBTC/logo.svg
-      name: Coinbase Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: cbBTC
-    - addressOrDenom: "0xA0197b2044D28b08Be34d98b23c9312158Ea9A18"
-      chainName: flowmainnet
-      connections:
-        - token: ethereum|ethereum|0xfF5C22ea202258143557f6cc3bDe174dde6E8fE1
-      decimals: 8
-      logoURI: /deployments/warp_routes/CBBTC/logo.svg
-      name: Coinbase Wrapped BTC
-      standard: EvmHypSynthetic
-      symbol: cbBTC
-cbBTC/zeronetwork:
-  tokens:
-    - addressOrDenom: "0x2A872Ae01375A5ca7e044cb0e75cb97621Ca954A"
-      chainName: base
-      coinGeckoId: coinbase-wrapped-btc
-      collateralAddressOrDenom: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
-      connections:
-        - token: ethereum|zeronetwork|0x3f7F02453518A55C0c6F89F0A6A8ab6c22Da01Df
-      decimals: 8
-      logoURI: /deployments/warp_routes/CBBTC/logo.svg
-      name: Coinbase Wrapped BTC
-      standard: EvmHypCollateral
-      symbol: cbBTC
-    - addressOrDenom: "0x3f7F02453518A55C0c6F89F0A6A8ab6c22Da01Df"
-      chainName: zeronetwork
-      connections:
-        - token: ethereum|base|0x2A872Ae01375A5ca7e044cb0e75cb97621Ca954A
-      decimals: 8
-      logoURI: /deployments/warp_routes/CBBTC/logo.svg
-      name: Coinbase Wrapped BTC
-      standard: EvmHypSynthetic
-      symbol: cbBTC
-enzoBTC/hyperevm:
-  tokens:
-    - addressOrDenom: "0xba06D7f285C6B0d5EacC50ceA931163B23Ab889c"
-      chainName: bsc
-      coinGeckoId: lorenzo-stbtc
-      collateralAddressOrDenom: "0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a"
-      connections:
-        - token: ethereum|hyperevm|0xcb98BD947B58445Fc4815f10285F44De42129918
-      decimals: 8
-      logoURI: /deployments/warp_routes/enzoBTC/logo.svg
-      name: Lorenzo Wrapped Bitcoin
-      standard: EvmHypCollateral
-      symbol: enzoBTC
-    - addressOrDenom: "0xcb98BD947B58445Fc4815f10285F44De42129918"
-      chainName: hyperevm
-      connections:
-        - token: ethereum|bsc|0xba06D7f285C6B0d5EacC50ceA931163B23Ab889c
-      decimals: 8
-      logoURI: /deployments/warp_routes/enzoBTC/logo.svg
-      name: Lorenzo Wrapped Bitcoin
+      logoURI: /deployments/warp_routes/ETH/logo.svg
+      name: Ether
       standard: EvmHypSynthetic
-      symbol: enzoBTC
-ezETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit:
+      symbol: ETH
+EZETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit:
   tokens:
     - addressOrDenom: "0xB26bBfC6d1F469C821Ea25099017862e7368F4E8"
       chainName: arbitrum
@@ -5452,7 +1535,377 @@ ezETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei
       name: Renzo Restaked ETH
       standard: EvmHypXERC20
       symbol: ezETH
-ezSOL/eclipsemainnet:
+EZETHSTAGE/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-worldchain-zircuit:
+  tokens:
+    - addressOrDenom: "0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5"
+      chainName: base
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA"
+      chainName: berachain
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x89E3530137aD51743536443a3EC838b502E72eb7"
+      chainName: blast
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x01bFbc80b32469c36DB4C7fc564E75475dfC278C"
+      chainName: bsc
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x74c8290836612e6251E49e8f3198fdD80C4DbEB8"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20Lockbox
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC"
+      chainName: fraxtal
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x9E3075E067932d744119e583B34d11b144CE1e4A"
+      chainName: linea
+      collateralAddressOrDenom: "0x5EA461E19ba6C002b7024E4A2e9CeFe79a47d3bB"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D"
+      chainName: mode
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326"
+      chainName: optimism
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0xdD313D475f8A9d81CBE2eA953a357f52e10BA357"
+      chainName: sei
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2"
+      chainName: swell
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x652e2F475Af7b1154817E09f5408f9011037492a"
+      chainName: taiko
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
+      chainName: unichain
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0xa2656c131A9F204F73944D7B60DDB17565E71292"
+      chainName: zircuit
+      collateralAddressOrDenom: "0x585afea249031Ea4168A379F664e91dFc5F77E7D"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|worldchain|0x04A0B8355EF40C6F15e203D582Ad66c717E1D247
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+    - addressOrDenom: "0x04A0B8355EF40C6F15e203D582Ad66c717E1D247"
+      chainName: worldchain
+      collateralAddressOrDenom: "0xC33DdE0a44e3Bed87cc3Ff0325D3fcbA5279930E"
+      connections:
+        - token: ethereum|arbitrum|0x3F536e156eD291c135ACb1D20F77C3B948E0F8a5
+        - token: ethereum|base|0xBbcA34fF173339094cAc51e33BADeE86AA2C35b5
+        - token: ethereum|berachain|0xDF96074eefdD1Ae137C008bE165A3Ed4A55718FA
+        - token: ethereum|blast|0x89E3530137aD51743536443a3EC838b502E72eb7
+        - token: ethereum|bsc|0x01bFbc80b32469c36DB4C7fc564E75475dfC278C
+        - token: ethereum|ethereum|0xdfA407edf065b7ECfD95c3c5F4C32F9f34a5Fe80
+        - token: ethereum|fraxtal|0x21581dE0CB0Ce91E87b9d5124543C75Fa01ED9CC
+        - token: ethereum|linea|0x9E3075E067932d744119e583B34d11b144CE1e4A
+        - token: ethereum|mode|0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D
+        - token: ethereum|optimism|0xbA6BbAe1c1d25fFdd5bB74192d687A25d5e65326
+        - token: ethereum|sei|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|swell|0x7712b534bF2b9fb7fA8D14EE83fDd077691a76C2
+        - token: ethereum|taiko|0x652e2F475Af7b1154817E09f5408f9011037492a
+        - token: ethereum|unichain|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+        - token: ethereum|zircuit|0xa2656c131A9F204F73944D7B60DDB17565E71292
+      decimals: 18
+      name: Renzo Restaked ETH Stage 9
+      standard: EvmHypXERC20
+      symbol: EZETHSTAGE
+EZSOL/eclipsemainnet-solanamainnet:
   tokens:
     - addressOrDenom: CshTfxXWMvnRAwBTCjQ4577bkP5po5ZuNG1QTuQxA5Au
       chainName: eclipsemainnet
@@ -5475,7 +1928,7 @@ ezSOL/eclipsemainnet:
       name: Renzo Restaked SOL
       standard: SealevelHypCollateral
       symbol: ezSOL
-fastUSD/ethereum-sei:
+FASTUSD/ethereum-sei:
   tokens:
     - addressOrDenom: "0xeA895A7Ff45d8d3857A04c1E38A362f3bd9a076f"
       chainName: sei
@@ -5498,7 +1951,3992 @@ fastUSD/ethereum-sei:
       name: fastUSD
       standard: EvmHypCollateral
       symbol: fastUSD
-kySOL/eclipsemainnet:
+FORM/ethereum-form:
+  tokens:
+    - addressOrDenom: "0xEa35E107fB64Ff8C3c8c37DB2d23A7179f31D8EC"
+      chainName: ethereum
+      coinGeckoId: form
+      collateralAddressOrDenom: "0xE7deE4823EE18F1347F1Cf7997f70B94eFDe2E1F"
+      connections:
+        - token: ethereum|form|0x688da80Dfe2916c0a0Aa360323E52Aa5881AdB78
+      decimals: 18
+      logoURI: /deployments/warp_routes/FORM/logo.svg
+      name: Form
+      standard: EvmHypCollateral
+      symbol: FORM
+    - addressOrDenom: "0x688da80Dfe2916c0a0Aa360323E52Aa5881AdB78"
+      chainName: form
+      connections:
+        - token: ethereum|ethereum|0xEa35E107fB64Ff8C3c8c37DB2d23A7179f31D8EC
+      decimals: 18
+      logoURI: /deployments/warp_routes/FORM/logo.svg
+      name: Form
+      standard: EvmHypSynthetic
+      symbol: FORM
+FUEL/base-bsc-ethereum:
+  tokens:
+    - addressOrDenom: "0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634"
+      chainName: base
+      connections:
+        - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
+        - token: ethereum|bsc|0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5
+      decimals: 9
+      logoURI: /deployments/warp_routes/FUEL/logo.svg
+      name: FUEL
+      standard: EvmHypSynthetic
+      symbol: FUEL
+    - addressOrDenom: "0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5"
+      chainName: bsc
+      connections:
+        - token: ethereum|ethereum|0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C
+        - token: ethereum|base|0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634
+      decimals: 9
+      logoURI: /deployments/warp_routes/FUEL/logo.svg
+      name: FUEL
+      standard: EvmHypSynthetic
+      symbol: FUEL
+    - addressOrDenom: "0x3cF30C1D8DECBF45CD36C9492F6395D47357b91C"
+      chainName: ethereum
+      coinGeckoId: fuel-network
+      collateralAddressOrDenom: "0x675B68AA4d9c2d3BB3F0397048e62E6B7192079c"
+      connections:
+        - token: ethereum|bsc|0x5c8daEabc57E9249606D3bD6d1E097eF492eA3C5
+        - token: ethereum|base|0xFdedBefEc262fE0eeaA2bbdE1afA2ef09AaB6634
+      decimals: 9
+      logoURI: /deployments/warp_routes/FUEL/logo.svg
+      name: FUEL
+      standard: EvmHypCollateral
+      symbol: FUEL
+Fartcoin/apechain-solanamainnet:
+  tokens:
+    - addressOrDenom: "0x5FC9b323013DAcF2d56046F9ff0f61c95c6A466B"
+      chainName: apechain
+      coinGeckoId: fartcoin
+      connections:
+        - token: sealevel|solanamainnet|4YGKdefcJMUVnzZFu124t7epCNWnAjmXbKXyC13HiAFR
+      decimals: 6
+      logoURI: /deployments/warp_routes/Fartcoin/logo.svg
+      name: Fartcoin
+      standard: EvmHypSynthetic
+      symbol: Fartcoin
+    - addressOrDenom: 4YGKdefcJMUVnzZFu124t7epCNWnAjmXbKXyC13HiAFR
+      chainName: solanamainnet
+      coinGeckoId: fartcoin
+      collateralAddressOrDenom: 9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump
+      connections:
+        - token: ethereum|apechain|0x5FC9b323013DAcF2d56046F9ff0f61c95c6A466B
+      decimals: 6
+      logoURI: /deployments/warp_routes/Fartcoin/logo.svg
+      name: Fartcoin
+      standard: SealevelHypCollateral
+      symbol: Fartcoin
+GAME/base-form:
+  tokens:
+    - addressOrDenom: "0x96D51cc3f7500d501bAeB1A2a62BB96fa03532F8"
+      chainName: form
+      connections:
+        - token: ethereum|base|0x6a5579ABECE07b73d4d92a8bBFF51aF827bB21f1
+      decimals: 18
+      logoURI: /deployments/warp_routes/GAME/logo.svg
+      name: GAME by Virtuals
+      standard: EvmHypSynthetic
+      symbol: GAME
+    - addressOrDenom: "0x6a5579ABECE07b73d4d92a8bBFF51aF827bB21f1"
+      chainName: base
+      coinGeckoId: game-by-virtuals
+      collateralAddressOrDenom: "0x1C4CcA7C5DB003824208aDDA61Bd749e55F463a3"
+      connections:
+        - token: ethereum|form|0x96D51cc3f7500d501bAeB1A2a62BB96fa03532F8
+      decimals: 18
+      logoURI: /deployments/warp_routes/GAME/logo.svg
+      name: GAME by Virtuals
+      standard: EvmHypCollateral
+      symbol: GAME
+GG/apechain-arbitrum:
+  tokens:
+    - addressOrDenom: "0x0bb999f106C1246810686891f97Bbc22C53E4850"
+      chainName: apechain
+      connections:
+        - token: ethereum|arbitrum|0x0bb999f106C1246810686891f97Bbc22C53E4850
+      decimals: 18
+      logoURI: /deployments/warp_routes/GG/logo.svg
+      name: GG
+      standard: EvmHypSynthetic
+      symbol: GG
+    - addressOrDenom: "0x0bb999f106C1246810686891f97Bbc22C53E4850"
+      chainName: arbitrum
+      coinGeckoId: reboot
+      collateralAddressOrDenom: "0x000000000026839b3f4181f2cF69336af6153b99"
+      connections:
+        - token: ethereum|apechain|0x0bb999f106C1246810686891f97Bbc22C53E4850
+      decimals: 18
+      logoURI: /deployments/warp_routes/GG/logo.svg
+      name: GG
+      standard: EvmHypCollateral
+      symbol: GG
+GIGA/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: GHcg7qY2cXQ4Ej9xQqjnLdYUV41bt2ncaPuo5AxN5eTy
+      chainName: soon
+      collateralAddressOrDenom: 5msdLukGrv3nkRH8Nwz6LELahbMB5yzmaM6xGhUfcysm
+      connections:
+        - token: sealevel|solanamainnet|CjP8N5L2KV4iWobXoVV1dhftRdfQ7S3rKVrT7Lja9Jku
+      decimals: 5
+      logoURI: /deployments/warp_routes/GIGA/logo.svg
+      name: GIGACHAD
+      standard: SealevelHypSynthetic
+      symbol: GIGA
+    - addressOrDenom: CjP8N5L2KV4iWobXoVV1dhftRdfQ7S3rKVrT7Lja9Jku
+      chainName: solanamainnet
+      coinGeckoId: gigachad-2
+      collateralAddressOrDenom: 63LfDmNb3MQ8mw9MtZ2To9bEA2M71kZUUGq5tiJxcqj9
+      connections:
+        - token: sealevel|soon|GHcg7qY2cXQ4Ej9xQqjnLdYUV41bt2ncaPuo5AxN5eTy
+      decimals: 5
+      logoURI: /deployments/warp_routes/GIGA/logo.svg
+      name: GIGACHAD
+      standard: SealevelHypCollateral
+      symbol: GIGA
+GOAT/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 9NhiDziXERQUsb3NxRNdamR6ivfeF8GanUJvBffQbyBF
+      chainName: soon
+      collateralAddressOrDenom: 6ABPSb8Pj7B6waFjcPf8JgosQnghqqqiL9kAL3ykatk4
+      connections:
+        - token: sealevel|solanamainnet|HM4qABV4C6KPYhZQmJnQXJ9Q9Syo5waPcxFWLQNiDq2e
+      decimals: 6
+      logoURI: /deployments/warp_routes/GOAT/logo.svg
+      name: Goatseus Maximus
+      standard: SealevelHypSynthetic
+      symbol: GOAT
+    - addressOrDenom: HM4qABV4C6KPYhZQmJnQXJ9Q9Syo5waPcxFWLQNiDq2e
+      chainName: solanamainnet
+      coinGeckoId: goatseus-maximus
+      collateralAddressOrDenom: CzLSujWBLFsSjncfkh59rUFqvafWcY5tzedWJSuypump
+      connections:
+        - token: sealevel|soon|9NhiDziXERQUsb3NxRNdamR6ivfeF8GanUJvBffQbyBF
+      decimals: 6
+      logoURI: /deployments/warp_routes/GOAT/logo.svg
+      name: Goatseus Maximus
+      standard: SealevelHypCollateral
+      symbol: GOAT
+GPS/base-bsc:
+  tokens:
+    - addressOrDenom: "0x01efc19badCAC4EDaE0d75c5F344AcD0F7311722"
+      chainName: base
+      coinGeckoId: goplus-security
+      collateralAddressOrDenom: "0x0c1dc73159e30c4b06170f2593d3118968a0dca5"
+      connections:
+        - token: ethereum|bsc|0x9A4a67721573f2c9209DfFf972c52Be4E3F6642e
+      decimals: 18
+      logoURI: /deployments/warp_routes/GPS/logo.svg
+      name: GoPlus Security
+      standard: EvmHypCollateral
+      symbol: GPS
+    - addressOrDenom: "0x9A4a67721573f2c9209DfFf972c52Be4E3F6642e"
+      chainName: bsc
+      connections:
+        - token: ethereum|base|0x01efc19badCAC4EDaE0d75c5F344AcD0F7311722
+      decimals: 18
+      logoURI: /deployments/warp_routes/GPS/logo.svg
+      name: GoPlus Security
+      standard: EvmHypSynthetic
+      symbol: GPS
+HYPER/arbitrum-base-bsc-ethereum-optimism:
+  tokens:
+    - addressOrDenom: "0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
+        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
+      decimals: 18
+      logoURI: /deployments/warp_routes/HYPER/logo.svg
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPER
+    - addressOrDenom: "0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4"
+      chainName: base
+      connections:
+        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
+        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
+      decimals: 18
+      logoURI: /deployments/warp_routes/HYPER/logo.svg
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPER
+    - addressOrDenom: "0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4"
+      chainName: bsc
+      connections:
+        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
+        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
+      decimals: 18
+      logoURI: /deployments/warp_routes/HYPER/logo.svg
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPER
+    - addressOrDenom: "0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5"
+      chainName: ethereum
+      coinGeckoId: hyperlane
+      connections:
+        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|optimism|0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979
+      decimals: 18
+      logoURI: /deployments/warp_routes/HYPER/logo.svg
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPER
+    - addressOrDenom: "0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979"
+      chainName: optimism
+      connections:
+        - token: ethereum|arbitrum|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|base|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|bsc|0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4
+        - token: ethereum|ethereum|0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5
+      decimals: 18
+      logoURI: /deployments/warp_routes/HYPER/logo.svg
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPER
+HYPERSTAGE/arbitrum-base-bsc-ethereum-optimism:
+  tokens:
+    - addressOrDenom: "0xF80dcED2488Add147E60561F8137338F7f3976e1"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
+        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
+        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
+        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
+      decimals: 18
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPERSTAGE
+    - addressOrDenom: "0x830B15a1986C75EaF8e048442a13715693CBD8bD"
+      chainName: base
+      connections:
+        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
+        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
+        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
+        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
+      decimals: 18
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPERSTAGE
+    - addressOrDenom: "0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D"
+      chainName: bsc
+      connections:
+        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
+        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
+        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
+        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
+      decimals: 18
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPERSTAGE
+    - addressOrDenom: "0xC10c27afcb915439C27cAe54F5F46Da48cd71190"
+      chainName: ethereum
+      connections:
+        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
+        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
+        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
+        - token: ethereum|optimism|0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8
+      decimals: 18
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPERSTAGE
+    - addressOrDenom: "0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8"
+      chainName: optimism
+      connections:
+        - token: ethereum|arbitrum|0xF80dcED2488Add147E60561F8137338F7f3976e1
+        - token: ethereum|base|0x830B15a1986C75EaF8e048442a13715693CBD8bD
+        - token: ethereum|bsc|0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D
+        - token: ethereum|ethereum|0xC10c27afcb915439C27cAe54F5F46Da48cd71190
+      decimals: 18
+      name: Hyperlane
+      standard: EvmHypSynthetic
+      symbol: HYPERSTAGE
+INJ/inevm-injective:
+  options:
+    interchainFeeConstants:
+      - addressOrDenom: inj
+        amount: "30000000000000000"
+        destination: inevm
+        origin: injective
+    localFeeConstants:
+      - addressOrDenom: inj
+        amount: "1000000000000000"
+        destination: inevm
+        origin: injective
+  tokens:
+    - addressOrDenom: inj1mv9tjvkaw7x8w8y9vds8pkfq46g2vcfkjehc6k
+      chainName: injective
+      coinGeckoId: injective-protocol
+      connections:
+        - token: ethereum|inevm|0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4
+      decimals: 18
+      logoURI: /deployments/warp_routes/INJ/logo.svg
+      name: Injective Coin
+      standard: CwHypNative
+      symbol: INJ
+    - addressOrDenom: "0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4"
+      chainName: inevm
+      connections:
+        - token: cosmos|injective|inj1mv9tjvkaw7x8w8y9vds8pkfq46g2vcfkjehc6k
+      decimals: 18
+      logoURI: /deployments/warp_routes/INJ/logo.svg
+      name: Injective Coin
+      standard: EvmHypNative
+      symbol: INJ
+INTERN/echos-inevm:
+  tokens:
+    - addressOrDenom: "0xEad0F28bDCEdb19698C4D9f64fd69c70d24ec0D5"
+      chainName: echos
+      collateralAddressOrDenom: "0x7cd386bd75f2a5d7706c39da56bc5d52544b5617"
+      connections:
+        - token: ethereum|inevm|0xFd2fCfee83bDB31c6f9bee4013FAEe0c675f2Dd5
+      decimals: 18
+      logoURI: /deployments/warp_routes/INTERN/logo.png
+      name: Injective Intern
+      standard: EvmHypCollateral
+      symbol: INTERN
+    - addressOrDenom: "0xFd2fCfee83bDB31c6f9bee4013FAEe0c675f2Dd5"
+      chainName: inevm
+      connections:
+        - token: ethereum|echos|0xEad0F28bDCEdb19698C4D9f64fd69c70d24ec0D5
+      decimals: 18
+      logoURI: /deployments/warp_routes/INTERN/logo.png
+      name: Injective Intern
+      standard: EvmHypSynthetic
+      symbol: INTERN
+JC/base-zeronetwork:
+  tokens:
+    - addressOrDenom: "0xa7ec41980E9871e1FCA7131D05427b15A8c95E9F"
+      chainName: base
+      collateralAddressOrDenom: "0x93aC8f81e799c3b76112A649715DD86CEa655BDF"
+      connections:
+        - token: ethereum|zeronetwork|0x7d6dF201ed9fD35146F89aE98818843eDdadc053
+      decimals: 18
+      logoURI: /deployments/warp_routes/JC/logo.svg
+      name: JACKIE CHAIN
+      standard: EvmHypCollateral
+      symbol: JC
+    - addressOrDenom: "0x7d6dF201ed9fD35146F89aE98818843eDdadc053"
+      chainName: zeronetwork
+      connections:
+        - token: ethereum|base|0xa7ec41980E9871e1FCA7131D05427b15A8c95E9F
+      decimals: 18
+      logoURI: /deployments/warp_routes/JC/logo.svg
+      name: JACKIE CHAIN
+      standard: EvmHypSynthetic
+      symbol: JC
+KLC/arbitrum-bsc-kalychain-polygon:
+  tokens:
+    - addressOrDenom: "0x7542c62565f48520A34Cf79884656efDEdD38176"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|bsc|0x02CF1778c07584D92b610E0C03fA285DfD00c354
+        - token: ethereum|kalychain|0x8A1ABbB167b149F2493C8141091028fD812Da6E4
+        - token: ethereum|polygon|0x285C14145EB75A1918B48f93E126139ea1a0f294
+      decimals: 18
+      name: KalyCoin
+      standard: EvmHypSynthetic
+      symbol: KLC
+    - addressOrDenom: "0x02CF1778c07584D92b610E0C03fA285DfD00c354"
+      chainName: bsc
+      connections:
+        - token: ethereum|arbitrum|0x7542c62565f48520A34Cf79884656efDEdD38176
+        - token: ethereum|kalychain|0x8A1ABbB167b149F2493C8141091028fD812Da6E4
+        - token: ethereum|polygon|0x285C14145EB75A1918B48f93E126139ea1a0f294
+      decimals: 18
+      name: KalyCoin
+      standard: EvmHypSynthetic
+      symbol: KLC
+    - addressOrDenom: "0x8A1ABbB167b149F2493C8141091028fD812Da6E4"
+      chainName: kalychain
+      connections:
+        - token: ethereum|arbitrum|0x7542c62565f48520A34Cf79884656efDEdD38176
+        - token: ethereum|bsc|0x02CF1778c07584D92b610E0C03fA285DfD00c354
+        - token: ethereum|polygon|0x285C14145EB75A1918B48f93E126139ea1a0f294
+      decimals: 18
+      name: KalyCoin
+      standard: EvmHypNative
+      symbol: KLC
+    - addressOrDenom: "0x285C14145EB75A1918B48f93E126139ea1a0f294"
+      chainName: polygon
+      connections:
+        - token: ethereum|arbitrum|0x7542c62565f48520A34Cf79884656efDEdD38176
+        - token: ethereum|bsc|0x02CF1778c07584D92b610E0C03fA285DfD00c354
+        - token: ethereum|kalychain|0x8A1ABbB167b149F2493C8141091028fD812Da6E4
+      decimals: 18
+      name: KalyCoin
+      standard: EvmHypSynthetic
+      symbol: KLC
+KYVE/base-kyve:
+  tokens:
+    - addressOrDenom: "0xAD13BcE42394Add02e6c215a40e582309B7975C7"
+      chainName: base
+      coinGeckoId: kyve-network
+      connections:
+        - token: cosmosnative|kyve|0x726f757465725f61707000000000000000000000000000010000000000000000
+      decimals: 6
+      logoURI: /deployments/warp_routes/KYVE/logo.svg
+      name: KYVE Network
+      standard: EvmHypSynthetic
+      symbol: KYVE
+    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
+      chainName: kyve
+      coinGeckoId: kyve-network
+      connections:
+        - token: ethereum|base|0xAD13BcE42394Add02e6c215a40e582309B7975C7
+      decimals: 6
+      logoURI: /deployments/warp_routes/KYVE/logo.svg
+      name: KYVE Network
+      standard: CosmosNativeHypCollateral
+      symbol: KYVE
+LESS/arthera-celo:
+  tokens:
+    - addressOrDenom: "0xa6D019ea6D132FF091d5bef0B077EC1e045c9461"
+      chainName: arthera
+      collateralAddressOrDenom: "0xdc93F137EdfB14133686e90de9C845A7c7Fca3De"
+      connections:
+        - token: ethereum|celo|0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D
+      decimals: 18
+      logoURI: /deployments/warp_routes/LESS/logo.svg
+      name: Lessgas
+      standard: EvmHypCollateral
+      symbol: LESS
+    - addressOrDenom: "0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D"
+      chainName: celo
+      connections:
+        - token: ethereum|arthera|0xa6D019ea6D132FF091d5bef0B077EC1e045c9461
+      decimals: 18
+      logoURI: /deployments/warp_routes/LESS/logo.svg
+      name: Lessgas
+      standard: EvmHypSynthetic
+      symbol: LESS
+LESS/artheratestnet-holesky:
+  tokens:
+    - addressOrDenom: "0x48867511B5c9c6A0E28b36553cd0DC9A0A95A6D2"
+      chainName: artheratestnet
+      collateralAddressOrDenom: "0xcae706200441f8D3f8E880B7C977c57f0c4747d5"
+      connections:
+        - token: ethereum|holesky|0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D
+      decimals: 18
+      logoURI: /deployments/warp_routes/LESS/logo.svg
+      name: Lessgas
+      standard: EvmHypCollateral
+      symbol: LESS
+    - addressOrDenom: "0x2201B4cC55c82EE23554C9CDA5CFF62BBa01c69D"
+      chainName: holesky
+      connections:
+        - token: ethereum|artheratestnet|0x48867511B5c9c6A0E28b36553cd0DC9A0A95A6D2
+      decimals: 18
+      logoURI: /deployments/warp_routes/LESS/logo.svg
+      name: Lessgas
+      standard: EvmHypSynthetic
+      symbol: LESS
+LOGX/arbitrum-solanamainnet:
+  tokens:
+    - addressOrDenom: "0x79EdA6DAfB2B9531930CbD9240A73B5eF0e8c9E2"
+      chainName: arbitrum
+      coinGeckoId: logx
+      collateralAddressOrDenom: "0x59062301Fb510F4ea2417B67404CB16D31E604BA"
+      connections:
+        - token: sealevel|solanamainnet|975wpF9KmWTVnh398Qs6VcnDtYZsXVWtKiSkXfWH22GP
+      decimals: 18
+      logoURI: /deployments/warp_routes/LOGX/logo.png
+      name: LogX Network
+      standard: EvmHypCollateral
+      symbol: LOGX
+    - addressOrDenom: 975wpF9KmWTVnh398Qs6VcnDtYZsXVWtKiSkXfWH22GP
+      chainName: solanamainnet
+      collateralAddressOrDenom: 7cHJTPkhnCKesVFijmMXVFVY4HjpkLd9qYjg6neb74yD
+      connections:
+        - token: ethereum|arbitrum|0x79EdA6DAfB2B9531930CbD9240A73B5eF0e8c9E2
+      decimals: 9
+      logoURI: /deployments/warp_routes/LOGX/logo.png
+      name: LogX Network
+      standard: SealevelHypSynthetic
+      symbol: LOGX
+LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon:
+  tokens:
+    - addressOrDenom: "0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047"
+      chainName: bsc
+      connections:
+        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypSynthetic
+      symbol: LUMIA
+    - addressOrDenom: "0xdD313D475f8A9d81CBE2eA953a357f52e10BA357"
+      chainName: ethereum
+      coinGeckoId: lumia
+      collateralAddressOrDenom: "0xD9343a049D5DBd89CD19DC6BcA8c48fB3a0a42a7"
+      connections:
+        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypCollateral
+      symbol: LUMIA
+    - addressOrDenom: "0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B"
+      chainName: lumiaprism
+      coinGeckoId: lumia
+      connections:
+        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypNative
+      symbol: LUMIA
+    - addressOrDenom: "0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypSynthetic
+      symbol: LUMIA
+    - addressOrDenom: "0x02EB40D41676F20eDcF95f9110f00412ca53a85F"
+      chainName: avalanche
+      connections:
+        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypSynthetic
+      symbol: LUMIA
+    - addressOrDenom: "0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4"
+      chainName: base
+      connections:
+        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypSynthetic
+      symbol: LUMIA
+    - addressOrDenom: "0x978B9dE4D8A41b023408383e3B4F760932AaDdc1"
+      chainName: optimism
+      connections:
+        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+        - token: ethereum|polygon|0x72749806df5A6BBb72032039bbE9a3f1b17D1936
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypSynthetic
+      symbol: LUMIA
+    - addressOrDenom: "0x72749806df5A6BBb72032039bbE9a3f1b17D1936"
+      chainName: polygon
+      connections:
+        - token: ethereum|bsc|0x7F39BcdCa8E0E581c1d43aaa1cB862AA1c8C2047
+        - token: ethereum|ethereum|0xdD313D475f8A9d81CBE2eA953a357f52e10BA357
+        - token: ethereum|lumiaprism|0x98eF2a7DD4261BE8691DCb4B95a08De84d4Ffe5B
+        - token: ethereum|arbitrum|0x4e2B1FcC07a8E80736c80Bcf53753e8d0b8042f1
+        - token: ethereum|avalanche|0x02EB40D41676F20eDcF95f9110f00412ca53a85F
+        - token: ethereum|base|0x155c68274c5C7729c64CF6B0F21f1E6110Fa00d4
+        - token: ethereum|optimism|0x978B9dE4D8A41b023408383e3B4F760932AaDdc1
+      decimals: 18
+      logoURI: /deployments/warp_routes/LUMIA/logo.svg
+      name: Lumia Token
+      standard: EvmHypSynthetic
+      symbol: LUMIA
+MAGIC/arbitrum-treasure:
+  tokens:
+    - addressOrDenom: "0x240d04a70B038369C8DF703B78B3b47332EeE116"
+      chainName: arbitrum
+      coinGeckoId: magic
+      collateralAddressOrDenom: "0x539bdE0d7Dbd336b79148AA742883198BBF60342"
+      connections:
+        - token: ethereum|treasure|0x01c94f24F8D72BB9C3f61c4ED0b9b86BfC23BADd
+      decimals: 18
+      name: MAGIC
+      standard: EvmHypCollateral
+      symbol: MAGIC
+    - addressOrDenom: "0x01c94f24F8D72BB9C3f61c4ED0b9b86BfC23BADd"
+      chainName: treasure
+      connections:
+        - token: ethereum|arbitrum|0x240d04a70B038369C8DF703B78B3b47332EeE116
+      decimals: 18
+      name: MAGIC
+      standard: EvmHypNative
+      symbol: MAGIC
+MEW/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 9JcBcd9bRDQjRtkZq7sWfNF4DRFRA24KsuhV9rTemUgC
+      chainName: soon
+      collateralAddressOrDenom: GvW8my8MggjKf8m3LAds4bpL4GgQRmRaDhbWUon7ZzF3
+      connections:
+        - token: sealevel|solanamainnet|BEzLRBDBJyRrzZN2CfGJB3bedBj3HwHqj6MB8BQn1mdL
+      decimals: 5
+      logoURI: /deployments/warp_routes/MEW/logo.svg
+      name: MEW
+      standard: SealevelHypSynthetic
+      symbol: MEW
+    - addressOrDenom: BEzLRBDBJyRrzZN2CfGJB3bedBj3HwHqj6MB8BQn1mdL
+      chainName: solanamainnet
+      coinGeckoId: mew
+      collateralAddressOrDenom: MEW1gQWJ3nEXg2qgERiKu7FAFj79PHvQVREQUzScPP5
+      connections:
+        - token: sealevel|soon|9JcBcd9bRDQjRtkZq7sWfNF4DRFRA24KsuhV9rTemUgC
+      decimals: 5
+      logoURI: /deployments/warp_routes/MEW/logo.svg
+      name: MEW
+      standard: SealevelHypCollateral
+      symbol: MEW
+MIGGLES/base-zeronetwork:
+  tokens:
+    - addressOrDenom: "0x9C417D68dE6Acb6a9b0fBeD56767F1f3548A48a1"
+      chainName: base
+      coinGeckoId: mister-miggles
+      collateralAddressOrDenom: "0xB1a03EdA10342529bBF8EB700a06C60441fEf25d"
+      connections:
+        - token: ethereum|zeronetwork|0xEE7bF7bB7575163edd413e36E9f06a124b51B9fa
+      decimals: 18
+      logoURI: /deployments/warp_routes/MIGGLES/logo.svg
+      name: Mister Miggles
+      standard: EvmHypCollateral
+      symbol: MIGGLES
+    - addressOrDenom: "0xEE7bF7bB7575163edd413e36E9f06a124b51B9fa"
+      chainName: zeronetwork
+      connections:
+        - token: ethereum|base|0x9C417D68dE6Acb6a9b0fBeD56767F1f3548A48a1
+      decimals: 18
+      logoURI: /deployments/warp_routes/MIGGLES/logo.svg
+      name: Mister Miggles
+      standard: EvmHypSynthetic
+      symbol: MIGGLES
+MILK/bsc-milkyway:
+  tokens:
+    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
+      chainName: milkyway
+      coinGeckoId: milkyway-2
+      connections:
+        - token: ethereum|bsc|0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD
+      decimals: 6
+      logoURI: /deployments/warp_routes/MILK/logo.svg
+      name: MilkyWay
+      standard: CosmosNativeHypCollateral
+      symbol: MILK
+    - addressOrDenom: "0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD"
+      chainName: bsc
+      connections:
+        - token: cosmosnative|milkyway|0x726f757465725f61707000000000000000000000000000010000000000000000
+      decimals: 6
+      logoURI: /deployments/warp_routes/MILK/logo.svg
+      name: MilkyWay
+      standard: EvmHypSynthetic
+      symbol: MILK
+MINT/mint-solanamainnet:
+  tokens:
+    - addressOrDenom: "0x787561C5131d9328a28Ef810867299176a5b66C4"
+      chainName: mint
+      coinGeckoId: usdc
+      collateralAddressOrDenom: "0x8511138208529fe1b9a37b863c7EEE3Fe234b7Ab"
+      connections:
+        - token: sealevel|solanamainnet|DTp6yLfHyGo46Zu7xrbXwUF3YZSaYV2W7UhQb8q9QN5Q
+      decimals: 18
+      logoURI: /deployments/warp_routes/MINT/logo.svg
+      name: Mint
+      standard: EvmHypCollateral
+      symbol: MINT
+    - addressOrDenom: DTp6yLfHyGo46Zu7xrbXwUF3YZSaYV2W7UhQb8q9QN5Q
+      chainName: solanamainnet
+      collateralAddressOrDenom: HwmvBfZP6SUgaQSYtLicvLqY4UepKw2J1LLkqFxiLB7L
+      connections:
+        - token: ethereum|mint|0x787561C5131d9328a28Ef810867299176a5b66C4
+      decimals: 9
+      logoURI: /deployments/warp_routes/MINT/logo.svg
+      name: Mint
+      standard: SealevelHypSynthetic
+      symbol: MINT
+MIRAI/abstract-bsc-solanamainnet:
+  tokens:
+    - addressOrDenom: "0xbCdA9Ae6A148Bc4fb411979fFA883c9D1DF08F43"
+      chainName: abstract
+      connections:
+        - token: ethereum|bsc|0xcb508877ffe5a085B2474641dD3B28F8Bc22A57c
+        - token: sealevel|solanamainnet|27CK2NMbkSTTddgbBDvujccpqNrfGztr9WggXusNmnD1
+      decimals: 6
+      logoURI: /deployments/warp_routes/MIRAI/logo.jpg
+      name: Project Mirai
+      standard: EvmHypSynthetic
+      symbol: MIRAI
+    - addressOrDenom: "0xcb508877ffe5a085B2474641dD3B28F8Bc22A57c"
+      chainName: bsc
+      connections:
+        - token: ethereum|abstract|0xbCdA9Ae6A148Bc4fb411979fFA883c9D1DF08F43
+        - token: sealevel|solanamainnet|27CK2NMbkSTTddgbBDvujccpqNrfGztr9WggXusNmnD1
+      decimals: 6
+      logoURI: /deployments/warp_routes/MIRAI/logo.jpg
+      name: Project Mirai
+      standard: EvmHypSynthetic
+      symbol: MIRAI
+    - addressOrDenom: 27CK2NMbkSTTddgbBDvujccpqNrfGztr9WggXusNmnD1
+      chainName: solanamainnet
+      collateralAddressOrDenom: 5evN2exivZXJfLaA1KhHfiJKWfwH8znqyH36w1SFz89Y
+      connections:
+        - token: ethereum|abstract|0xbCdA9Ae6A148Bc4fb411979fFA883c9D1DF08F43
+        - token: ethereum|bsc|0xcb508877ffe5a085B2474641dD3B28F8Bc22A57c
+      decimals: 6
+      logoURI: /deployments/warp_routes/MIRAI/logo.jpg
+      name: Project Mirai
+      standard: SealevelHypCollateral
+      symbol: MIRAI
+NTN/holesky-piccadilly:
+  tokens:
+    - addressOrDenom: "0xdF73856d44C1f7b3B14Fd0DaD8B0792fCf1c3f68"
+      chainName: holesky
+      connections:
+        - token: ethereum|piccadilly|0xB671973E737c1793eE5AbCaA97769d7a81445704
+      decimals: 18
+      name: Newton
+      standard: EvmHypSynthetic
+      symbol: NTN
+    - addressOrDenom: "0xB671973E737c1793eE5AbCaA97769d7a81445704"
+      chainName: piccadilly
+      collateralAddressOrDenom: "0xBd770416a3345F91E4B34576cb804a576fa48EB1"
+      connections:
+        - token: ethereum|holesky|0xdF73856d44C1f7b3B14Fd0DaD8B0792fCf1c3f68
+      decimals: 18
+      name: Newton
+      standard: EvmHypCollateral
+      symbol: NTN
+OORT/bsc-ethereum-oortmainnet:
+  tokens:
+    - addressOrDenom: "0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B"
+      chainName: bsc
+      collateralAddressOrDenom: "0x5651fA7a726B9Ec0cAd00Ee140179912B6E73599"
+      connections:
+        - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
+        - token: ethereum|ethereum|0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697
+      decimals: 18
+      logoURI: /deployments/warp_routes/OORT/logo.svg
+      name: OORT
+      standard: EvmHypCollateral
+      symbol: OORT
+    - addressOrDenom: "0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B"
+      chainName: oortmainnet
+      connections:
+        - token: ethereum|bsc|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
+        - token: ethereum|ethereum|0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697
+      decimals: 18
+      logoURI: /deployments/warp_routes/OORT/logo.svg
+      name: OORT
+      standard: EvmHypNative
+      symbol: OORT
+    - addressOrDenom: "0x70f34d5cC2527Cd81de9F6e7C9208f26f7252697"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x5651fA7a726B9Ec0cAd00Ee140179912B6E73599"
+      connections:
+        - token: ethereum|bsc|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
+        - token: ethereum|oortmainnet|0x15366f1a7c71baa6fd1c8FAB56b30faf98d56a3B
+      decimals: 18
+      logoURI: /deployments/warp_routes/OORT/logo.svg
+      name: OORT
+      standard: EvmHypCollateral
+      symbol: OORT
+OP/optimism-superseed:
+  tokens:
+    - addressOrDenom: "0x0Ea3C23A4dC198c289D5443ac302335aBc86E6b1"
+      chainName: optimism
+      coinGeckoId: optimism
+      collateralAddressOrDenom: "0x4200000000000000000000000000000000000042"
+      connections:
+        - token: ethereum|superseed|0x4e128A1b613A9C9Ecf650FeE461c353612559fcf
+      decimals: 18
+      logoURI: /deployments/warp_routes/OP/logo.svg
+      name: Optimism
+      standard: EvmHypCollateral
+      symbol: OP
+    - addressOrDenom: "0x4e128A1b613A9C9Ecf650FeE461c353612559fcf"
+      chainName: superseed
+      connections:
+        - token: ethereum|optimism|0x0Ea3C23A4dC198c289D5443ac302335aBc86E6b1
+      decimals: 18
+      logoURI: /deployments/warp_routes/OP/logo.svg
+      name: Optimism
+      standard: EvmHypSynthetic
+      symbol: OP
+ORCA/eclipsemainnet-solanamainnet:
+  tokens:
+    - addressOrDenom: 8CvWJS7SPtauAXinJUURkBDLsGUXWiiTdENkEFUPjQ9j
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: 2tGbYEm4nuPFyS6zjDTELzEhvVKizgKewi6xT7AaSKzn
+      connections:
+        - token: sealevel|solanamainnet|8acihSm2QTGswniKgdgr4JBvJihZ1cakfvbqWCPBLoSp
+      decimals: 6
+      logoURI: /deployments/warp_routes/ORCA/logo.svg
+      name: Orca
+      standard: SealevelHypSynthetic
+      symbol: ORCA
+    - addressOrDenom: 8acihSm2QTGswniKgdgr4JBvJihZ1cakfvbqWCPBLoSp
+      chainName: solanamainnet
+      coinGeckoId: orca
+      collateralAddressOrDenom: orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE
+      connections:
+        - token: sealevel|eclipsemainnet|8CvWJS7SPtauAXinJUURkBDLsGUXWiiTdENkEFUPjQ9j
+      decimals: 6
+      logoURI: /deployments/warp_routes/ORCA/logo.svg
+      name: Orca
+      standard: SealevelHypCollateral
+      symbol: ORCA
+PAXG/arbitrum-ethereum:
+  tokens:
+    - addressOrDenom: "0x68A593C7F42e0f6616F9356dCb1CFd130e4e7694"
+      chainName: ethereum
+      coinGeckoId: pax-gold
+      collateralAddressOrDenom: "0x45804880de22913dafe09f4980848ece6ecbaf78"
+      connections:
+        - token: ethereum|arbitrum|0xE7eFb127249Ec17B484B5Bb0Ea5f79A14A6d0721
+      decimals: 18
+      logoURI: /deployments/warp_routes/PAXG/logo.svg
+      name: Paxos Gold
+      standard: EvmHypCollateral
+      symbol: PAXG
+    - addressOrDenom: "0xE7eFb127249Ec17B484B5Bb0Ea5f79A14A6d0721"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|ethereum|0x68A593C7F42e0f6616F9356dCb1CFd130e4e7694
+      decimals: 18
+      logoURI: /deployments/warp_routes/PAXG/logo.svg
+      name: Paxos Gold
+      standard: EvmHypSynthetic
+      symbol: PAXG
+PENGU/apechain-solanamainnet:
+  tokens:
+    - addressOrDenom: "0x9Eaf39A97d56119236a356225B339fE7383549B3"
+      chainName: apechain
+      coinGeckoId: pudgy-penguins
+      connections:
+        - token: sealevel|solanamainnet|C7a43nYF9atxgJhfqoP2vc95exJcEQhvJqYbtCNkDf8f
+      decimals: 6
+      logoURI: /deployments/warp_routes/PENGU/logo.svg
+      name: Pudgy Penguins
+      standard: EvmHypSynthetic
+      symbol: PENGU
+    - addressOrDenom: C7a43nYF9atxgJhfqoP2vc95exJcEQhvJqYbtCNkDf8f
+      chainName: solanamainnet
+      coinGeckoId: pudgy-penguins
+      collateralAddressOrDenom: 2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv
+      connections:
+        - token: ethereum|apechain|0x9Eaf39A97d56119236a356225B339fE7383549B3
+      decimals: 6
+      logoURI: /deployments/warp_routes/PENGU/logo.svg
+      name: Pudgy Penguins
+      standard: SealevelHypCollateral
+      symbol: PENGU
+PEPE/apechain-arbitrum:
+  tokens:
+    - addressOrDenom: "0x46C41c67471bF859A4453512a7dc1B2431b45993"
+      chainName: apechain
+      connections:
+        - token: ethereum|arbitrum|0x46C41c67471bF859A4453512a7dc1B2431b45993
+      decimals: 18
+      logoURI: /deployments/warp_routes/PEPE/logo.svg
+      name: Pepe
+      standard: EvmHypSynthetic
+      symbol: PEPE
+    - addressOrDenom: "0x46C41c67471bF859A4453512a7dc1B2431b45993"
+      chainName: arbitrum
+      coinGeckoId: pepe
+      collateralAddressOrDenom: "0x25d887ce7a35172c62febfd67a1856f20faebb00"
+      connections:
+        - token: ethereum|apechain|0x46C41c67471bF859A4453512a7dc1B2431b45993
+      decimals: 18
+      logoURI: /deployments/warp_routes/PEPE/logo.svg
+      name: Pepe
+      standard: EvmHypCollateral
+      symbol: PEPE
+PNDR/bsc-ethereum-lumiaprism:
+  tokens:
+    - addressOrDenom: "0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a"
+      chainName: ethereum
+      coinGeckoId: ponder-one
+      collateralAddressOrDenom: "0x73624d2dEF952C77a1f3B5AD995eef53E49639EC"
+      connections:
+        - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
+        - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
+      decimals: 18
+      logoURI: /deployments/warp_routes/PNDR/logo.jpeg
+      name: Ponder
+      standard: EvmHypCollateral
+      symbol: PNDR
+    - addressOrDenom: "0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1"
+      chainName: bsc
+      connections:
+        - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
+        - token: ethereum|lumiaprism|0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1
+      decimals: 18
+      logoURI: /deployments/warp_routes/PNDR/logo.jpeg
+      name: Ponder
+      standard: EvmHypSynthetic
+      symbol: PNDR
+    - addressOrDenom: "0x1fdfD1486b8339638C6b92f8a96D698D8182D2b1"
+      chainName: lumiaprism
+      connections:
+        - token: ethereum|ethereum|0xC868Ea07031eE67dCE475D535F1AA0e5571Ba92a
+        - token: ethereum|bsc|0xDcE63e8cc7f1E2Ed25a226166abE3217c19d0BF1
+      decimals: 18
+      logoURI: /deployments/warp_routes/PNDR/logo.jpeg
+      name: Ponder
+      standard: EvmHypSynthetic
+      symbol: PNDR
+POL/kalychain-polygon:
+  tokens:
+    - addressOrDenom: "0x706C9a63d7c8b7Aaf85DDCca52654645f470E8Ac"
+      chainName: kalychain
+      connections:
+        - token: ethereum|polygon|0x0a6364152EA7a487C697a36Eb2522f48bC62fB4c
+      decimals: 18
+      name: Polygon Ecosystem Token
+      standard: EvmHypSynthetic
+      symbol: POL
+    - addressOrDenom: "0x0a6364152EA7a487C697a36Eb2522f48bC62fB4c"
+      chainName: polygon
+      connections:
+        - token: ethereum|kalychain|0x706C9a63d7c8b7Aaf85DDCca52654645f470E8Ac
+      decimals: 18
+      name: Polygon Ecosystem Token
+      standard: EvmHypNative
+      symbol: POL
+POL/polygon-zeronetwork:
+  tokens:
+    - addressOrDenom: "0x76Af114f7Ebe96C02a3e4AB10f1511a7A66057A1"
+      chainName: polygon
+      coinGeckoId: polygon-ecosystem-token
+      connections:
+        - token: ethereum|zeronetwork|0x3d7dBc3dab88C0e3c3Dcb6901a6163bb02417e6B
+      decimals: 18
+      logoURI: /deployments/warp_routes/POL/logo.svg
+      name: Polygon Ecosystem Token
+      standard: EvmHypNative
+      symbol: POL
+    - addressOrDenom: "0x3d7dBc3dab88C0e3c3Dcb6901a6163bb02417e6B"
+      chainName: zeronetwork
+      connections:
+        - token: ethereum|polygon|0x76Af114f7Ebe96C02a3e4AB10f1511a7A66057A1
+      decimals: 18
+      logoURI: /deployments/warp_routes/POL/logo.svg
+      name: Polygon Ecosystem Token
+      standard: EvmHypSynthetic
+      symbol: POL
+POPCAT/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 2CPGmQCNdGrh45n6BgTG98G7AkQfEKPZCcYW2reju2kn
+      chainName: soon
+      collateralAddressOrDenom: Hxf93wyFCRi4Je5R1dYc4xAtPug48YdC6vuorUJFW5dv
+      connections:
+        - token: sealevel|solanamainnet|BSrwJNiHM88XRYX93CRXGSTR4GfnZfxn3kTa4rvanPKr
+      decimals: 9
+      logoURI: /deployments/warp_routes/POPCAT/logo.svg
+      name: POPCAT
+      standard: SealevelHypSynthetic
+      symbol: POPCAT
+    - addressOrDenom: BSrwJNiHM88XRYX93CRXGSTR4GfnZfxn3kTa4rvanPKr
+      chainName: solanamainnet
+      coinGeckoId: popcat
+      collateralAddressOrDenom: 7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr
+      connections:
+        - token: sealevel|soon|2CPGmQCNdGrh45n6BgTG98G7AkQfEKPZCcYW2reju2kn
+      decimals: 9
+      logoURI: /deployments/warp_routes/POPCAT/logo.svg
+      name: POPCAT
+      standard: SealevelHypCollateral
+      symbol: POPCAT
+PROM/bsc-ethereum-polygon:
+  tokens:
+    - addressOrDenom: "0xA83e1e21e82038e425e7a47aD7c2e059D7F1cae6"
+      chainName: bsc
+      collateralAddressOrDenom: "0xaf53d56ff99f1322515e54fdde93ff8b3b7dafd5"
+      connections:
+        - token: ethereum|ethereum|0x25C147Bd61bdaB6ce5A1Ae4939d2765092e0e2F8
+        - token: ethereum|polygon|0x6539BB7b4533E5cc004CeD6429431b3594923650
+      decimals: 18
+      logoURI: /deployments/warp_routes/PROM/logo.svg
+      name: Prometeus
+      standard: EvmHypCollateral
+      symbol: PROM
+    - addressOrDenom: "0x25C147Bd61bdaB6ce5A1Ae4939d2765092e0e2F8"
+      chainName: ethereum
+      collateralAddressOrDenom: "0xfc82bb4ba86045af6f327323a46e80412b91b27d"
+      connections:
+        - token: ethereum|bsc|0xA83e1e21e82038e425e7a47aD7c2e059D7F1cae6
+        - token: ethereum|polygon|0x6539BB7b4533E5cc004CeD6429431b3594923650
+      decimals: 18
+      logoURI: /deployments/warp_routes/PROM/logo.svg
+      name: Prometeus
+      standard: EvmHypCollateral
+      symbol: PROM
+    - addressOrDenom: "0x6539BB7b4533E5cc004CeD6429431b3594923650"
+      chainName: polygon
+      connections:
+        - token: ethereum|bsc|0xA83e1e21e82038e425e7a47aD7c2e059D7F1cae6
+        - token: ethereum|ethereum|0x25C147Bd61bdaB6ce5A1Ae4939d2765092e0e2F8
+      decimals: 18
+      logoURI: /deployments/warp_routes/PROM/logo.svg
+      name: Prometeus
+      standard: EvmHypSynthetic
+      symbol: PROM
+PROM/bsc-polygon-prom:
+  tokens:
+    - addressOrDenom: "0x700b9322F6Cce0c8EFF4754bE9AcE88Ce6582821"
+      chainName: bsc
+      collateralAddressOrDenom: "0xaf53d56ff99f1322515e54fdde93ff8b3b7dafd5"
+      connections:
+        - token: ethereum|polygon|0x23Ae469604E3c1b581ADabf07c035472FbdB5Ee1
+        - token: ethereum|prom|0xc1f4b896B94bd57dEfB7b6e630Bb91995b86CbAC
+      decimals: 18
+      logoURI: /deployments/warp_routes/PROM/logo.svg
+      name: Prometeus
+      standard: EvmHypCollateral
+      symbol: PROM
+    - addressOrDenom: "0x23Ae469604E3c1b581ADabf07c035472FbdB5Ee1"
+      chainName: polygon
+      connections:
+        - token: ethereum|bsc|0x700b9322F6Cce0c8EFF4754bE9AcE88Ce6582821
+        - token: ethereum|prom|0xc1f4b896B94bd57dEfB7b6e630Bb91995b86CbAC
+      decimals: 18
+      logoURI: /deployments/warp_routes/PROM/logo.svg
+      name: Prometeus
+      standard: EvmHypSynthetic
+      symbol: PROM
+    - addressOrDenom: "0xc1f4b896B94bd57dEfB7b6e630Bb91995b86CbAC"
+      chainName: prom
+      connections:
+        - token: ethereum|bsc|0x700b9322F6Cce0c8EFF4754bE9AcE88Ce6582821
+        - token: ethereum|polygon|0x23Ae469604E3c1b581ADabf07c035472FbdB5Ee1
+      decimals: 18
+      logoURI: /deployments/warp_routes/PROM/logo.svg
+      name: Prometeus
+      standard: EvmHypNative
+      symbol: PROM
+PZETH/berachain-ethereum-swell-unichain-zircuit:
+  tokens:
+    - addressOrDenom: "0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd"
+      chainName: ethereum
+      coinGeckoId: renzo-restaked-lst
+      collateralAddressOrDenom: "0xbC5511354C4A9a50DE928F56DB01DD327c4e56d5"
+      connections:
+        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
+        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
+        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
+        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
+      decimals: 18
+      logoURI: /deployments/warp_routes/PZETH/logo.svg
+      name: Renzo Restaked LST
+      standard: EvmHypXERC20Lockbox
+      symbol: pzETH
+    - addressOrDenom: "0x982AbBb04F91acc47aD0CB0A11f29d50c5007934"
+      chainName: swell
+      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
+      connections:
+        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
+        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
+        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
+        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
+      decimals: 18
+      logoURI: /deployments/warp_routes/PZETH/logo.svg
+      name: Renzo Restaked LST
+      standard: EvmHypXERC20
+      symbol: pzETH
+    - addressOrDenom: "0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764"
+      chainName: zircuit
+      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
+      connections:
+        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
+        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
+        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
+        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
+      decimals: 18
+      logoURI: /deployments/warp_routes/PZETH/logo.svg
+      name: Renzo Restaked LST
+      standard: EvmHypXERC20
+      symbol: pzETH
+    - addressOrDenom: "0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0"
+      chainName: berachain
+      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
+      connections:
+        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
+        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
+        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
+        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
+      decimals: 18
+      logoURI: /deployments/warp_routes/PZETH/logo.svg
+      name: Renzo Restaked LST
+      standard: EvmHypXERC20
+      symbol: pzETH
+    - addressOrDenom: "0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7"
+      chainName: unichain
+      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
+      connections:
+        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
+        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
+        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
+        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
+      decimals: 18
+      logoURI: /deployments/warp_routes/PZETH/logo.svg
+      name: Renzo Restaked LST
+      standard: EvmHypXERC20
+      symbol: pzETH
+PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit:
+  tokens:
+    - addressOrDenom: "0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x9E1a2b6de93164b77Fc5CA11e647EECB38BB463D"
+      connections:
+        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
+        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
+        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
+        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
+      decimals: 18
+      name: Renzo Restaked LST Stage
+      standard: EvmHypXERC20Lockbox
+      symbol: PZETHSTAGE
+    - addressOrDenom: "0xCBC928268870F216A510c207C456544660ec8566"
+      chainName: swell
+      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
+      connections:
+        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
+        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
+        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
+        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
+      decimals: 18
+      name: Renzo Restaked LST Stage
+      standard: EvmHypXERC20
+      symbol: PZETHSTAGE
+    - addressOrDenom: "0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6"
+      chainName: zircuit
+      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
+      connections:
+        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
+        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
+        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
+        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
+      decimals: 18
+      name: Renzo Restaked LST Stage
+      standard: EvmHypXERC20
+      symbol: PZETHSTAGE
+    - addressOrDenom: "0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74"
+      chainName: berachain
+      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
+      connections:
+        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
+        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
+        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
+        - token: ethereum|unichain|0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4
+      decimals: 18
+      name: Renzo Restaked LST Stage
+      standard: EvmHypXERC20
+      symbol: PZETHSTAGE
+    - addressOrDenom: "0xd5C36a45e3B7fCeFf0d926dc377d4648a8301cc4"
+      chainName: unichain
+      collateralAddressOrDenom: "0xDe9e4211087A43112b0e0e9d840459Acf1d9E6C8"
+      connections:
+        - token: ethereum|ethereum|0xFF5C5b61AE627D6659a70aD72A76f1bE7343fEEC
+        - token: ethereum|swell|0xCBC928268870F216A510c207C456544660ec8566
+        - token: ethereum|zircuit|0x5891A7EDB2734C3dAAE7a9FF66cdf98b46aF02F6
+        - token: ethereum|berachain|0xb475C9a3d52340e37a5007cA43a2f0D4876A4b74
+      decimals: 18
+      name: Renzo Restaked LST Stage
+      standard: EvmHypXERC20
+      symbol: PZETHSTAGE
+Pnut/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 5WHM6rm9HpFqNY8hye9ZY9vrgCCM7M5YnCeKcq29FpXz
+      chainName: soon
+      collateralAddressOrDenom: HHJDLRYkp2SPdo2Wv7F62ccKeqVcgEzowaEctUP2r2Cu
+      connections:
+        - token: sealevel|solanamainnet|J8fVLBiLMniYxaBYhfpGmqDpf2qtgaiDAPuznfRMhLs6
+      decimals: 6
+      logoURI: /deployments/warp_routes/Pnut/logo.svg
+      name: Peanut the Squirrel
+      standard: SealevelHypSynthetic
+      symbol: Pnut
+    - addressOrDenom: J8fVLBiLMniYxaBYhfpGmqDpf2qtgaiDAPuznfRMhLs6
+      chainName: solanamainnet
+      coinGeckoId: Pnut
+      collateralAddressOrDenom: 2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump
+      connections:
+        - token: sealevel|soon|5WHM6rm9HpFqNY8hye9ZY9vrgCCM7M5YnCeKcq29FpXz
+      decimals: 6
+      logoURI: /deployments/warp_routes/Pnut/logo.svg
+      name: Peanut the Squirrel
+      standard: SealevelHypCollateral
+      symbol: Pnut
+RDO/bsc-ethereum:
+  tokens:
+    - addressOrDenom: "0xd86E6ef14b96D942eF0AbF0720C549197EA8c528"
+      chainName: ethereum
+      coinGeckoId: reddio
+      collateralAddressOrDenom: "0x57240C3E140f98abe315CA8E0213c7a77F34A334"
+      connections:
+        - token: ethereum|bsc|0xd86E6ef14b96D942eF0AbF0720C549197EA8c528
+      decimals: 18
+      logoURI: /deployments/warp_routes/RDO/logo.svg
+      name: RDO Token
+      standard: EvmHypCollateral
+      symbol: RDO
+    - addressOrDenom: "0xd86E6ef14b96D942eF0AbF0720C549197EA8c528"
+      chainName: bsc
+      coinGeckoId: reddio
+      connections:
+        - token: ethereum|ethereum|0xd86E6ef14b96D942eF0AbF0720C549197EA8c528
+      decimals: 18
+      logoURI: /deployments/warp_routes/RDO/logo.svg
+      name: RDO Token
+      standard: EvmHypSynthetic
+      symbol: RDO
+REZ/base-ethereum-unichain:
+  tokens:
+    - addressOrDenom: "0xF4eae2f139D8032b8410Fef46f6873cD71A0FD76"
+      chainName: base
+      collateralAddressOrDenom: "0xf757c9804cF2EE8d8Ed64e0A8936293Fe43a7252"
+      connections:
+        - token: ethereum|ethereum|0xc32848c38Dd5A5098Cd53d33e425c1013a4E06A8
+        - token: ethereum|unichain|0xaEae59338bc13642D674DA22d56c83EA4D9d9B73
+      decimals: 18
+      logoURI: /deployments/warp_routes/REZ/REZ-logo.svg
+      name: Renzo
+      standard: EvmHypXERC20
+      symbol: REZ
+    - addressOrDenom: "0xc32848c38Dd5A5098Cd53d33e425c1013a4E06A8"
+      chainName: ethereum
+      coinGeckoId: renzo
+      collateralAddressOrDenom: "0xd8B543fEac4EEcEF5a46a926e10D6f4a72de6fE0"
+      connections:
+        - token: ethereum|base|0xF4eae2f139D8032b8410Fef46f6873cD71A0FD76
+        - token: ethereum|unichain|0xaEae59338bc13642D674DA22d56c83EA4D9d9B73
+      decimals: 18
+      logoURI: /deployments/warp_routes/REZ/REZ-logo.svg
+      name: Renzo
+      standard: EvmHypXERC20Lockbox
+      symbol: REZ
+    - addressOrDenom: "0xaEae59338bc13642D674DA22d56c83EA4D9d9B73"
+      chainName: unichain
+      collateralAddressOrDenom: "0xf757c9804cF2EE8d8Ed64e0A8936293Fe43a7252"
+      connections:
+        - token: ethereum|base|0xF4eae2f139D8032b8410Fef46f6873cD71A0FD76
+        - token: ethereum|ethereum|0xc32848c38Dd5A5098Cd53d33e425c1013a4E06A8
+      decimals: 18
+      logoURI: /deployments/warp_routes/REZ/REZ-logo.svg
+      name: Renzo
+      standard: EvmHypXERC20
+      symbol: REZ
+REZSTAGING/base-ethereum-unichain:
+  tokens:
+    - addressOrDenom: "0xD23f3de954eeF59752DF0ca614403B1377F9302A"
+      chainName: base
+      collateralAddressOrDenom: "0x19c5C2316171A2cff8773435a9A5F3f0e3eaB14B"
+      connections:
+        - token: ethereum|ethereum|0x9c48903a8b95d7a208dC45a1905da271108dD56a
+        - token: ethereum|unichain|0x644bD9f172a890d769F7A82D533f799051E1A07f
+      decimals: 18
+      name: REZ
+      standard: EvmHypXERC20
+      symbol: REZ
+    - addressOrDenom: "0x9c48903a8b95d7a208dC45a1905da271108dD56a"
+      chainName: ethereum
+      collateralAddressOrDenom: "0xc693943eACc1Cb74b748Cf1B953946970b239279"
+      connections:
+        - token: ethereum|base|0xD23f3de954eeF59752DF0ca614403B1377F9302A
+        - token: ethereum|unichain|0x644bD9f172a890d769F7A82D533f799051E1A07f
+      decimals: 18
+      name: REZ
+      standard: EvmHypXERC20Lockbox
+      symbol: REZ
+    - addressOrDenom: "0x644bD9f172a890d769F7A82D533f799051E1A07f"
+      chainName: unichain
+      collateralAddressOrDenom: "0x19c5C2316171A2cff8773435a9A5F3f0e3eaB14B"
+      connections:
+        - token: ethereum|base|0xD23f3de954eeF59752DF0ca614403B1377F9302A
+        - token: ethereum|ethereum|0x9c48903a8b95d7a208dC45a1905da271108dD56a
+      decimals: 18
+      name: REZ
+      standard: EvmHypXERC20
+      symbol: REZ
+Re7LRT/ethereum-zircuit:
+  tokens:
+    - addressOrDenom: "0x7D77702f1c7A1662923FD654f904127988Caa3fD"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x84631c0d0081FDe56DeB72F6DE77abBbF6A9f93a"
+      connections:
+        - token: ethereum|zircuit|0x4d08A785212Ce848cFc35e198E86F5ebcb388c86
+      decimals: 18
+      name: Re7 Labs LRT
+      standard: EvmHypCollateral
+      symbol: Re7LRT
+    - addressOrDenom: "0x4d08A785212Ce848cFc35e198E86F5ebcb388c86"
+      chainName: zircuit
+      connections:
+        - token: ethereum|ethereum|0x7D77702f1c7A1662923FD654f904127988Caa3fD
+      decimals: 18
+      name: Re7 Labs LRT
+      standard: EvmHypSynthetic
+      symbol: Re7LRT
+SMOL/arbitrum-ethereum-solanamainnet-treasure:
+  tokens:
+    - addressOrDenom: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5"
+      connections:
+        - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
+        - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
+      decimals: 18
+      logoURI: /deployments/warp_routes/SMOL/logo.svg
+      name: SMOL
+      standard: EvmHypCollateral
+      symbol: SMOL
+    - addressOrDenom: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
+      chainName: ethereum
+      connections:
+        - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
+        - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
+        - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
+      decimals: 18
+      logoURI: /deployments/warp_routes/SMOL/logo.svg
+      name: SMOL
+      standard: EvmHypSynthetic
+      symbol: SMOL
+    - addressOrDenom: 7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
+      chainName: solanamainnet
+      collateralAddressOrDenom: 5KHQeeQvM4qBtmX3WnaCMGpM3Th7jYpqcHf3c6qzPodM
+      connections:
+        - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
+        - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
+      decimals: 9
+      logoURI: /deployments/warp_routes/SMOL/logo.svg
+      name: SMOL
+      standard: SealevelHypSynthetic
+      symbol: SMOL
+    - addressOrDenom: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
+      chainName: treasure
+      connections:
+        - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
+        - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
+        - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
+      decimals: 18
+      logoURI: /deployments/warp_routes/SMOL/logo.svg
+      name: SMOL
+      standard: EvmHypSynthetic
+      symbol: SMOL
+SOL/apechain-solanamainnet:
+  tokens:
+    - addressOrDenom: "0x16eE589E237f2c70aBE91F87a6C0712C836941bb"
+      chainName: apechain
+      connections:
+        - token: sealevel|solanamainnet|BwD1LvMvofVZAAWyG318S17zqKMXXeeNeVHQimaWG6qt
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: EvmHypSynthetic
+      symbol: SOL
+    - addressOrDenom: BwD1LvMvofVZAAWyG318S17zqKMXXeeNeVHQimaWG6qt
+      chainName: solanamainnet
+      coinGeckoId: solana
+      connections:
+        - token: ethereum|apechain|0x16eE589E237f2c70aBE91F87a6C0712C836941bb
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypNative
+      symbol: SOL
+SOL/eclipsemainnet-solanamainnet:
+  tokens:
+    - addressOrDenom: FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: BeRUj3h7BqkbdfFU7FBNYbodgf8GCHodzKvF9aVjNNfL
+      connections:
+        - token: sealevel|solanamainnet|8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypSynthetic
+      symbol: SOL
+    - addressOrDenom: 8DtAGQpcMuD5sG3KdxDy49ydqXUggR1LQtebh2TECbAc
+      chainName: solanamainnet
+      coinGeckoId: solana
+      connections:
+        - token: sealevel|eclipsemainnet|FJu4E1BDYKVg7aTWdwATZRUvytJZ8ZZ2gQuvPfMWAz9y
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypNative
+      symbol: SOL
+SOL/hyperevm-solanamainnet:
+  tokens:
+    - addressOrDenom: "0x96029bcf706FAC4176492F4a05f63f7d23cE78fb"
+      chainName: hyperevm
+      connections:
+        - token: sealevel|solanamainnet|4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: EvmHypSynthetic
+      symbol: SOL
+    - addressOrDenom: 4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
+      chainName: solanamainnet
+      coinGeckoId: solana
+      connections:
+        - token: ethereum|hyperevm|0x96029bcf706FAC4176492F4a05f63f7d23cE78fb
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypNative
+      symbol: SOL
+SOL/solanamainnet-sonicsvm:
+  tokens:
+    - addressOrDenom: 7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY
+      chainName: sonicsvm
+      connections:
+        - token: sealevel|solanamainnet|BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypNative
+      symbol: SOL
+    - addressOrDenom: BXKDfnNkgUNVT5uCfk36sv2GDtK6RwAt9SLbGiKzZkih
+      chainName: solanamainnet
+      coinGeckoId: solana
+      connections:
+        - token: sealevel|sonicsvm|7KD647mgysBeEt6PSrv2XYktkSNLzear124oaMENp8SY
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypNative
+      symbol: SOL
+SOL/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 6SGK4PnHefm4egyUUeVro8wKBkuPexVehsjuUK8auJ8b
+      chainName: soon
+      collateralAddressOrDenom: ERFzpDteGNo8LTDKW1WwVGrkRMmA2y9WZHXNHxMA6BSV
+      connections:
+        - token: sealevel|solanamainnet|GPFwRQ5Cw6dTWnmappUKJt76DD8yawxPx28QugfCaGaA
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypSynthetic
+      symbol: SOL
+    - addressOrDenom: GPFwRQ5Cw6dTWnmappUKJt76DD8yawxPx28QugfCaGaA
+      chainName: solanamainnet
+      coinGeckoId: solana
+      connections:
+        - token: sealevel|soon|6SGK4PnHefm4egyUUeVro8wKBkuPexVehsjuUK8auJ8b
+      decimals: 9
+      logoURI: /deployments/warp_routes/SOL/logo.svg
+      name: Solana
+      standard: SealevelHypNative
+      symbol: SOL
+SONIC/solanamainnet-sonicsvm:
+  tokens:
+    - addressOrDenom: 2e6hyJbUpbhqbJzorDZ1m4QVTj5oPhsn2H3KBaMFVXAz
+      chainName: solanamainnet
+      coinGeckoId: sonic-svm
+      collateralAddressOrDenom: SonicxvLud67EceaEzCLRnMTBqzYUUYNr93DBkBdDES
+      connections:
+        - token: sealevel|sonicsvm|5sPRiRLfmohVmtkgiGV6scrzy2C6qEZRGRUiePZf1Fs2
+      decimals: 9
+      logoURI: /deployments/warp_routes/SONIC/logo.svg
+      name: Sonic SVM
+      standard: SealevelHypCollateral
+      symbol: SONIC
+    - addressOrDenom: 5sPRiRLfmohVmtkgiGV6scrzy2C6qEZRGRUiePZf1Fs2
+      chainName: sonicsvm
+      collateralAddressOrDenom: mrujEYaN1oyQXDHeYNxBYpxWKVkQ2XsGxfznpifu4aL
+      connections:
+        - token: sealevel|solanamainnet|2e6hyJbUpbhqbJzorDZ1m4QVTj5oPhsn2H3KBaMFVXAz
+      decimals: 9
+      logoURI: /deployments/warp_routes/SONIC/logo.svg
+      name: Sonic SVM
+      standard: SealevelHypSynthetic
+      symbol: SONIC
+SPICE/solanamainnet-sonicsvm:
+  tokens:
+    - addressOrDenom: 7XYiQwKkHDgALca91sCj7sRBQbgDNB9zANX11UzP3Wt8
+      chainName: solanamainnet
+      coinGeckoId: spice
+      collateralAddressOrDenom: SPQkEcsdALLLn4MqCb3XH64hYTmdD4fZZk9CF5LiQV8
+      connections:
+        - token: sealevel|sonicsvm|CDCcn2156JBN5RvUXKvgpxzk9Yt8NbcG5DqGnoKzQu21
+      decimals: 6
+      logoURI: /deployments/warp_routes/SPICE/logo.svg
+      name: SPICE
+      standard: SealevelHypCollateral
+      symbol: SPICE
+    - addressOrDenom: CDCcn2156JBN5RvUXKvgpxzk9Yt8NbcG5DqGnoKzQu21
+      chainName: sonicsvm
+      collateralAddressOrDenom: 6sBvZHs9u5HRt25c3bQKLij8gYPheFJCaKnSagz1Nn9N
+      connections:
+        - token: sealevel|solanamainnet|7XYiQwKkHDgALca91sCj7sRBQbgDNB9zANX11UzP3Wt8
+      decimals: 6
+      logoURI: /deployments/warp_routes/SPICE/logo.svg
+      name: SPICE
+      standard: SealevelHypSynthetic
+      symbol: SPICE
+SPORE/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: JDnjXhoucA9HwTk1s7piyoCLvwQSKdnaRitdkpXsRgtj
+      chainName: soon
+      collateralAddressOrDenom: 4zCFfTv26uUgo9APJcbCuGEwx5hhyb9HMgbM35gnsQ6B
+      connections:
+        - token: sealevel|solanamainnet|34V29ar8oahnZVnnQqEfd9pUE3MBrAxpgMtQf1Xccs1A
+      decimals: 6
+      logoURI: /deployments/warp_routes/SPORE/logo.svg
+      name: SPORE
+      standard: SealevelHypSynthetic
+      symbol: SPORE
+    - addressOrDenom: 34V29ar8oahnZVnnQqEfd9pUE3MBrAxpgMtQf1Xccs1A
+      chainName: solanamainnet
+      coinGeckoId: spore-2
+      collateralAddressOrDenom: 8bdhP1UQMevciC9oJ7NrvgDfoW8XPXPfbkkm6vKtMS7N
+      connections:
+        - token: sealevel|soon|JDnjXhoucA9HwTk1s7piyoCLvwQSKdnaRitdkpXsRgtj
+      decimals: 6
+      logoURI: /deployments/warp_routes/SPORE/logo.svg
+      name: SPORE
+      standard: SealevelHypCollateral
+      symbol: SPORE
+SUPR/base-ethereum-ink-optimism-superseed:
+  tokens:
+    - addressOrDenom: "0x458BDDd0793fe4f70912535f172466a5473f2e77"
+      chainName: base
+      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
+      connections:
+        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
+        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
+        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
+        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
+      decimals: 18
+      logoURI: /deployments/warp_routes/SUPR/logo.svg
+      name: Superseed
+      standard: EvmHypXERC20
+      symbol: SUPR
+    - addressOrDenom: "0xbc808c98beA0a097346273A9Fd7a5B231fc2d889"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
+      connections:
+        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
+        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
+        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
+        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
+      decimals: 18
+      logoURI: /deployments/warp_routes/SUPR/logo.svg
+      name: Superseed
+      standard: EvmHypXERC20
+      symbol: SUPR
+    - addressOrDenom: "0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0"
+      chainName: ink
+      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
+      connections:
+        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
+        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
+        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
+        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
+      decimals: 18
+      logoURI: /deployments/warp_routes/SUPR/logo.svg
+      name: Superseed
+      standard: EvmHypXERC20
+      symbol: SUPR
+    - addressOrDenom: "0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97"
+      chainName: optimism
+      collateralAddressOrDenom: "0x17906b1Cd88aA8EfaEfC5e82891B52a22219BD45"
+      connections:
+        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
+        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
+        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
+        - token: ethereum|superseed|0xA1863B4b02b7DCd7429F62C775816328D63020F4
+      decimals: 18
+      logoURI: /deployments/warp_routes/SUPR/logo.svg
+      name: Superseed
+      standard: EvmHypXERC20
+      symbol: SUPR
+    - addressOrDenom: "0xA1863B4b02b7DCd7429F62C775816328D63020F4"
+      chainName: superseed
+      collateralAddressOrDenom: "0xEe64bC3f4A58D638D0845b24e2f51534d01b6549"
+      connections:
+        - token: ethereum|base|0x458BDDd0793fe4f70912535f172466a5473f2e77
+        - token: ethereum|ethereum|0xbc808c98beA0a097346273A9Fd7a5B231fc2d889
+        - token: ethereum|ink|0x6cfDDfa3e0867A873675B80FDEBeB94e9262b5F0
+        - token: ethereum|optimism|0xae1E04F18D1323d8EaC7Ba5b2c683c95DC3baC97
+      decimals: 18
+      logoURI: /deployments/warp_routes/SUPR/logo.svg
+      name: Superseed
+      standard: EvmHypXERC20Lockbox
+      symbol: SUPR
+TAURA/euphoriatestnet-holesky:
+  tokens:
+    - addressOrDenom: "0x120f461C4d95412c4a1BC4e8BE6917C9da404510"
+      chainName: euphoriatestnet
+      connections:
+        - token: ethereum|holesky|0x0bA0E052b993E8486AA8dab82c361404F7576573
+      decimals: 18
+      name: Aura Testing
+      standard: EvmHypSynthetic
+      symbol: tAURA
+    - addressOrDenom: "0x0bA0E052b993E8486AA8dab82c361404F7576573"
+      chainName: holesky
+      collateralAddressOrDenom: "0x89C17409dc7222E378A433CE75DDd4dF8a1c4874"
+      connections:
+        - token: ethereum|euphoriatestnet|0x120f461C4d95412c4a1BC4e8BE6917C9da404510
+      decimals: 18
+      name: Aura Testing
+      standard: EvmHypCollateral
+      symbol: tAURA
+TGT/bsc-immutablezkevmmainnet:
+  tokens:
+    - addressOrDenom: "0x6c58E4a513D3A8062E57f41a1442e003aF14eBb5"
+      chainName: bsc
+      connections:
+        - token: ethereum|immutablezkevmmainnet|0x4d9D942010eB2411fF16a9d910Badbc8520a9BfF
+      decimals: 18
+      logoURI: /deployments/warp_routes/TGT/logo.svg
+      name: TGT
+      standard: EvmHypSynthetic
+      symbol: TGT
+    - addressOrDenom: "0x4d9D942010eB2411fF16a9d910Badbc8520a9BfF"
+      chainName: immutablezkevmmainnet
+      coinGeckoId: tokyo-games-token
+      collateralAddressOrDenom: "0x0FA1d8Ffa9B414ABF0F47183e088bddC32e084F3"
+      connections:
+        - token: ethereum|bsc|0x6c58E4a513D3A8062E57f41a1442e003aF14eBb5
+      decimals: 18
+      logoURI: /deployments/warp_routes/TGT/logo.svg
+      name: TGT
+      standard: EvmHypCollateral
+      symbol: TGT
+TIA/arbitrum-neutron:
+  options:
+    interchainFeeConstants:
+      - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+        amount: 270000
+        destination: arbitrum
+        origin: neutron
+  tokens:
+    - addressOrDenom: neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
+      chainName: neutron
+      coinGeckoId: celestia
+      collateralAddressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+      connections:
+        - token: ethereum|arbitrum|0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.n
+      standard: CwHypCollateral
+      symbol: TIA.n
+    - addressOrDenom: "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C"
+      chainName: arbitrum
+      connections:
+        - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.n
+      standard: EvmHypSynthetic
+      symbol: TIA.n
+    - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+      chainName: neutron
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.n
+      standard: CosmosIbc
+      symbol: TIA.n
+TIA/eclipsemainnet-stride:
+  options:
+    interchainFeeConstants:
+      - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+        amount: 500000
+        destination: eclipsemainnet
+        origin: stride
+  tokens:
+    - addressOrDenom: stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6
+      chainName: stride
+      coinGeckoId: celestia
+      collateralAddressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+      connections:
+        - token: sealevel|eclipsemainnet|BpXHAiktwjx7fN6M9ST9wr6qKAsH27wZFhdHEhReJsR6
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: Celestia
+      standard: CwHypCollateral
+      symbol: TIA
+    - addressOrDenom: BpXHAiktwjx7fN6M9ST9wr6qKAsH27wZFhdHEhReJsR6
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: 9RryNMhAVJpAwAGjCAMKbbTFwgjapqPkzpGMfTQhEjf8
+      connections:
+        - token: cosmos|stride|stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: Celestia
+      standard: SealevelHypSynthetic
+      symbol: TIA
+    - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+      chainName: stride
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: Celestia
+      standard: CosmosIbc
+      symbol: TIA
+TIA/forma-stride:
+  options:
+    interchainFeeConstants:
+      - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+        amount: 500000
+        destination: forma
+        origin: stride
+      - addressOrDenom: utia
+        amount: 20000
+        destination: forma
+        origin: celestia
+      - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
+        amount: 20000000000000000
+        destination: stride
+        origin: forma
+      - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
+        amount: 20000000000000000
+        destination: celestia
+        origin: forma
+  tokens:
+    - addressOrDenom: utia
+      chainName: celestia
+      connections:
+        - intermediateChainName: stride
+          intermediateIbcDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+          intermediateRouterAddress: stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
+          sourceChannel: channel-4
+          sourcePort: transfer
+          token: ethereum|forma|0x832d26B6904BA7539248Db4D58614251FD63dC05
+          type: ibc-hyperlane
+        - sourceChannel: channel-4
+          sourcePort: transfer
+          token: cosmos|stride|ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+          type: ibc
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA
+      standard: CosmosIbc
+      symbol: TIA
+    - addressOrDenom: stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
+      chainName: stride
+      collateralAddressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+      connections:
+        - token: ethereum|forma|0x832d26B6904BA7539248Db4D58614251FD63dC05
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA
+      standard: CwHypCollateral
+      symbol: TIA
+    - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
+      chainName: forma
+      connections:
+        - token: cosmos|stride|stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
+      decimals: 18
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA
+      standard: EvmNative
+      symbol: TIA
+    - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
+      chainName: stride
+      connections:
+        - sourceChannel: channel-4
+          sourcePort: transfer
+          token: cosmos|celestia|utia
+          type: ibc
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA
+      standard: CosmosIbc
+      symbol: TIA
+TIA/mantapacific-neutron:
+  options:
+    interchainFeeConstants:
+      - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+        amount: 270000
+        destination: mantapacific
+        origin: neutron
+  tokens:
+    - addressOrDenom: neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
+      chainName: neutron
+      coinGeckoId: celestia
+      collateralAddressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+      connections:
+        - token: ethereum|mantapacific|0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.n
+      standard: CwHypCollateral
+      symbol: TIA.n
+    - addressOrDenom: "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa"
+      chainName: mantapacific
+      connections:
+        - token: cosmos|neutron|neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.n
+      standard: EvmHypSynthetic
+      symbol: TIA.n
+    - addressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
+      chainName: neutron
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.n
+      standard: CosmosIbc
+      symbol: TIA.n
+TIA/mantapacific-osmosis:
+  options:
+    interchainFeeConstants:
+      - addressOrDenom: ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877
+        amount: 840000
+        destination: mantapacific
+        origin: osmosis
+  tokens:
+    - addressOrDenom: osmo1h4y9xjcvs8lrx4z8ha48uq9a338w74dpl2ly3tf74fzvugp2kj4q9l0jkw
+      chainName: osmosis
+      collateralAddressOrDenom: ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877
+      connections:
+        - token: ethereum|mantapacific|0x88410F3D8135b4D23b98dC37C4652C6969a5B1a8
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.o
+      standard: CwHypCollateral
+      symbol: TIA.o
+    - addressOrDenom: "0x88410F3D8135b4D23b98dC37C4652C6969a5B1a8"
+      chainName: mantapacific
+      connections:
+        - token: cosmos|osmosis|osmo1h4y9xjcvs8lrx4z8ha48uq9a338w74dpl2ly3tf74fzvugp2kj4q9l0jkw
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA.o
+      standard: EvmHypSynthetic
+      symbol: TIA.o
+TOBY/base-optimism:
+  tokens:
+    - addressOrDenom: "0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B"
+      chainName: base
+      collateralAddressOrDenom: "0xb8d98a102b0079b69ffbc760c8d857a31653e56e"
+      connections:
+        - token: ethereum|optimism|0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B
+      decimals: 18
+      logoURI: /deployments/warp_routes/TOBY/logo.svg
+      name: Toby ToadGod
+      standard: EvmHypCollateral
+      symbol: TOBY
+    - addressOrDenom: "0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B"
+      chainName: optimism
+      connections:
+        - token: ethereum|base|0xf2aCC7a8Cd1fAA7a178B1569e11505372ea7943B
+      decimals: 18
+      logoURI: /deployments/warp_routes/TOBY/logo.svg
+      name: Toby ToadGod
+      standard: EvmHypSynthetic
+      symbol: TOBY
+TONY/base-solanamainnet:
+  tokens:
+    - addressOrDenom: "0xcc9EcE816641c8350Db06af375811107B1Aa0b9d"
+      chainName: base
+      coinGeckoId: bonk
+      collateralAddressOrDenom: "0xb22a793a81ff5b6ad37f40d5fe1e0ac4184d52f3"
+      connections:
+        - token: sealevel|solanamainnet|Fa4zQJCH7id5KL1eFJt2mHyFpUNfCCSkHgtMrLvrRJBN
+      decimals: 18
+      logoURI: /deployments/warp_routes/TONY/logo.png
+      name: Big Tony
+      standard: EvmHypCollateral
+      symbol: TONY
+    - addressOrDenom: Fa4zQJCH7id5KL1eFJt2mHyFpUNfCCSkHgtMrLvrRJBN
+      chainName: solanamainnet
+      collateralAddressOrDenom: 3SboFTm5xF3VGcduCP6CPue3ZTh8qKXNcNSXR74YDaw1
+      connections:
+        - token: ethereum|base|0xcc9EcE816641c8350Db06af375811107B1Aa0b9d
+      decimals: 9
+      logoURI: /deployments/warp_routes/TONY/logo.png
+      name: Big Tony
+      standard: SealevelHypSynthetic
+      symbol: TONY
+TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain:
+  tokens:
+    - addressOrDenom: "0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8"
+      chainName: base
+      connections:
+        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypSynthetic
+      symbol: TRUMP
+    - addressOrDenom: "0x5155EB1bcD30189915cF84717550Acfa537068bF"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypSynthetic
+      symbol: TRUMP
+    - addressOrDenom: "0x0e2A546a53678ee8F8605748193a8c114fA0317F"
+      chainName: avalanche
+      connections:
+        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypSynthetic
+      symbol: TRUMP
+    - addressOrDenom: "0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760"
+      chainName: flowmainnet
+      connections:
+        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypSynthetic
+      symbol: TRUMP
+    - addressOrDenom: "0x8528bAa7d1d386E7967603e480fa2B558a23644c"
+      chainName: form
+      connections:
+        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypSynthetic
+      symbol: TRUMP
+    - addressOrDenom: "0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922"
+      chainName: worldchain
+      connections:
+        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypSynthetic
+      symbol: TRUMP
+    - addressOrDenom: "0xe36c02471e708a9f16da58168da744b059a1c6fe"
+      chainName: optimism
+      connections:
+        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+        - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypSynthetic
+      symbol: TRUMP
+    - addressOrDenom: 21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+      chainName: solanamainnet
+      coinGeckoId: official-trump
+      collateralAddressOrDenom: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
+      connections:
+        - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+        - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+        - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+        - token: ethereum|form|0x8528bAa7d1d386E7967603e480fa2B558a23644c
+        - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+        - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+        - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      decimals: 6
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: SealevelHypCollateral
+      symbol: TRUMP
+TRUMP/solanamainnet-trumpchain:
+  tokens:
+    - addressOrDenom: "0xD84981Ecd4c411A86E1Ccda77F944c8f3D9737ab"
+      chainName: trumpchain
+      connections:
+        - token: sealevel|solanamainnet|AyJk3V2SjswRv1ppDazVofXnFgjCTeydNEDSyA2UyVNX
+      decimals: 18
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: EvmHypNative
+      symbol: TRUMP
+    - addressOrDenom: AyJk3V2SjswRv1ppDazVofXnFgjCTeydNEDSyA2UyVNX
+      chainName: solanamainnet
+      coinGeckoId: official-trump
+      collateralAddressOrDenom: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
+      connections:
+        - token: ethereum|trumpchain|0xD84981Ecd4c411A86E1Ccda77F944c8f3D9737ab
+      decimals: 6
+      logoURI: /deployments/warp_routes/TRUMP/logo.png
+      name: OFFICIAL TRUMP
+      standard: SealevelHypCollateral
+      symbol: TRUMP
+TURTLE/ethereum-linea:
+  tokens:
+    - addressOrDenom: "0x15dE2C58FCF168bf9bB8860ab6EA10e1670C5D4c"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x2BE3be1D8A556954320c2252dF4f891F64699d50"
+      connections:
+        - token: ethereum|linea|0xB88F86E0c403B02d4cCF893Fc37312A18Fa2Fe1B
+      decimals: 18
+      logoURI: /deployments/warp_routes/TURTLE/logo.png
+      name: Turtle
+      standard: EvmHypCollateral
+      symbol: TURTLE
+    - addressOrDenom: "0xB88F86E0c403B02d4cCF893Fc37312A18Fa2Fe1B"
+      chainName: linea
+      connections:
+        - token: ethereum|ethereum|0x15dE2C58FCF168bf9bB8860ab6EA10e1670C5D4c
+      decimals: 18
+      logoURI: /deployments/warp_routes/TURTLE/logo.png
+      name: Turtle
+      standard: EvmHypSynthetic
+      symbol: TURTLE
+UBTC/boba-bsquared-soneium-swell:
+  tokens:
+    - addressOrDenom: "0xFA3198ecF05303a6d96E57a45E6c815055D255b1"
+      chainName: boba
+      connections:
+        - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+        - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
+      decimals: 18
+      logoURI: /deployments/warp_routes/UBTC/logo.svg
+      name: uBTC
+      standard: EvmHypSynthetic
+      symbol: uBTC
+    - addressOrDenom: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+      chainName: bsquared
+      collateralAddressOrDenom: "0x796e4D53067FF374B89b2Ac101ce0c1f72ccaAc2"
+      connections:
+        - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+        - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+        - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
+      decimals: 18
+      logoURI: /deployments/warp_routes/UBTC/logo.svg
+      name: uBTC
+      standard: EvmHypCollateral
+      symbol: uBTC
+    - addressOrDenom: "0xFA3198ecF05303a6d96E57a45E6c815055D255b1"
+      chainName: swell
+      connections:
+        - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+        - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
+      decimals: 18
+      logoURI: /deployments/warp_routes/UBTC/logo.svg
+      name: uBTC
+      standard: EvmHypSynthetic
+      symbol: uBTC
+    - addressOrDenom: "0x61F2993a644762A345b483ADF0d6351C5EdFB3b5"
+      chainName: soneium
+      connections:
+        - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+        - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+      decimals: 18
+      logoURI: /deployments/warp_routes/UBTC/logo.svg
+      name: uBTC
+      standard: EvmHypSynthetic
+      symbol: uBTC
+UFD/apechain-solanamainnet:
+  tokens:
+    - addressOrDenom: "0xC58eeC72352b04358b0b6979ba10462190f0d54C"
+      chainName: apechain
+      connections:
+        - token: sealevel|solanamainnet|DTNQ9T9KYbB2rpnJxdwcZbnxB17G9jAiiSqU8fAf6uSS
+      decimals: 6
+      logoURI: /deployments/warp_routes/UFD/logo.svg
+      name: Unicorn Fart Dust
+      standard: EvmHypSynthetic
+      symbol: UFD
+    - addressOrDenom: DTNQ9T9KYbB2rpnJxdwcZbnxB17G9jAiiSqU8fAf6uSS
+      chainName: solanamainnet
+      coinGeckoId: unicorn-fart-dust
+      collateralAddressOrDenom: eL5fUxj2J4CiQsmW85k5FG9DvuQjjUoBHoQBi2Kpump
+      connections:
+        - token: ethereum|apechain|0xC58eeC72352b04358b0b6979ba10462190f0d54C
+      decimals: 6
+      logoURI: /deployments/warp_routes/UFD/logo.svg
+      name: Unicorn Fart Dust
+      standard: SealevelHypCollateral
+      symbol: UFD
+USDB/blast-zeronetwork:
+  tokens:
+    - addressOrDenom: "0x1CF975C9bF2DF76c43a14405066007f8393142E9"
+      chainName: blast
+      coinGeckoId: usdb
+      collateralAddressOrDenom: "0x4300000000000000000000000000000000000003"
+      connections:
+        - token: ethereum|zeronetwork|0xB11a9606f3e470abD00b1bbB28AffAC3126c2Acb
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDB/logo.svg
+      name: USDB
+      standard: EvmHypCollateral
+      symbol: USDB
+    - addressOrDenom: "0xB11a9606f3e470abD00b1bbB28AffAC3126c2Acb"
+      chainName: zeronetwork
+      connections:
+        - token: ethereum|blast|0x1CF975C9bF2DF76c43a14405066007f8393142E9
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDB/logo.svg
+      name: USDB
+      standard: EvmHypSynthetic
+      symbol: USDB
+USDC/ancient8-ethereum:
+  tokens:
+    - addressOrDenom: "0x8b4192B9Ad1fCa440A5808641261e5289e6de95D"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|ancient8|0x97423A68BAe94b5De52d767a17aBCc54c157c0E5
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x97423A68BAe94b5De52d767a17aBCc54c157c0E5"
+      chainName: ancient8
+      connections:
+        - token: ethereum|ethereum|0x8b4192B9Ad1fCa440A5808641261e5289e6de95D
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+USDC/appchain-base:
+  tokens:
+    - addressOrDenom: "0x675C3ce7F43b00045a4Dab954AF36160fb57cB45"
+      chainName: appchain
+      connections:
+        - token: ethereum|base|0xF6B933267d0aC9e08c4904FB39fa047eD7b6a814
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+    - addressOrDenom: "0xF6B933267d0aC9e08c4904FB39fa047eD7b6a814"
+      chainName: base
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      connections:
+        - token: ethereum|appchain|0x675C3ce7F43b00045a4Dab954AF36160fb57cB45
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+USDC/arbitrum-base-endurance:
+  tokens:
+    - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
+      chainName: arbitrum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+      connections:
+        - token: ethereum|endurance|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
+      chainName: base
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      connections:
+        - token: ethereum|endurance|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xa66a9C0112a428d407388Db87659E9C66F3eF29c"
+      chainName: endurance
+      connections:
+        - token: ethereum|arbitrum|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
+        - token: ethereum|base|0xa66a9C0112a428d407388Db87659E9C66F3eF29c
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateralFiat
+      symbol: USDC
+USDC/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed:
+  tokens:
+    - addressOrDenom: "0xc927767CF7bddc5e8b996A0f957e5F22250A2F67"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xa7D6042eEf06E81168e640b5C41632eE5295227D"
+      chainName: superseed
+      collateralAddressOrDenom: "0xc316c8252b5f2176d0135ebb0999e99296998f2e"
+      connections:
+        - token: ethereum|arbitrum|0x2cB0E5AbE11346679749063d3FBfC1f390e6e70A
+        - token: ethereum|base|0x955132016f9B6376B1392aA7BFF50538d21Ababc
+        - token: ethereum|ethereum|0xc927767CF7bddc5e8b996A0f957e5F22250A2F67
+        - token: ethereum|ink|0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC
+        - token: ethereum|optimism|0x741B077c69FA219CEdb11364706a3880A792423e
+        - token: sealevel|solanamainnet|7aM3itqXToHXhdR97EwJjZc7fay6uBszhUs1rzJm3tto
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateralFiat
+      symbol: USDC
+    - addressOrDenom: "0x2cB0E5AbE11346679749063d3FBfC1f390e6e70A"
+      chainName: arbitrum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+      connections:
+        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x955132016f9B6376B1392aA7BFF50538d21Ababc"
+      chainName: base
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      connections:
+        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC"
+      chainName: ink
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xF1815bd50389c46847f0Bda824eC8da914045D14"
+      connections:
+        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x741B077c69FA219CEdb11364706a3880A792423e"
+      chainName: optimism
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+      connections:
+        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: 7aM3itqXToHXhdR97EwJjZc7fay6uBszhUs1rzJm3tto
+      chainName: solanamainnet
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+      connections:
+        - token: ethereum|superseed|0xa7D6042eEf06E81168e640b5C41632eE5295227D
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: SealevelHypCollateral
+      symbol: USDC
+USDC/arbitrum-base-ethereum-lisk-optimism-polygon-zeronetwork:
+  tokens:
+    - addressOrDenom: "0x14adE09354a20ed23E690afc803E64E60a84e7D3"
+      chainName: arbitrum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+      connections:
+        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D"
+      chainName: base
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      connections:
+        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xa6826c7Dd74c4e1B400AEF4a362692f99872F5F5"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+      chainName: lisk
+      connections:
+        - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
+        - token: ethereum|base|0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D
+        - token: ethereum|ethereum|0xa6826c7Dd74c4e1B400AEF4a362692f99872F5F5
+        - token: ethereum|optimism|0xcA11d580faaE3E6993aA230f437079ac21f3078a
+        - token: ethereum|polygon|0xb805ee88eE76EcE03ba503A2634344804a0Ea59A
+        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+    - addressOrDenom: "0xcA11d580faaE3E6993aA230f437079ac21f3078a"
+      chainName: optimism
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+      connections:
+        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xb805ee88eE76EcE03ba503A2634344804a0Ea59A"
+      chainName: polygon
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
+      connections:
+        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|zeronetwork|0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1"
+      chainName: zeronetwork
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x6a6394F47DD0BAF794808F2749C09bd4Ee874E70"
+      connections:
+        - token: ethereum|arbitrum|0x14adE09354a20ed23E690afc803E64E60a84e7D3
+        - token: ethereum|base|0x103C9CF52bBF6A6815a6c7e07C5Fb376De016C7D
+        - token: ethereum|ethereum|0xa6826c7Dd74c4e1B400AEF4a362692f99872F5F5
+        - token: ethereum|lisk|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|optimism|0xcA11d580faaE3E6993aA230f437079ac21f3078a
+        - token: ethereum|polygon|0xb805ee88eE76EcE03ba503A2634344804a0Ea59A
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+USDC/arbitrum-bsc-kalychain-polygon:
+  tokens:
+    - addressOrDenom: "0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+      connections:
+        - token: ethereum|bsc|0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0
+        - token: ethereum|kalychain|0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9
+        - token: ethereum|polygon|0xB3dF48224FA257D55e01342592f9A24cefc2628e
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0"
+      chainName: bsc
+      collateralAddressOrDenom: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
+      connections:
+        - token: ethereum|arbitrum|0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd
+        - token: ethereum|kalychain|0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9
+        - token: ethereum|polygon|0xB3dF48224FA257D55e01342592f9A24cefc2628e
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9"
+      chainName: kalychain
+      connections:
+        - token: ethereum|arbitrum|0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd
+        - token: ethereum|bsc|0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0
+        - token: ethereum|polygon|0xB3dF48224FA257D55e01342592f9A24cefc2628e
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+    - addressOrDenom: "0xB3dF48224FA257D55e01342592f9A24cefc2628e"
+      chainName: polygon
+      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
+      connections:
+        - token: ethereum|arbitrum|0xD0a1d1b8E10625eE7Ed4Be4Aa7afA7f169411FBd
+        - token: ethereum|bsc|0x3d7d707Df6390adB61e0Ec3eA91A8FC20E519dd0
+        - token: ethereum|kalychain|0x9cAb0c396cF0F4325913f2269a0b72BD4d46E3A9
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+USDC/arbitrum-cheesechain:
+  tokens:
+    - addressOrDenom: "0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41"
+      chainName: cheesechain
+      connections:
+        - token: ethereum|arbitrum|0xC9e048011E4A47584CE5b91AbD8695338A640648
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: EvmHypSynthetic
+      symbol: USDC
+    - addressOrDenom: "0xC9e048011E4A47584CE5b91AbD8695338A640648"
+      chainName: arbitrum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xa8E5800AEf846A38a5814A28bcB851Ed626a0053"
+      connections:
+        - token: ethereum|cheesechain|0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: EvmHypOwnerCollateral
+      symbol: USDC
+USDC/arbitrum-ethereum-optimism-polygon-prom:
+  tokens:
+    - addressOrDenom: "0x736f1150203E88E6aBA183f216A4a51b6ca12156"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      connections:
+        - token: ethereum|ethereum|0x424712Bec7c94a0F804c50F77B641A24F33A138e
+        - token: ethereum|optimism|0xEa1A15ed2710f860a38091877c6A84b18206b501
+        - token: ethereum|polygon|0x93b637AEA6a0dF51E8E24E49C62da34f616491c5
+        - token: ethereum|prom|0xd9c95e2ad330E11D7Dfa58f18504049f625E955e
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x424712Bec7c94a0F804c50F77B641A24F33A138e"
+      chainName: ethereum
+      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      connections:
+        - token: ethereum|arbitrum|0x736f1150203E88E6aBA183f216A4a51b6ca12156
+        - token: ethereum|optimism|0xEa1A15ed2710f860a38091877c6A84b18206b501
+        - token: ethereum|polygon|0x93b637AEA6a0dF51E8E24E49C62da34f616491c5
+        - token: ethereum|prom|0xd9c95e2ad330E11D7Dfa58f18504049f625E955e
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xEa1A15ed2710f860a38091877c6A84b18206b501"
+      chainName: optimism
+      collateralAddressOrDenom: "0x0b2c639c533813f4aa9d7837caf62653d097ff85"
+      connections:
+        - token: ethereum|arbitrum|0x736f1150203E88E6aBA183f216A4a51b6ca12156
+        - token: ethereum|ethereum|0x424712Bec7c94a0F804c50F77B641A24F33A138e
+        - token: ethereum|polygon|0x93b637AEA6a0dF51E8E24E49C62da34f616491c5
+        - token: ethereum|prom|0xd9c95e2ad330E11D7Dfa58f18504049f625E955e
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x93b637AEA6a0dF51E8E24E49C62da34f616491c5"
+      chainName: polygon
+      collateralAddressOrDenom: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"
+      connections:
+        - token: ethereum|arbitrum|0x736f1150203E88E6aBA183f216A4a51b6ca12156
+        - token: ethereum|ethereum|0x424712Bec7c94a0F804c50F77B641A24F33A138e
+        - token: ethereum|optimism|0xEa1A15ed2710f860a38091877c6A84b18206b501
+        - token: ethereum|prom|0xd9c95e2ad330E11D7Dfa58f18504049f625E955e
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xd9c95e2ad330E11D7Dfa58f18504049f625E955e"
+      chainName: prom
+      connections:
+        - token: ethereum|arbitrum|0x736f1150203E88E6aBA183f216A4a51b6ca12156
+        - token: ethereum|ethereum|0x424712Bec7c94a0F804c50F77B641A24F33A138e
+        - token: ethereum|optimism|0xEa1A15ed2710f860a38091877c6A84b18206b501
+        - token: ethereum|polygon|0x93b637AEA6a0dF51E8E24E49C62da34f616491c5
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+USDC/artela-base:
+  tokens:
+    - addressOrDenom: "0x8d9Bd7E9ec3cd799a659EE650DfF6C799309fA91"
+      chainName: artela
+      connections:
+        - token: ethereum|base|0x01348F639D6e418A5a9673c08c0dDf6ecCB80F37
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC.a
+    - addressOrDenom: "0x01348F639D6e418A5a9673c08c0dDf6ecCB80F37"
+      chainName: base
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      connections:
+        - token: ethereum|artela|0x8d9Bd7E9ec3cd799a659EE650DfF6C799309fA91
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+USDC/base-ethereum-solanamainnet-subtensor:
+  tokens:
+    - addressOrDenom: "0x26af973A5b256F9B9bc0B1A3c566de1566568a87"
+      chainName: base
+      coinGeckoId: usdc
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      connections:
+        - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
+        - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
+        - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b"
+      chainName: ethereum
+      coinGeckoId: usdc
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
+        - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
+        - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xB833E8137FEDf80de7E908dc6fea43a029142F20"
+      chainName: subtensor
+      connections:
+        - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
+        - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
+        - token: ethereum|solanamainnet|GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+    - addressOrDenom: GPCsiXvm9NaFjrxB6sThscap6akyvRgD5V6decCk25c
+      chainName: solanamainnet
+      coinGeckoId: usdc
+      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+      connections:
+        - token: ethereum|base|0x26af973A5b256F9B9bc0B1A3c566de1566568a87
+        - token: ethereum|ethereum|0x3C43C421f08e2a48889eA3F75a747b7a7a366A0b
+        - token: ethereum|subtensor|0xB833E8137FEDf80de7E908dc6fea43a029142F20
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: SealevelHypCollateral
+      symbol: USDC
+USDC/base-optimism:
+  tokens:
+    - addressOrDenom: "0x524410b1e64f689eeBa15E7E511110438811B3dC"
+      chainName: base
+      collateralAddressOrDenom: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+      connections:
+        - token: ethereum|optimism|0x2DBe8c163f080b244D420be781abD37c1bfc51A6
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x2DBe8c163f080b244D420be781abD37c1bfc51A6"
+      chainName: optimism
+      connections:
+        - token: ethereum|base|0x524410b1e64f689eeBa15E7E511110438811B3dC
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+USDC/bsc-polygon-prom:
+  tokens:
+    - addressOrDenom: "0x647eeD57dFDd335f9B6f2a9DbDFe09f166b1AdaC"
+      chainName: bsc
+      collateralAddressOrDenom: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
+      connections:
+        - token: ethereum|polygon|0xFDf46770Da4F907c09aEd92299552DC9c7996d99
+        - token: ethereum|prom|0x424712Bec7c94a0F804c50F77B641A24F33A138e
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xFDf46770Da4F907c09aEd92299552DC9c7996d99"
+      chainName: polygon
+      connections:
+        - token: ethereum|bsc|0x647eeD57dFDd335f9B6f2a9DbDFe09f166b1AdaC
+        - token: ethereum|prom|0x424712Bec7c94a0F804c50F77B641A24F33A138e
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+    - addressOrDenom: "0x424712Bec7c94a0F804c50F77B641A24F33A138e"
+      chainName: prom
+      collateralAddressOrDenom: "0xcd1D86a6fDb32e9525C40a1a91892F33A0617E13"
+      connections:
+        - token: ethereum|bsc|0x647eeD57dFDd335f9B6f2a9DbDFe09f166b1AdaC
+        - token: ethereum|polygon|0xFDf46770Da4F907c09aEd92299552DC9c7996d99
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+USDC/bsc-prom:
+  tokens:
+    - addressOrDenom: "0xb4aF6757691573f0acAbA35A724a8E0EE049aB5a"
+      chainName: bsc
+      collateralAddressOrDenom: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
+      connections:
+        - token: ethereum|prom|0x451c22b06a5f38a43641f6910834C90f3619cEb9
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x451c22b06a5f38a43641f6910834C90f3619cEb9"
+      chainName: prom
+      connections:
+        - token: ethereum|bsc|0xb4aF6757691573f0acAbA35A724a8E0EE049aB5a
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+USDC/coti-ethereum:
+  tokens:
+    - addressOrDenom: "0xEE2e85Df244e32d95d9f327D7a35Ba3d2d412225"
+      chainName: coti
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xf1Feebc4376c68B7003450ae66343Ae59AB37D3C"
+      connections:
+        - token: ethereum|ethereum|0x6de5FaBC6B4663BD6BdBc064Bbb183E61aF1daDE
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateralFiat
+      symbol: USDC
+    - addressOrDenom: "0x6de5FaBC6B4663BD6BdBc064Bbb183E61aF1daDE"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      connections:
+        - token: ethereum|coti|0xEE2e85Df244e32d95d9f327D7a35Ba3d2d412225
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+USDC/eclipsemainnet-ethereum-solanamainnet:
+  tokens:
+    - addressOrDenom: "0xe1De9910fe71cC216490AC7FCF019e13a34481D7"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      connections:
+        - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: AKEWE7Bgh87GPp171b4cJPSSZfmZwQ3KaqYqXoKLNAEE
+      connections:
+        - token: ethereum|ethereum|0xe1De9910fe71cC216490AC7FCF019e13a34481D7
+        - token: sealevel|solanamainnet|3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: SealevelHypSynthetic
+      symbol: USDC
+    - addressOrDenom: 3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
+      chainName: solanamainnet
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+      connections:
+        - token: sealevel|eclipsemainnet|EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: SealevelHypCollateral
+      symbol: USDC
+USDC/ethereum-form:
+  tokens:
+    - addressOrDenom: "0x3551011EA5F210981E9C2a8659444011370f41e2"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|form|0xC316C8252B5F2176d0135Ebb0999E99296998F2e
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xC316C8252B5F2176d0135Ebb0999E99296998F2e"
+      chainName: form
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xFBf489bb4783D4B1B2e7D07ba39873Fb8068507D"
+      connections:
+        - token: ethereum|ethereum|0x3551011EA5F210981E9C2a8659444011370f41e2
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateralFiat
+      symbol: USDC
+USDC/ethereum-inevm:
+  tokens:
+    - addressOrDenom: "0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      connections:
+        - token: ethereum|inevm|0x8358d8291e3bedb04804975eea0fe9fe0fafb147
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x8358d8291e3bedb04804975eea0fe9fe0fafb147"
+      chainName: inevm
+      connections:
+        - token: ethereum|ethereum|0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: EvmHypSynthetic
+      symbol: USDC
+USDC/ethereum-ink:
+  tokens:
+    - addressOrDenom: "0xAf4f3329D271655a4287882310dE25Fb77Dc0a14"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|ink|0x23f63C65c474f2A5BF80ea845Ca496Da3689A2B9
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x23f63C65c474f2A5BF80ea845Ca496Da3689A2B9"
+      chainName: ink
+      connections:
+        - token: ethereum|ethereum|0xAf4f3329D271655a4287882310dE25Fb77Dc0a14
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+USDC/ethereum-lumiaprism:
+  tokens:
+    - addressOrDenom: "0x066abc14c59cF7681b4b66844500733D2258032A"
+      chainName: ethereum
+      coinGeckoId: usdc
+      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      connections:
+        - token: ethereum|lumiaprism|0x2D0b95BB7eC6A8A3B3229e8FB8bE5848aBEA137a
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x2D0b95BB7eC6A8A3B3229e8FB8bE5848aBEA137a"
+      chainName: lumiaprism
+      coinGeckoId: usdc
+      collateralAddressOrDenom: "0xFF297AC2CB0a236155605EB37cB55cFCAe6D3F01"
+      connections:
+        - token: ethereum|ethereum|0x066abc14c59cF7681b4b66844500733D2258032A
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateralFiat
+      symbol: USDC
+USDC/ethereum-swell:
+  tokens:
+    - addressOrDenom: "0x1fbcc5A3EE1EfC5e920FFF999AE97a0C2DF4A583"
+      chainName: ethereum
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|swell|0x93D41E41cA545a35A81d11b08D2eE8b852C768df
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0x93D41E41cA545a35A81d11b08D2eE8b852C768df"
+      chainName: swell
+      collateralAddressOrDenom: "0x99a38322cAF878Ef55AE4d0Eda535535eF8C7960"
+      connections:
+        - token: ethereum|ethereum|0x1fbcc5A3EE1EfC5e920FFF999AE97a0C2DF4A583
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateralFiat
+      symbol: USDC
+USDC/ethereum-viction:
+  tokens:
+    - addressOrDenom: "0x31Dca7762930f56D81292f85E65c9D67575804fE"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      connections:
+        - token: ethereum|viction|0xbda330ea8f3005c421c8088e638fbb64fa71b9e0
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: EvmHypCollateral
+      symbol: USDC
+    - addressOrDenom: "0xbda330ea8f3005c421c8088e638fbb64fa71b9e0"
+      chainName: viction
+      connections:
+        - token: ethereum|ethereum|0x31Dca7762930f56D81292f85E65c9D67575804fE
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: EvmHypSynthetic
+      symbol: USDC
+USDC/solanamainnet-sonicsvm:
+  tokens:
+    - addressOrDenom: 996EsR8a7MC6odE6j7sjsArmDQVqB96qWu84wHdthahm
+      chainName: solanamainnet
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+      connections:
+        - token: sealevel|sonicsvm|BvTEYSqCcfMwpAriC1vDpNhzR1JWzasRFfCPCdgsYaCd
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: SealevelHypCollateral
+      symbol: USDC
+    - addressOrDenom: BvTEYSqCcfMwpAriC1vDpNhzR1JWzasRFfCPCdgsYaCd
+      chainName: sonicsvm
+      collateralAddressOrDenom: HbDgpvHVxeNSRCGEUFvapCYmtYfqxexWcCbxtYecruy8
+      connections:
+        - token: sealevel|solanamainnet|996EsR8a7MC6odE6j7sjsArmDQVqB96qWu84wHdthahm
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USDC
+      standard: SealevelHypSynthetic
+      symbol: USDC
+USDCSTAGE/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed:
+  tokens:
+    - addressOrDenom: "0x1d82BC329E5E6CA5CBc41571435824dda7895e92"
+      chainName: ethereum
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDCSTAGE
+    - addressOrDenom: "0xf728C884De5275a608dEC222dACd0f2BF2E23AB6"
+      chainName: superseed
+      collateralAddressOrDenom: "0x99a38322cAF878Ef55AE4d0Eda535535eF8C7960"
+      connections:
+        - token: ethereum|ethereum|0x1d82BC329E5E6CA5CBc41571435824dda7895e92
+        - token: ethereum|arbitrum|0xD74706A5Be0cb87357EF80b4fAEa709287D4f640
+        - token: ethereum|base|0x23eE98fD566eBae12296d1B111064921143AD6a7
+        - token: ethereum|ink|0x5D71b91B92AAE933cbf85065F49bC14f16c55c55
+        - token: ethereum|optimism|0x2171e985D95eB12451B723b19458A7f1AdEbc086
+        - token: sealevel|solanamainnet|8UUnM8wheNwAf3KM65Yx72Mq8mSAHf33GUwEp3MAyQX1
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateralFiat
+      symbol: USDCSTAGE
+    - addressOrDenom: "0xD74706A5Be0cb87357EF80b4fAEa709287D4f640"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+      connections:
+        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDCSTAGE
+    - addressOrDenom: "0x23eE98fD566eBae12296d1B111064921143AD6a7"
+      chainName: base
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      connections:
+        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDCSTAGE
+    - addressOrDenom: "0x5D71b91B92AAE933cbf85065F49bC14f16c55c55"
+      chainName: ink
+      collateralAddressOrDenom: "0xF1815bd50389c46847f0Bda824eC8da914045D14"
+      connections:
+        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDCSTAGE
+    - addressOrDenom: "0x2171e985D95eB12451B723b19458A7f1AdEbc086"
+      chainName: optimism
+      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+      connections:
+        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
+      decimals: 6
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDCSTAGE
+    - addressOrDenom: 8UUnM8wheNwAf3KM65Yx72Mq8mSAHf33GUwEp3MAyQX1
+      chainName: solanamainnet
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+      connections:
+        - token: ethereum|superseed|0xf728C884De5275a608dEC222dACd0f2BF2E23AB6
+      decimals: 6
+      name: USD Coin
+      standard: SealevelHypCollateral
+      symbol: USDCSTAGE
+USDN/auroratestnet-nobletestnet:
+  tokens:
+    - addressOrDenom: "0x2d10ad108d26384329Ac879476Ae0F4cc0531DEC"
+      chainName: auroratestnet
+      connections:
+        - token: cosmosnative|nobletestnet|0x726f757465725f61707000000000000000000000000000010000000000000000
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDN/logo.svg
+      name: Noble Dollar
+      standard: EvmHypSynthetic
+      symbol: USDN
+    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
+      chainName: nobletestnet
+      collateralAddressOrDenom: uusdn
+      connections:
+        - token: ethereum|auroratestnet|0x2d10ad108d26384329Ac879476Ae0F4cc0531DEC
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDN/logo.svg
+      name: Noble Dollar
+      standard: CosmosNativeHypCollateral
+      symbol: USDN
+USDStar/solanamainnet-sonicsvm:
+  tokens:
+    - addressOrDenom: FRPTWpmnNPm4LS2a5NUL1QenUrzGDAuifZBUi1mTWTdt
+      chainName: solanamainnet
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: BenJy1n3WTx9mTjEvy63e8Q1j4RqUc6E4VBMz3ir4Wo6
+      connections:
+        - token: sealevel|sonicsvm|68g96Cq16vKAqyG79BFVeJCgitjK9fQ1NRCRmcPkJtDB
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDStar/logo.svg
+      name: USD Star
+      standard: SealevelHypCollateral
+      symbol: USD*
+    - addressOrDenom: 68g96Cq16vKAqyG79BFVeJCgitjK9fQ1NRCRmcPkJtDB
+      chainName: sonicsvm
+      collateralAddressOrDenom: BhaUtuAuuv8B5BiPx4LZyaPhY8CCtJsGNAic24pZzV78
+      connections:
+        - token: sealevel|solanamainnet|FRPTWpmnNPm4LS2a5NUL1QenUrzGDAuifZBUi1mTWTdt
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDStar/logo.svg
+      name: USD Star
+      standard: SealevelHypSynthetic
+      symbol: USD*
+USDT/arbitrum-bsc-kalychain-polygon:
+  tokens:
+    - addressOrDenom: "0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
+      connections:
+        - token: ethereum|bsc|0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101
+        - token: ethereum|kalychain|0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A
+        - token: ethereum|polygon|0x2f7c83FC82A0e39A997c262e5BAB13176C275104
+      decimals: 6
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101"
+      chainName: bsc
+      collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
+      connections:
+        - token: ethereum|arbitrum|0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9
+        - token: ethereum|kalychain|0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A
+        - token: ethereum|polygon|0x2f7c83FC82A0e39A997c262e5BAB13176C275104
+      decimals: 6
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A"
+      chainName: kalychain
+      connections:
+        - token: ethereum|arbitrum|0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9
+        - token: ethereum|bsc|0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101
+        - token: ethereum|polygon|0x2f7c83FC82A0e39A997c262e5BAB13176C275104
+      decimals: 6
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+    - addressOrDenom: "0x2f7c83FC82A0e39A997c262e5BAB13176C275104"
+      chainName: polygon
+      collateralAddressOrDenom: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
+      connections:
+        - token: ethereum|arbitrum|0xFDb3307a16442ed5A7C040AE1600a3B3D3C8e7D9
+        - token: ethereum|bsc|0xf4f62eC5C9d4e5464A9D1Dd738e3f50b1d652101
+        - token: ethereum|kalychain|0x2CA775C77B922A51FcF3097F52bFFdbc0250D99A
+      decimals: 6
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork:
+  tokens:
+    - addressOrDenom: "0x83AF845F002c2dA8748eaB8203D2704BdAE6fB8e"
+      chainName: arbitrum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
+      connections:
+        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec"
+      chainName: mantle
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE"
+      connections:
+        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec"
+      chainName: mode
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xf0F161fDA2712DB8b566946122a5af183995e2eD"
+      connections:
+        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x6701d503369cf6aA9e5EdFfEBFA40A2ffdf3dB21"
+      chainName: polygon
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
+      connections:
+        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
+      chainName: scroll
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df"
+      connections:
+        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x36dcfe3A0C6e0b5425F298587159249d780AAfab"
+      chainName: zeronetwork
+      connections:
+        - token: ethereum|arbitrum|0x83AF845F002c2dA8748eaB8203D2704BdAE6fB8e
+        - token: ethereum|mantle|0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec
+        - token: ethereum|mode|0x803e7524526c579cCF6Ef0474d03012EdFD0d3Ec
+        - token: ethereum|polygon|0x6701d503369cf6aA9e5EdFfEBFA40A2ffdf3dB21
+        - token: ethereum|scroll|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
+        - token: ethereum|ethereum|0x95fBD1037a307A49587174E06a6600fD05c5f58e
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+    - addressOrDenom: "0x95fBD1037a307A49587174E06a6600fD05c5f58e"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+      connections:
+        - token: ethereum|zeronetwork|0x36dcfe3A0C6e0b5425F298587159249d780AAfab
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+USDT/arbitrum-ethereum-optimism-polygon-prom:
+  tokens:
+    - addressOrDenom: "0xB9D49E18c69628C6D6B12Ab06F1918C4c4fe9546"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"
+      connections:
+        - token: ethereum|ethereum|0xBA18df45758a09647F1902a06807844EA5DD47b4
+        - token: ethereum|optimism|0xE9ef49e77c9f4751fBb0176836da70D062bBae02
+        - token: ethereum|polygon|0x009eA8aBe4CE04fFA4A2b2Ec62cBAC859fc48B19
+        - token: ethereum|prom|0x7e942605B5028E3B751dBB5Ef8afC5CF85a5A7eD
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xBA18df45758a09647F1902a06807844EA5DD47b4"
+      chainName: ethereum
+      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      connections:
+        - token: ethereum|arbitrum|0xB9D49E18c69628C6D6B12Ab06F1918C4c4fe9546
+        - token: ethereum|optimism|0xE9ef49e77c9f4751fBb0176836da70D062bBae02
+        - token: ethereum|polygon|0x009eA8aBe4CE04fFA4A2b2Ec62cBAC859fc48B19
+        - token: ethereum|prom|0x7e942605B5028E3B751dBB5Ef8afC5CF85a5A7eD
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xE9ef49e77c9f4751fBb0176836da70D062bBae02"
+      chainName: optimism
+      collateralAddressOrDenom: "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"
+      connections:
+        - token: ethereum|arbitrum|0xB9D49E18c69628C6D6B12Ab06F1918C4c4fe9546
+        - token: ethereum|ethereum|0xBA18df45758a09647F1902a06807844EA5DD47b4
+        - token: ethereum|polygon|0x009eA8aBe4CE04fFA4A2b2Ec62cBAC859fc48B19
+        - token: ethereum|prom|0x7e942605B5028E3B751dBB5Ef8afC5CF85a5A7eD
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x009eA8aBe4CE04fFA4A2b2Ec62cBAC859fc48B19"
+      chainName: polygon
+      collateralAddressOrDenom: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
+      connections:
+        - token: ethereum|arbitrum|0xB9D49E18c69628C6D6B12Ab06F1918C4c4fe9546
+        - token: ethereum|ethereum|0xBA18df45758a09647F1902a06807844EA5DD47b4
+        - token: ethereum|optimism|0xE9ef49e77c9f4751fBb0176836da70D062bBae02
+        - token: ethereum|prom|0x7e942605B5028E3B751dBB5Ef8afC5CF85a5A7eD
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x7e942605B5028E3B751dBB5Ef8afC5CF85a5A7eD"
+      chainName: prom
+      connections:
+        - token: ethereum|arbitrum|0xB9D49E18c69628C6D6B12Ab06F1918C4c4fe9546
+        - token: ethereum|ethereum|0xBA18df45758a09647F1902a06807844EA5DD47b4
+        - token: ethereum|optimism|0xE9ef49e77c9f4751fBb0176836da70D062bBae02
+        - token: ethereum|polygon|0x009eA8aBe4CE04fFA4A2b2Ec62cBAC859fc48B19
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/bsc-polygon-prom:
+  tokens:
+    - addressOrDenom: "0x74e19D0c1828be422dDCd367a6ADa8CA7003d1a9"
+      chainName: bsc
+      collateralAddressOrDenom: "0x55d398326f99059ff775485246999027b3197955"
+      connections:
+        - token: ethereum|polygon|0xd9765D5fE176493808202e63E6B73b523D6A1C3A
+        - token: ethereum|prom|0xDf6C58ec668daB037373BC49215722c2b0664484
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xd9765D5fE176493808202e63E6B73b523D6A1C3A"
+      chainName: polygon
+      connections:
+        - token: ethereum|bsc|0x74e19D0c1828be422dDCd367a6ADa8CA7003d1a9
+        - token: ethereum|prom|0xDf6C58ec668daB037373BC49215722c2b0664484
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+    - addressOrDenom: "0xDf6C58ec668daB037373BC49215722c2b0664484"
+      chainName: prom
+      collateralAddressOrDenom: "0x7d7b730CBc9C98cB423a6F206840028036d1DA48"
+      connections:
+        - token: ethereum|bsc|0x74e19D0c1828be422dDCd367a6ADa8CA7003d1a9
+        - token: ethereum|polygon|0xd9765D5fE176493808202e63E6B73b523D6A1C3A
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+USDT/bsc-prom:
+  tokens:
+    - addressOrDenom: "0xCf2D543345728da295CC5d3A3d54B117979643f8"
+      chainName: bsc
+      collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
+      connections:
+        - token: ethereum|prom|0x6064C9028d069a7822d30EF17065A57524A5FcAb
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x6064C9028d069a7822d30EF17065A57524A5FcAb"
+      chainName: prom
+      connections:
+        - token: ethereum|bsc|0xCf2D543345728da295CC5d3A3d54B117979643f8
+      decimals: 18
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/eclipsemainnet-ethereum-solanamainnet:
+  tokens:
+    - addressOrDenom: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      connections:
+        - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: 5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: CEBP3CqAbW4zdZA57H2wfaSG1QNdzQ72GiQEbQXyW9Tm
+      connections:
+        - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
+        - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: SealevelHypSynthetic
+      symbol: USDT
+    - addressOrDenom: Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
+      chainName: solanamainnet
+      coinGeckoId: tether
+      collateralAddressOrDenom: Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
+      connections:
+        - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: SealevelHypCollateral
+      symbol: USDT
+USDT/ethereum-form:
+  tokens:
+    - addressOrDenom: "0x6435821A260B6A8EcB4ab723B84e1Bc3BC8b5304"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      connections:
+        - token: ethereum|form|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xFA3198ecF05303a6d96E57a45E6c815055D255b1"
+      chainName: form
+      connections:
+        - token: ethereum|ethereum|0x6435821A260B6A8EcB4ab723B84e1Bc3BC8b5304
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/ethereum-hyperevm:
+  tokens:
+    - addressOrDenom: "0xf6ff77f2dCAD6dbab2142404F7b64C5517587e29"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      connections:
+        - token: ethereum|hyperevm|0xbF2D3b1a37D54ce86d0e1455884dA875a97C87a8
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xbF2D3b1a37D54ce86d0e1455884dA875a97C87a8"
+      chainName: hyperevm
+      connections:
+        - token: ethereum|ethereum|0xf6ff77f2dCAD6dbab2142404F7b64C5517587e29
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/ethereum-inevm:
+  tokens:
+    - addressOrDenom: "0xab852e67bf03E74C89aF67C4BA97dd1088D3dA19"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+      connections:
+        - token: ethereum|inevm|0x97423a68bae94b5de52d767a17abcc54c157c0e5
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x97423a68bae94b5de52d767a17abcc54c157c0e5"
+      chainName: inevm
+      connections:
+        - token: ethereum|ethereum|0xab852e67bf03E74C89aF67C4BA97dd1088D3dA19
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/ethereum-lumiaprism:
+  tokens:
+    - addressOrDenom: "0x32fF31FfeB04070e9E34C345965C1bB9B5C1F787"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+      connections:
+        - token: ethereum|lumiaprism|0xee7Fc418f5659a366b548b4E205d374C1F0B46e7
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xee7Fc418f5659a366b548b4E205d374C1F0B46e7"
+      chainName: lumiaprism
+      connections:
+        - token: ethereum|ethereum|0x32fF31FfeB04070e9E34C345965C1bB9B5C1F787
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/ethereum-superseed:
+  tokens:
+    - addressOrDenom: "0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      connections:
+        - token: ethereum|superseed|0xc5068BB6803ADbe5600DE5189fe27A4dAcE31170
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xc5068BB6803ADbe5600DE5189fe27A4dAcE31170"
+      chainName: superseed
+      connections:
+        - token: ethereum|ethereum|0xA7Db85E2925e3fec7C33A20d87CC895C948e62b3
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/ethereum-swell:
+  tokens:
+    - addressOrDenom: "0x72529594955CeFfc0ac4ECF23C45B9069A24Df14"
+      chainName: ethereum
+      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+      connections:
+        - token: ethereum|swell|0xb89c6ED617f5F46175E41551350725A09110bbCE
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0xb89c6ED617f5F46175E41551350725A09110bbCE"
+      chainName: swell
+      connections:
+        - token: ethereum|ethereum|0x72529594955CeFfc0ac4ECF23C45B9069A24Df14
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: Tether USD
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/ethereum-viction:
+  tokens:
+    - addressOrDenom: "0x4221a16A01F61c2b38A03C52d828a7041f6AAA49"
+      chainName: ethereum
+      coinGeckoId: tether
+      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+      connections:
+        - token: ethereum|viction|0x48083c69f5a42c6b69abbad48ae195bd36770ee2
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: EvmHypCollateral
+      symbol: USDT
+    - addressOrDenom: "0x48083c69f5a42c6b69abbad48ae195bd36770ee2"
+      chainName: viction
+      connections:
+        - token: ethereum|ethereum|0x4221a16A01F61c2b38A03C52d828a7041f6AAA49
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: EvmHypSynthetic
+      symbol: USDT
+USDT/solanamainnet-sonicsvm:
+  tokens:
+    - addressOrDenom: CKrNt2y1e2H9728mHRVYyF2owy9eKreepRKpTMj2j8JG
+      chainName: solanamainnet
+      coinGeckoId: tether
+      collateralAddressOrDenom: Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
+      connections:
+        - token: sealevel|sonicsvm|BGW8geBw12Yyp4rW7Fp97a3CQRA4Czi8PdtuV2Ec3Vdy
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: SealevelHypCollateral
+      symbol: USDT
+    - addressOrDenom: BGW8geBw12Yyp4rW7Fp97a3CQRA4Czi8PdtuV2Ec3Vdy
+      chainName: sonicsvm
+      collateralAddressOrDenom: qPzdrTCvxK3bxoh2YoTZtDcGVgRUwm37aQcC3abFgBy
+      connections:
+        - token: sealevel|solanamainnet|CKrNt2y1e2H9728mHRVYyF2owy9eKreepRKpTMj2j8JG
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDT/logo.svg
+      name: USDT
+      standard: SealevelHypSynthetic
+      symbol: USDT
+VANA/ethereum-vana:
+  tokens:
+    - addressOrDenom: "0x177778F19E89dD1012BdBe603F144088A95C4B53"
+      chainName: ethereum
+      connections:
+        - token: ethereum|vana|0x96b572D2d880cf2Fa2563651BD23ADE6f5516652
+      decimals: 18
+      name: Vana
+      standard: EvmHypSynthetic
+      symbol: VANA
+    - addressOrDenom: "0x96b572D2d880cf2Fa2563651BD23ADE6f5516652"
+      chainName: vana
+      coinGeckoId: vana
+      connections:
+        - token: ethereum|ethereum|0x177778F19E89dD1012BdBe603F144088A95C4B53
+      decimals: 18
+      name: Vana
+      standard: EvmHypNative
+      symbol: VANA
+WBTC/arbitrum-bsc-kalychain-polygon:
+  tokens:
+    - addressOrDenom: "0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4"
+      chainName: arbitrum
+      collateralAddressOrDenom: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+      connections:
+        - token: ethereum|bsc|0xD42Af909d323D88e0E933B6c50D3e91c279004ca
+        - token: ethereum|kalychain|0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455
+        - token: ethereum|polygon|0xfF00e814A0dCB9a614585c212C78Fdc596d02e47
+      decimals: 8
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: "0xD42Af909d323D88e0E933B6c50D3e91c279004ca"
+      chainName: bsc
+      collateralAddressOrDenom: "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c"
+      connections:
+        - token: ethereum|arbitrum|0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4
+        - token: ethereum|kalychain|0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455
+        - token: ethereum|polygon|0xfF00e814A0dCB9a614585c212C78Fdc596d02e47
+      decimals: 8
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: "0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455"
+      chainName: kalychain
+      connections:
+        - token: ethereum|arbitrum|0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4
+        - token: ethereum|bsc|0xD42Af909d323D88e0E933B6c50D3e91c279004ca
+        - token: ethereum|polygon|0xfF00e814A0dCB9a614585c212C78Fdc596d02e47
+      decimals: 8
+      name: Wrapped BTC
+      standard: EvmHypSynthetic
+      symbol: WBTC
+    - addressOrDenom: "0xfF00e814A0dCB9a614585c212C78Fdc596d02e47"
+      chainName: polygon
+      collateralAddressOrDenom: "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6"
+      connections:
+        - token: ethereum|arbitrum|0x3CDbaBE5Bf4E6cfE10A2A326E0ad31b2d16398D4
+        - token: ethereum|bsc|0xD42Af909d323D88e0E933B6c50D3e91c279004ca
+        - token: ethereum|kalychain|0xaA77D4a26d432B82DB07F8a47B7f7F623fd92455
+      decimals: 8
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+WBTC/coti-ethereum:
+  tokens:
+    - addressOrDenom: "0x5c43f06EF93bb0a2cd3C0f7b832AbA1F4d6575Ea"
+      chainName: ethereum
+      coinGeckoId: wrapped-bitcoin
+      collateralAddressOrDenom: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+      connections:
+        - token: ethereum|coti|0x8C39B1fD0e6260fdf20652Fc436d25026832bfEA
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: "0x8C39B1fD0e6260fdf20652Fc436d25026832bfEA"
+      chainName: coti
+      connections:
+        - token: ethereum|ethereum|0x5c43f06EF93bb0a2cd3C0f7b832AbA1F4d6575Ea
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypSynthetic
+      symbol: WBTC
+WBTC/eclipsemainnet-ethereum:
+  tokens:
+    - addressOrDenom: "0x5B4e223DE74ef8c3218e66EEcC541003CAB3121A"
+      chainName: ethereum
+      coinGeckoId: wrapped-bitcoin
+      collateralAddressOrDenom: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+      connections:
+        - token: sealevel|eclipsemainnet|A7EGCDYFw5R7Jfm6cYtKvY8dmkrYMgwRCJFkyQwpHTYu
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: A7EGCDYFw5R7Jfm6cYtKvY8dmkrYMgwRCJFkyQwpHTYu
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: 7UTjr1VC6Z9DPsWD6mh5wPzNtufN17VnzpKS3ASpfAji
+      connections:
+        - token: ethereum|ethereum|0x5B4e223DE74ef8c3218e66EEcC541003CAB3121A
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: WBTC
+      standard: SealevelHypSynthetic
+      symbol: WBTC
+WBTC/ethereum-form:
+  tokens:
+    - addressOrDenom: "0x0dc95Af5156fb0cC34a8c9BD646B748B9989A956"
+      chainName: form
+      connections:
+        - token: ethereum|ethereum|0xd0d5271926f352c0161b0365a4156E2Bc0f99FAD
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypSynthetic
+      symbol: WBTC
+    - addressOrDenom: "0xd0d5271926f352c0161b0365a4156E2Bc0f99FAD"
+      chainName: ethereum
+      coinGeckoId: wrapped-bitcoin
+      collateralAddressOrDenom: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+      connections:
+        - token: ethereum|form|0x0dc95Af5156fb0cC34a8c9BD646B748B9989A956
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+WBTC/ethereum-hyperevm:
+  tokens:
+    - addressOrDenom: "0x55A66567dFEc91e7Af39e0feb06009F35E8D68a9"
+      chainName: ethereum
+      coinGeckoId: wrapped-bitcoin
+      collateralAddressOrDenom: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+      connections:
+        - token: ethereum|hyperevm|0xE2B36A37bD98ba81658dC5454F2dB2F98438d140
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: "0xE2B36A37bD98ba81658dC5454F2dB2F98438d140"
+      chainName: hyperevm
+      connections:
+        - token: ethereum|ethereum|0x55A66567dFEc91e7Af39e0feb06009F35E8D68a9
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypSynthetic
+      symbol: WBTC
+WBTC/ethereum-mode-scroll-zeronetwork:
+  tokens:
+    - addressOrDenom: "0x745C75868237F3635c486fe166639Cc4706512A9"
+      chainName: ethereum
+      coinGeckoId: wrapped-bitcoin
+      collateralAddressOrDenom: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+      connections:
+        - token: ethereum|mode|0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1
+        - token: ethereum|scroll|0x10a5263ACED246fCD0977f1a3C6A238a14183096
+        - token: ethereum|zeronetwork|0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: "0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1"
+      chainName: mode
+      coinGeckoId: wrapped-bitcoin
+      collateralAddressOrDenom: "0xcDd475325D6F564d27247D1DddBb0DAc6fA0a5CF"
+      connections:
+        - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9
+        - token: ethereum|scroll|0x10a5263ACED246fCD0977f1a3C6A238a14183096
+        - token: ethereum|zeronetwork|0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: "0x10a5263ACED246fCD0977f1a3C6A238a14183096"
+      chainName: scroll
+      coinGeckoId: wrapped-bitcoin
+      collateralAddressOrDenom: "0x3C1BCa5a656e69edCD0D4E36BEbb3FcDAcA60Cf1"
+      connections:
+        - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9
+        - token: ethereum|mode|0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1
+        - token: ethereum|zeronetwork|0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypCollateral
+      symbol: WBTC
+    - addressOrDenom: "0xe6ca7C4A9652Fe93190Bd84363f2056Df1fb9A94"
+      chainName: zeronetwork
+      connections:
+        - token: ethereum|ethereum|0x745C75868237F3635c486fe166639Cc4706512A9
+        - token: ethereum|mode|0x3c38fC01159E7BE0685653A0C896eA49F2BAa7c1
+        - token: ethereum|scroll|0x10a5263ACED246fCD0977f1a3C6A238a14183096
+      decimals: 8
+      logoURI: /deployments/warp_routes/WBTC/logo.svg
+      name: Wrapped BTC
+      standard: EvmHypSynthetic
+      symbol: WBTC
+WETH/artela-base:
+  tokens:
+    - addressOrDenom: "0xfae4e14D01D9E13FB5db20A0329ED0472A2D96C7"
+      chainName: artela
+      connections:
+        - token: ethereum|base|0x5B4d7FD7E6Cb11170137df1A0dB24645533EC0b5
+      decimals: 18
+      logoURI: /deployments/warp_routes/WETH/logo.svg
+      name: Wrapped Ether
+      standard: EvmHypSynthetic
+      symbol: WETH.a
+    - addressOrDenom: "0x5B4d7FD7E6Cb11170137df1A0dB24645533EC0b5"
+      chainName: base
+      coinGeckoId: l2-standard-bridged-weth-base
+      collateralAddressOrDenom: "0x4200000000000000000000000000000000000006"
+      connections:
+        - token: ethereum|artela|0xfae4e14D01D9E13FB5db20A0329ED0472A2D96C7
+      decimals: 18
+      logoURI: /deployments/warp_routes/WETH/logo.svg
+      name: Wrapped Ether
+      standard: EvmHypCollateral
+      symbol: WETH
+WFRAGJTO/eclipsemainnet-solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
+      chainName: solanamainnet
+      coinGeckoId: wrapped-fragjto
+      collateralAddressOrDenom: WFRGJnQt5pK8Dv4cDAbrSsgPcmboysrmX3RYhmRRyTR
+      connections:
+        - token: sealevel|eclipsemainnet|4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
+        - token: sealevel|soon|A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
+      decimals: 9
+      logoURI: /deployments/warp_routes/wfragJTO/logo.svg
+      name: Wrapped Fragmetric Restaked JTO
+      standard: SealevelHypCollateral
+      symbol: wfragJTO
+    - addressOrDenom: 4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: HqDHrCWhdELCf21AAzhpAYTtKLtkqVzGfHTz7fo1yNxy
+      connections:
+        - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
+        - token: sealevel|soon|A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
+      decimals: 9
+      logoURI: /deployments/warp_routes/wfragJTO/logo.svg
+      name: Wrapped Fragmetric Restaked JTO
+      standard: SealevelHypSynthetic
+      symbol: wfragJTO
+    - addressOrDenom: A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
+      chainName: soon
+      collateralAddressOrDenom: 6vrMyHTVQvmGzCjphMZxnfYV7R8C9tDWAQsWDTgCq1mE
+      connections:
+        - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
+        - token: sealevel|eclipsemainnet|4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
+      decimals: 9
+      logoURI: /deployments/warp_routes/wfragJTO/logo.svg
+      name: Wrapped Fragmetric Restaked JTO
+      standard: SealevelHypSynthetic
+      symbol: wfragJTO
+WFRAGSOL/eclipsemainnet-solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
+      chainName: solanamainnet
+      coinGeckoId: wrapped-fragsol
+      collateralAddressOrDenom: WFRGSWjaz8tbAxsJitmbfRuFV2mSNwy7BMWcCwaA28U
+      connections:
+        - token: sealevel|eclipsemainnet|FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
+        - token: sealevel|soon|6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
+      decimals: 9
+      logoURI: /deployments/warp_routes/wfragSOL/logo.svg
+      name: Wrapped Fragmetric Restaked SOL
+      standard: SealevelHypCollateral
+      symbol: wfragSOL
+    - addressOrDenom: FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: 97UNrMjduqbHhnZ5T5w3DifYnxwM2LAEpYxfoMcMjXK1
+      connections:
+        - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
+        - token: sealevel|soon|6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
+      decimals: 9
+      logoURI: /deployments/warp_routes/wfragSOL/logo.svg
+      name: Wrapped Fragmetric Restaked SOL
+      standard: SealevelHypSynthetic
+      symbol: wfragSOL
+    - addressOrDenom: 6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
+      chainName: soon
+      collateralAddressOrDenom: 7T9sawCGJAV4wC49CjHpw8TGL3ZuPAbZipNq86YXGecy
+      connections:
+        - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
+        - token: sealevel|eclipsemainnet|FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
+      decimals: 9
+      logoURI: /deployments/warp_routes/wfragSOL/logo.svg
+      name: Wrapped Fragmetric Restaked SOL
+      standard: SealevelHypSynthetic
+      symbol: wfragSOL
+WIF/eclipsemainnet-solanamainnet:
+  tokens:
+    - addressOrDenom: 6tBGmKNxirxBYnm9khkaTtcr2fhJ9YviCgRm1RWM8NJv
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: 841P4tebEgNux2jaWSjCoi9LhrVr9eHGjLc758Va3RPH
+      connections:
+        - token: sealevel|solanamainnet|CuQmsT4eSF4dYiiGUGYYQxJ7c58pUAD5ADE3BbFGzQKx
+      decimals: 6
+      logoURI: /deployments/warp_routes/WIF/logo.jpg
+      name: dogwifhat
+      standard: SealevelHypSynthetic
+      symbol: WIF
+    - addressOrDenom: CuQmsT4eSF4dYiiGUGYYQxJ7c58pUAD5ADE3BbFGzQKx
+      chainName: solanamainnet
+      coinGeckoId: dogwifcoin
+      collateralAddressOrDenom: EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm
+      connections:
+        - token: sealevel|eclipsemainnet|6tBGmKNxirxBYnm9khkaTtcr2fhJ9YviCgRm1RWM8NJv
+      decimals: 6
+      logoURI: /deployments/warp_routes/WIF/logo.jpg
+      name: dogwifhat
+      standard: SealevelHypCollateral
+      symbol: WIF
+WIF/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: HzP6KbL7fVAwqVgix4eJhijGMFeyg7mhHkQs7kBwrGPQ
+      chainName: soon
+      collateralAddressOrDenom: 4LamGFWF36vfBCVtWrZv17wDkbBSkJ8vSJhGFzui4wkZ
+      connections:
+        - token: sealevel|solanamainnet|BJkD7PFuMKRFPdc8H3pxL5u4KuQ2HWGkQgbvP3hw26AF
+      decimals: 6
+      logoURI: /deployments/warp_routes/WIF/logo.jpg
+      name: dogwifhat
+      standard: SealevelHypSynthetic
+      symbol: WIF
+    - addressOrDenom: BJkD7PFuMKRFPdc8H3pxL5u4KuQ2HWGkQgbvP3hw26AF
+      chainName: solanamainnet
+      coinGeckoId: dogwifcoin
+      collateralAddressOrDenom: EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm
+      connections:
+        - token: sealevel|soon|HzP6KbL7fVAwqVgix4eJhijGMFeyg7mhHkQs7kBwrGPQ
+      decimals: 6
+      logoURI: /deployments/warp_routes/WIF/logo.jpg
+      name: dogwifhat
+      standard: SealevelHypCollateral
+      symbol: WIF
+WSTETH/ethereum-form:
+  tokens:
+    - addressOrDenom: "0x5CBD4c5f9CD55747285652f815Cc7b9A2Ef6c586"
+      chainName: form
+      connections:
+        - token: ethereum|ethereum|0x9c7e8dc6b35E66873dA683aF2dE1BaB4cabc98B5
+      decimals: 18
+      logoURI: /deployments/warp_routes/WSTETH/logo.svg
+      name: Wrapped liquid staked Ether 2.0
+      standard: EvmHypSynthetic
+      symbol: wstETH
+    - addressOrDenom: "0x9c7e8dc6b35E66873dA683aF2dE1BaB4cabc98B5"
+      chainName: ethereum
+      coinGeckoId: wrapped-steth
+      collateralAddressOrDenom: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+      connections:
+        - token: ethereum|form|0x5CBD4c5f9CD55747285652f815Cc7b9A2Ef6c586
+      decimals: 18
+      logoURI: /deployments/warp_routes/WSTETH/logo.svg
+      name: Wrapped liquid staked Ether 2.0
+      standard: EvmHypCollateral
+      symbol: wstETH
+ai16z/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: BrJbX9a9bi9hvV5WesfbuXudQP49G8jnKEqAutRNMYK5
+      chainName: soon
+      collateralAddressOrDenom: Hc3feJHN3S7Kh2TorCKTFQWFx7jgznjzKNG37ufPmp2r
+      connections:
+        - token: sealevel|solanamainnet|9TxKLb6RBo4hEfFNN6up6obvebnEUcm2gkBXrzQFq8s8
+      decimals: 9
+      logoURI: /deployments/warp_routes/ai16z/logo.png
+      name: ai16z
+      standard: SealevelHypSynthetic
+      symbol: ai16z
+    - addressOrDenom: 9TxKLb6RBo4hEfFNN6up6obvebnEUcm2gkBXrzQFq8s8
+      chainName: solanamainnet
+      coinGeckoId: ai16z
+      collateralAddressOrDenom: HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC
+      connections:
+        - token: sealevel|soon|BrJbX9a9bi9hvV5WesfbuXudQP49G8jnKEqAutRNMYK5
+      decimals: 9
+      logoURI: /deployments/warp_routes/ai16z/logo.png
+      name: ai16z
+      standard: SealevelHypCollateral
+      symbol: ai16z
+bbSOL/solanamainnet-soon:
+  tokens:
+    - addressOrDenom: 5mzc5Sv61721Xr44Uw7Kb9txoMWLz8XYLrgCewe1sj2B
+      chainName: soon
+      collateralAddressOrDenom: GxV545AqavAEnu6HbUQGy2DQQpwuY5wAxwrq5F3yG3Mh
+      connections:
+        - token: sealevel|solanamainnet|8rodtMgnpCboxNiaQozdCTGiCEkK6BDXmFuoJ9qhTxfh
+      decimals: 9
+      logoURI: /deployments/warp_routes/bbSOL/logo.png
+      name: Bybit Staked SOL
+      standard: SealevelHypSynthetic
+      symbol: bbSOL
+    - addressOrDenom: 8rodtMgnpCboxNiaQozdCTGiCEkK6BDXmFuoJ9qhTxfh
+      chainName: solanamainnet
+      coinGeckoId: bybit-staked-sol
+      collateralAddressOrDenom: Bybit2vBJGhPF52GBdNaQfUJ6ZpThSgHBobjWZpLPb4B
+      connections:
+        - token: sealevel|soon|5mzc5Sv61721Xr44Uw7Kb9txoMWLz8XYLrgCewe1sj2B
+      decimals: 9
+      logoURI: /deployments/warp_routes/bbSOL/logo.png
+      name: Bybit Staked SOL
+      standard: SealevelHypCollateral
+      symbol: bbSOL
+enzoBTC/bsc-hyperevm:
+  tokens:
+    - addressOrDenom: "0xba06D7f285C6B0d5EacC50ceA931163B23Ab889c"
+      chainName: bsc
+      coinGeckoId: lorenzo-stbtc
+      collateralAddressOrDenom: "0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a"
+      connections:
+        - token: ethereum|hyperevm|0xcb98BD947B58445Fc4815f10285F44De42129918
+      decimals: 8
+      logoURI: /deployments/warp_routes/enzoBTC/logo.svg
+      name: Lorenzo Wrapped Bitcoin
+      standard: EvmHypCollateral
+      symbol: enzoBTC
+    - addressOrDenom: "0xcb98BD947B58445Fc4815f10285F44De42129918"
+      chainName: hyperevm
+      connections:
+        - token: ethereum|bsc|0xba06D7f285C6B0d5EacC50ceA931163B23Ab889c
+      decimals: 8
+      logoURI: /deployments/warp_routes/enzoBTC/logo.svg
+      name: Lorenzo Wrapped Bitcoin
+      standard: EvmHypSynthetic
+      symbol: enzoBTC
+jitoSOL/eclipsemainnet-solanamainnet:
+  tokens:
+    - addressOrDenom: G3hWozA3c4iK5oSX9rTWFFDo5rS9W49bjhWDgg3gDPk8
+      chainName: eclipsemainnet
+      collateralAddressOrDenom: JAh5pFYn1Kbh7kCuqZab8viVFdNgTmpS6hzFstSGNBvG
+      connections:
+        - token: sealevel|solanamainnet|8EMWCPyv6AxgRtMFEZxmxKfhmLmLvi3XbHHendLAUKUF
+      decimals: 9
+      logoURI: /deployments/warp_routes/jitoSOL/logo.svg
+      name: Jito Staked SOL
+      standard: SealevelHypSynthetic
+      symbol: JitoSOL
+    - addressOrDenom: 8EMWCPyv6AxgRtMFEZxmxKfhmLmLvi3XbHHendLAUKUF
+      chainName: solanamainnet
+      coinGeckoId: jito-staked-sol
+      collateralAddressOrDenom: J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn
+      connections:
+        - token: sealevel|eclipsemainnet|G3hWozA3c4iK5oSX9rTWFFDo5rS9W49bjhWDgg3gDPk8
+      decimals: 9
+      logoURI: /deployments/warp_routes/jitoSOL/logo.svg
+      name: Jito Staked SOL
+      standard: SealevelHypCollateral
+      symbol: JitoSOL
+kySOL/eclipsemainnet-solanamainnet:
   tokens:
     - addressOrDenom: 5XbuBdh4V5hmqQrazmGLXJBoLUE2jtvYhwMbGNoLNvG2
       chainName: eclipsemainnet
@@ -5521,7 +5959,7 @@ kySOL/eclipsemainnet:
       name: Kyros Restaked SOL
       standard: SealevelHypCollateral
       symbol: kySOL
-lrtsSOL/sonicsvm:
+lrtsSOL/solanamainnet-sonicsvm:
   tokens:
     - addressOrDenom: HNaDuUrtr34tXZApiAMGHG9DgAvGYsY5C6w9M2iHu59u
       chainName: solanamainnet
@@ -5543,7 +5981,7 @@ lrtsSOL/sonicsvm:
       name: adraLRT SOL (Solayer)
       standard: SealevelHypSynthetic
       symbol: lrtsSOL
-milkTIA.o/mantapacific:
+milkTIA/mantapacific-osmosis:
   options:
     interchainFeeConstants:
       - addressOrDenom: factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA
@@ -6364,7 +6802,7 @@ oUSDTSTAGE/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis
       name: OpenUSDT
       standard: EvmHypVSXERC20Lockbox
       symbol: oUSDTSTAGE
-pumpBTC.sei/sei:
+pumpBTCsei/ethereum-sei:
   tokens:
     - addressOrDenom: "0x179149B7E74910d2A58b2a737e1a8B6F44388882"
       chainName: ethereum
@@ -6386,7 +6824,7 @@ pumpBTC.sei/sei:
       name: redBTC
       standard: EvmHypSynthetic
       symbol: redBTC
-pumpBTC.uni/unichain:
+pumpBTCuni/ethereum-unichain:
   tokens:
     - addressOrDenom: "0x791a257977a147B501dA11013C826063FF2d881e"
       chainName: ethereum
@@ -6407,75 +6845,7 @@ pumpBTC.uni/unichain:
       name: pumpBTC.uni
       standard: EvmHypSynthetic
       symbol: pumpBTC.uni
-pzETH/berachain-ethereum-swell-unichain-zircuit:
-  tokens:
-    - addressOrDenom: "0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd"
-      chainName: ethereum
-      coinGeckoId: renzo-restaked-lst
-      collateralAddressOrDenom: "0xbC5511354C4A9a50DE928F56DB01DD327c4e56d5"
-      connections:
-        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
-        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
-        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
-        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
-      decimals: 18
-      logoURI: /deployments/warp_routes/PZETH/logo.svg
-      name: Renzo Restaked LST
-      standard: EvmHypXERC20Lockbox
-      symbol: pzETH
-    - addressOrDenom: "0x982AbBb04F91acc47aD0CB0A11f29d50c5007934"
-      chainName: swell
-      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
-      connections:
-        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
-        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
-        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
-        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
-      decimals: 18
-      logoURI: /deployments/warp_routes/PZETH/logo.svg
-      name: Renzo Restaked LST
-      standard: EvmHypXERC20
-      symbol: pzETH
-    - addressOrDenom: "0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764"
-      chainName: zircuit
-      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
-      connections:
-        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
-        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
-        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
-        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
-      decimals: 18
-      logoURI: /deployments/warp_routes/PZETH/logo.svg
-      name: Renzo Restaked LST
-      standard: EvmHypXERC20
-      symbol: pzETH
-    - addressOrDenom: "0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0"
-      chainName: berachain
-      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
-      connections:
-        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
-        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
-        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
-        - token: ethereum|unichain|0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7
-      decimals: 18
-      logoURI: /deployments/warp_routes/PZETH/logo.svg
-      name: Renzo Restaked LST
-      standard: EvmHypXERC20
-      symbol: pzETH
-    - addressOrDenom: "0x89c1768E0449c11fbE2409D4de7Dbc3EEB9b22C7"
-      chainName: unichain
-      collateralAddressOrDenom: "0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7"
-      connections:
-        - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
-        - token: ethereum|swell|0x982AbBb04F91acc47aD0CB0A11f29d50c5007934
-        - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
-        - token: ethereum|berachain|0x25a851bF599cb8AEf00Ac1D1a9fb575EBf9d94b0
-      decimals: 18
-      logoURI: /deployments/warp_routes/PZETH/logo.svg
-      name: Renzo Restaked LST
-      standard: EvmHypXERC20
-      symbol: pzETH
-rstETH/zircuit:
+rstETH/ethereum-zircuit:
   tokens:
     - addressOrDenom: "0x18E5D2ae4fb6F5Cf4e6C5D493C4d0F027FAe5054"
       chainName: ethereum
@@ -6494,7 +6864,7 @@ rstETH/zircuit:
       name: Restaking Vault ETH
       standard: EvmHypSynthetic
       symbol: rstETH
-sSOL/sonicsvm:
+sSOL/solanamainnet-sonicsvm:
   tokens:
     - addressOrDenom: 9PHKQFEDzedHuigSm1ZBojEX4DVF3cincGZwy3k7VHTN
       chainName: solanamainnet
@@ -6517,7 +6887,7 @@ sSOL/sonicsvm:
       name: Solayer SOL
       standard: SealevelHypSynthetic
       symbol: sSOL
-sonicSOL/sonicsvm:
+sonicSOL/solanamainnet-sonicsvm:
   tokens:
     - addressOrDenom: Fhqa36L7sFJDiMdu54WUah9stAwRacycqHJYm3b3Geje
       chainName: solanamainnet
@@ -6539,7 +6909,7 @@ sonicSOL/sonicsvm:
       name: Sonic Restaked SOL
       standard: SealevelHypSynthetic
       symbol: sonicSOL
-stBTC/hyperevm:
+stBTC/bsc-hyperevm:
   tokens:
     - addressOrDenom: "0xA0B3b527A15218f980Ceb33df049Dd58D3Da8223"
       chainName: bsc
@@ -6561,7 +6931,7 @@ stBTC/hyperevm:
       name: Lorenzo stBTC
       standard: EvmHypSynthetic
       symbol: stBTC
-stHYPER/bsc:
+stHYPER/bsc-ethereum:
   tokens:
     - addressOrDenom: "0x6E9804a08092D8ba4E69DaCF422Df12459F2599E"
       chainName: bsc
@@ -6583,7 +6953,7 @@ stHYPER/bsc:
       name: Staked HYPER
       standard: EvmHypRebaseCollateral
       symbol: stHYPER
-stHYPERSTAGE/bsc:
+stHYPERSTAGE/bsc-ethereum:
   tokens:
     - addressOrDenom: "0xf0c8c5fc69fCC3fA49C319Fdf422D8279756afE2"
       chainName: bsc
@@ -6602,7 +6972,7 @@ stHYPERSTAGE/bsc:
       name: Staked HYPER
       standard: EvmHypRebaseCollateral
       symbol: stHYPERSTAGE
-stTIA/eclipsemainnet:
+stTIA/eclipsemainnet-stride:
   options:
     interchainFeeConstants:
       - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
@@ -6638,7 +7008,7 @@ stTIA/eclipsemainnet:
       name: Celestia
       standard: CosmosIbc
       symbol: TIA
-stTIA/ethereum:
+stTIA/ethereum-stride:
   options:
     interchainFeeConstants:
       - addressOrDenom: ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801
@@ -6665,26 +7035,7 @@ stTIA/ethereum:
       name: stTIA
       standard: EvmHypSynthetic
       symbol: stTIA
-tAURA/euphoriatestnet:
-  tokens:
-    - addressOrDenom: "0x120f461C4d95412c4a1BC4e8BE6917C9da404510"
-      chainName: euphoriatestnet
-      connections:
-        - token: ethereum|holesky|0x0bA0E052b993E8486AA8dab82c361404F7576573
-      decimals: 18
-      name: Aura Testing
-      standard: EvmHypSynthetic
-      symbol: tAURA
-    - addressOrDenom: "0x0bA0E052b993E8486AA8dab82c361404F7576573"
-      chainName: holesky
-      collateralAddressOrDenom: "0x89C17409dc7222E378A433CE75DDd4dF8a1c4874"
-      connections:
-        - token: ethereum|euphoriatestnet|0x120f461C4d95412c4a1BC4e8BE6917C9da404510
-      decimals: 18
-      name: Aura Testing
-      standard: EvmHypCollateral
-      symbol: tAURA
-tETH/eclipsemainnet:
+tETH/eclipsemainnet-ethereum:
   tokens:
     - addressOrDenom: "0xc2495f3183F043627CAECD56dAaa726e3B2D9c09"
       chainName: ethereum
@@ -6707,7 +7058,7 @@ tETH/eclipsemainnet:
       name: tETH
       standard: SealevelHypSynthetic
       symbol: tETH
-tUSD/eclipsemainnet:
+tUSD/eclipsemainnet-ethereum:
   tokens:
     - addressOrDenom: 53XFTNcTRTzrNyD3QodXbRBZ249G8v3iSHh8FzYeHZoX
       chainName: eclipsemainnet
@@ -6729,54 +7080,7 @@ tUSD/eclipsemainnet:
       name: Eclipse Turbo USD
       standard: EvmHypCollateral
       symbol: tUSD
-uBTC/boba-bsquared-soneium-swell:
-  tokens:
-    - addressOrDenom: "0xFA3198ecF05303a6d96E57a45E6c815055D255b1"
-      chainName: boba
-      connections:
-        - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-        - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
-      decimals: 18
-      logoURI: /deployments/warp_routes/UBTC/logo.svg
-      name: uBTC
-      standard: EvmHypSynthetic
-      symbol: uBTC
-    - addressOrDenom: "0x0FC41a92F526A8CD22060A4052e156502D6B9db0"
-      chainName: bsquared
-      collateralAddressOrDenom: "0x796e4D53067FF374B89b2Ac101ce0c1f72ccaAc2"
-      connections:
-        - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-        - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-        - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
-      decimals: 18
-      logoURI: /deployments/warp_routes/UBTC/logo.svg
-      name: uBTC
-      standard: EvmHypCollateral
-      symbol: uBTC
-    - addressOrDenom: "0xFA3198ecF05303a6d96E57a45E6c815055D255b1"
-      chainName: swell
-      connections:
-        - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-        - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|soneium|0x61F2993a644762A345b483ADF0d6351C5EdFB3b5
-      decimals: 18
-      logoURI: /deployments/warp_routes/UBTC/logo.svg
-      name: uBTC
-      standard: EvmHypSynthetic
-      symbol: uBTC
-    - addressOrDenom: "0x61F2993a644762A345b483ADF0d6351C5EdFB3b5"
-      chainName: soneium
-      connections:
-        - token: ethereum|bsquared|0x0FC41a92F526A8CD22060A4052e156502D6B9db0
-        - token: ethereum|boba|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-        - token: ethereum|swell|0xFA3198ecF05303a6d96E57a45E6c815055D255b1
-      decimals: 18
-      logoURI: /deployments/warp_routes/UBTC/logo.svg
-      name: uBTC
-      standard: EvmHypSynthetic
-      symbol: uBTC
-weETHs/eclipsemainnet:
+weETHs/eclipsemainnet-ethereum:
   tokens:
     - addressOrDenom: "0xef899e92DA472E014bE795Ecce948308958E25A2"
       chainName: ethereum
@@ -6799,97 +7103,3 @@ weETHs/eclipsemainnet:
       name: Super Symbiotic LRT
       standard: SealevelHypSynthetic
       symbol: weETHs
-wfragJTO/eclipsemainnet-solanamainnet-soon:
-  tokens:
-    - addressOrDenom: 21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
-      chainName: solanamainnet
-      coinGeckoId: wrapped-fragjto
-      collateralAddressOrDenom: WFRGJnQt5pK8Dv4cDAbrSsgPcmboysrmX3RYhmRRyTR
-      connections:
-        - token: sealevel|eclipsemainnet|4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
-        - token: sealevel|soon|A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
-      decimals: 9
-      logoURI: /deployments/warp_routes/wfragJTO/logo.svg
-      name: Wrapped Fragmetric Restaked JTO
-      standard: SealevelHypCollateral
-      symbol: wfragJTO
-    - addressOrDenom: 4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: HqDHrCWhdELCf21AAzhpAYTtKLtkqVzGfHTz7fo1yNxy
-      connections:
-        - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
-        - token: sealevel|soon|A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
-      decimals: 9
-      logoURI: /deployments/warp_routes/wfragJTO/logo.svg
-      name: Wrapped Fragmetric Restaked JTO
-      standard: SealevelHypSynthetic
-      symbol: wfragJTO
-    - addressOrDenom: A4UxZkWrEtfmhdtBE3VSS6n4E7Tnj7EMs5PA3hLgmFL8
-      chainName: soon
-      collateralAddressOrDenom: 6vrMyHTVQvmGzCjphMZxnfYV7R8C9tDWAQsWDTgCq1mE
-      connections:
-        - token: sealevel|solanamainnet|21dbSbBdoEqUtJcvBkvhjpEiqb3LTrUFGQxKHWjY3WwV
-        - token: sealevel|eclipsemainnet|4dLFhsXeK6QPxV2HEbXsF6eSTZdTFaGcGY5eEj5c8CbD
-      decimals: 9
-      logoURI: /deployments/warp_routes/wfragJTO/logo.svg
-      name: Wrapped Fragmetric Restaked JTO
-      standard: SealevelHypSynthetic
-      symbol: wfragJTO
-wfragSOL/eclipsemainnet-solanamainnet-soon:
-  tokens:
-    - addressOrDenom: 22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
-      chainName: solanamainnet
-      coinGeckoId: wrapped-fragsol
-      collateralAddressOrDenom: WFRGSWjaz8tbAxsJitmbfRuFV2mSNwy7BMWcCwaA28U
-      connections:
-        - token: sealevel|eclipsemainnet|FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
-        - token: sealevel|soon|6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
-      decimals: 9
-      logoURI: /deployments/warp_routes/wfragSOL/logo.svg
-      name: Wrapped Fragmetric Restaked SOL
-      standard: SealevelHypCollateral
-      symbol: wfragSOL
-    - addressOrDenom: FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
-      chainName: eclipsemainnet
-      collateralAddressOrDenom: 97UNrMjduqbHhnZ5T5w3DifYnxwM2LAEpYxfoMcMjXK1
-      connections:
-        - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
-        - token: sealevel|soon|6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
-      decimals: 9
-      logoURI: /deployments/warp_routes/wfragSOL/logo.svg
-      name: Wrapped Fragmetric Restaked SOL
-      standard: SealevelHypSynthetic
-      symbol: wfragSOL
-    - addressOrDenom: 6trL4uE7KANMqrPT5rw4uiN6TSTw7c5Ssv4GdAkhTzVc
-      chainName: soon
-      collateralAddressOrDenom: 7T9sawCGJAV4wC49CjHpw8TGL3ZuPAbZipNq86YXGecy
-      connections:
-        - token: sealevel|solanamainnet|22z73A4E7QjwjTsHGJptnALgBGuovEabCcQtPdBaQPpJ
-        - token: sealevel|eclipsemainnet|FF6PWPjiY1hwy3Kt5qTDoqhZ3PbmaXKYPzADEjZbK9iN
-      decimals: 9
-      logoURI: /deployments/warp_routes/wfragSOL/logo.svg
-      name: Wrapped Fragmetric Restaked SOL
-      standard: SealevelHypSynthetic
-      symbol: wfragSOL
-wstETH/form:
-  tokens:
-    - addressOrDenom: "0x5CBD4c5f9CD55747285652f815Cc7b9A2Ef6c586"
-      chainName: form
-      connections:
-        - token: ethereum|ethereum|0x9c7e8dc6b35E66873dA683aF2dE1BaB4cabc98B5
-      decimals: 18
-      logoURI: /deployments/warp_routes/WSTETH/logo.svg
-      name: Wrapped liquid staked Ether 2.0
-      standard: EvmHypSynthetic
-      symbol: wstETH
-    - addressOrDenom: "0x9c7e8dc6b35E66873dA683aF2dE1BaB4cabc98B5"
-      chainName: ethereum
-      coinGeckoId: wrapped-steth
-      collateralAddressOrDenom: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
-      connections:
-        - token: ethereum|form|0x5CBD4c5f9CD55747285652f815Cc7b9A2Ef6c586
-      decimals: 18
-      logoURI: /deployments/warp_routes/WSTETH/logo.svg
-      name: Wrapped liquid staked Ether 2.0
-      standard: EvmHypCollateral
-      symbol: wstETH

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -5,6 +5,7 @@ import { parse, stringify } from 'yaml';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import { BaseRegistry } from '../src/registry/BaseRegistry';
+import { WARP_ROUTE_ID_REGEX } from '../src/consts';
 const chainMetadata = {};
 const chainAddresses = {};
 const warpRouteConfigs = {};
@@ -110,9 +111,16 @@ function createWarpConfigFiles() {
     for (const warpFile of fs.readdirSync(inDirPath)) {
       if (!warpFile.endsWith('config.yaml')) continue;
       const [warpFileName] = warpFile.split('.');
+      // Remove the -config suffix from the filename
+      const routeName = warpFileName.replace('-config', '');
+      const warpRouteId = `${warpDir}/${routeName}`;
+      if (!WARP_ROUTE_ID_REGEX.test(warpRouteId)) {
+        throw new Error(`Invalid warp route ID format: ${warpRouteId}`);
+      }
+
       const config = parse(fs.readFileSync(`${inDirPath}/${warpFile}`, 'utf8'));
       //Situations where a config contains multiple symbols are not officially supported yet.
-      const id = BaseRegistry.warpRouteConfigToId(config, { symbol: config.tokens[0].symbol });
+      const id = BaseRegistry.warpRouteConfigToId(config, { warpRouteId });
       warpRouteConfigs[id] = config;
       fs.mkdirSync(`${assetOutPath}`, { recursive: true });
       fs.mkdirSync(`${tsOutPath}`, { recursive: true });

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -112,8 +112,8 @@ function createWarpConfigFiles() {
       if (!warpFile.endsWith('config.yaml')) continue;
       const [warpFileName] = warpFile.split('.');
       // Remove the -config suffix from the filename
-      const routeName = warpFileName.replace('-config', '');
-      const warpRouteId = `${warpDir}/${routeName}`;
+      const label = warpFileName.replace('-config', '');
+      const warpRouteId = `${warpDir}/${label}`;
       if (!WARP_ROUTE_ID_REGEX.test(warpRouteId)) {
         throw new Error(`Invalid warp route ID format: ${warpRouteId}`);
       }


### PR DESCRIPTION
### Description
This pull request updates the `scripts/build.ts` to use `warpRouteId` instead of deriving the ID based on token symbols for backwards compatibility

### Backward compatibility
Yes, but need to update warp UI to update `TIA.n` routes

### Testing
With warp UI
