### PR TITLE
chore: Add mailbox to solana mainnet + testnet metadata

### DIFF
--- a/chains/solanamainnet/metadata.yaml
+++ b/chains/solanamainnet/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
 displayName: Solana
 domainId: 1399811149
 gasCurrencyCoinGeckoId: solana
+mailbox: E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi
 name: solanamainnet
 nativeToken:
   decimals: 9

--- a/chains/solanatestnet/metadata.yaml
+++ b/chains/solanatestnet/metadata.yaml
@@ -17,6 +17,7 @@ displayNameShort: Solana Testnet
 domainId: 1399811150
 gasCurrencyCoinGeckoId: solana
 isTestnet: true
+mailbox: 75HBBLae3ddeneJVrZeyrDfv6vb7SMC3aCpBucSXS5aR
 name: solanatestnet
 nativeToken:
   decimals: 9


### PR DESCRIPTION
### Description

- Adds `mailbox` field to the chain metadata for `solanatestnet` and `solanamainnet`
- This is required when using the hyperlane CLI to send tokens over a warp route from an SVM chain, because the CLI requires the `mailbox` field for sealevel tokens (https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/823234337e2b3f3c9b6e19c026303610e4729040/typescript/sdk/src/token/Token.ts#L246)

### Backward compatibility

Yes
