### PR TITLE
feat(chain): switch starknet's coingeckoId from `starknet` to `ethereum`

### DIFF
--- a/.changeset/olive-cameras-laugh.md
+++ b/.changeset/olive-cameras-laugh.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update starknet's coingeckoId to be ethereum

--- a/chains/starknet/metadata.yaml
+++ b/chains/starknet/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: Starknet
 # keccak256("starknet") % MAX_INT32
 domainId: 358974494
-gasCurrencyCoinGeckoId: starknet
+gasCurrencyCoinGeckoId: ethereum
 name: starknet
 nativeToken:
   decimals: 18


### PR DESCRIPTION
### Description

- Currently, we are using ETH to pay the gas.

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
