### PR TITLE
chore: remove arbitrum from smol route

### DIFF
--- a/deployments/warp_routes/SMOL/ethereum-solanamainnet-treasure-config.yaml
+++ b/deployments/warp_routes/SMOL/ethereum-solanamainnet-treasure-config.yaml
@@ -1,20 +1,8 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
-    chainName: arbitrum
-    collateralAddressOrDenom: "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5"
-    connections:
-      - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
-      - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
-    decimals: 18
-    logoURI: /deployments/warp_routes/SMOL/logo.svg
-    name: SMOL
-    standard: EvmHypCollateral
-    symbol: SMOL
   - addressOrDenom: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
     chainName: ethereum
     connections:
-      - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
       - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
       - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
     decimals: 18
@@ -36,7 +24,6 @@ tokens:
   - addressOrDenom: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
     chainName: treasure
     connections:
-      - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
       - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
       - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
     decimals: 18

--- a/deployments/warp_routes/SMOL/ethereum-solanamainnet-treasure-deploy.yaml
+++ b/deployments/warp_routes/SMOL/ethereum-solanamainnet-treasure-deploy.yaml
@@ -1,16 +1,3 @@
-arbitrum:
-  decimals: 18
-  gas: 70000
-  name: SMOL
-  owner: "0xD1D943c09b9C3355207ce8c85aB1c4558f6Cd851"
-  remoteRouters:
-    "1":
-      address: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
-    "61166":
-      address: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
-  symbol: SMOL
-  token: "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5"
-  type: collateral
 ethereum:
   decimals: 18
   gas: 70000

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -3315,23 +3315,11 @@ Re7LRT/ethereum-zircuit:
       name: Re7 Labs LRT
       standard: EvmHypSynthetic
       symbol: Re7LRT
-SMOL/arbitrum-ethereum-solanamainnet-treasure:
+SMOL/ethereum-solanamainnet-treasure:
   tokens:
-    - addressOrDenom: "0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875"
-      chainName: arbitrum
-      collateralAddressOrDenom: "0x9e64d3b9e8ec387a9a58ced80b71ed815f8d82b5"
-      connections:
-        - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
-        - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
-      decimals: 18
-      logoURI: /deployments/warp_routes/SMOL/logo.svg
-      name: SMOL
-      standard: EvmHypCollateral
-      symbol: SMOL
     - addressOrDenom: "0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8"
       chainName: ethereum
       connections:
-        - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
         - token: ethereum|treasure|0xb73e4f558F7d4436d77a18f56e4EE9d01764c641
         - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
       decimals: 18
@@ -3353,7 +3341,6 @@ SMOL/arbitrum-ethereum-solanamainnet-treasure:
     - addressOrDenom: "0xb73e4f558F7d4436d77a18f56e4EE9d01764c641"
       chainName: treasure
       connections:
-        - token: ethereum|arbitrum|0xa4bbac7ed5bda8ec71a1af5ee84d4c5a737bd875
         - token: ethereum|ethereum|0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8
         - token: sealevel|solanamainnet|7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
       decimals: 18


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Remove arbitrum from SMOL route and update deploy and core config
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
Ran checkers