### PR TITLE
chore: don't check deleted routes

### DIFF
--- a/scripts/check-warp-deploy.sh
+++ b/scripts/check-warp-deploy.sh
@@ -14,7 +14,8 @@ export BASE_COMMIT="$1"
 export HEAD_COMMIT="$2"
 
 WARP_ROUTE_IDS=$(
-    git diff "$BASE_COMMIT".."$HEAD_COMMIT" --name-only |
+    # ARM = Additions, Renames, Modifications
+    git diff --diff-filter=ARM "$BASE_COMMIT".."$HEAD_COMMIT" --name-only |
     grep -E 'warp_routes/.+-(config|deploy)\.yaml$' |
     sed -E 's|deployments/warp_routes/||' |
     sed -E 's|-config\.yaml$||' |


### PR DESCRIPTION
### Description

chore: don't check deleted routes
- currently the diffing just looks at anything that changed, so if a file was deleted then we would try to check-warp-deploy that. but it does not exist. e.g 
![image](https://github.com/user-attachments/assets/847192b8-6830-4c83-99c9-4274e08a6d0c)
- by adding `--diff-filter=ARM`, we're only considering additions/renames/modifications

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

- tested by remaking the ousdt PR but with this change cherry-picked: https://github.com/hyperlane-xyz/hyperlane-registry/pull/928
- correctly didn't include removed routes:
![image](https://github.com/user-attachments/assets/7e76a986-b772-4a8c-967d-3c5b5ef9b165)
- correctly [reported](https://github.com/hyperlane-xyz/hyperlane-registry/pull/928#issuecomment-2934887322) staging ✅ and prod ❌:
![image](https://github.com/user-attachments/assets/96225107-e7d8-4e36-8c91-d3bfbb9fc269)

