### PR TITLE
feat: move rpc healthchecks to nightly builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,40 +14,15 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-      - name: yarn-install
-        # Check out the lockfile from main, reinstall, and then
-        # verify the lockfile matches what was committed.
-        run: |
-          yarn install
-          CHANGES=$(git status -s)
-          if [[ ! -z $CHANGES ]]; then
-            echo "Changes found: $CHANGES"
-            git diff
-            exit 1
-          fi
+    uses: ./.github/workflows/reusable-install-build.yml
+    with:
+      job: install
 
   build:
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/reusable-install-build.yml
+    with:
+      job: build
     needs: [install]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-      - name: build
-        run: yarn run build
 
   lint:
     runs-on: ubuntu-latest
@@ -108,36 +83,6 @@ jobs:
       - name: validate-file-data
         run: |
           node ./scripts/validate-file-data.js
-
-  # Running only the rpc health tests because block explorer ones take ages and need to be optimized
-
-  rpc-health-mainnet:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-      - name: test
-        run: yarn run test:rpc-health-mainnet
-
-  rpc-health-testnet:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-            .yarn/cache
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-      - name: test
-        run: yarn run test:rpc-health-testnet
 
   changeset:
     if: ${{ github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main' }}

--- a/.github/workflows/reusable-install-build.yml
+++ b/.github/workflows/reusable-install-build.yml
@@ -1,0 +1,48 @@
+name: Reusable Install and Build
+
+on:
+  workflow_call:
+    inputs:
+      job:
+        required: true
+        type: string
+        description: 'The job to run (install or build)'
+
+jobs:
+  install:
+    if: ${{ inputs.job == 'install' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+            .yarn/cache
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+      - name: yarn-install
+        # Check out the lockfile from main, reinstall, and then
+        # verify the lockfile matches what was committed.
+        run: |
+          yarn install
+          CHANGES=$(git status -s)
+          if [[ ! -z $CHANGES ]]; then
+            echo "Changes found: $CHANGES"
+            git diff
+            exit 1
+          fi
+
+  build:
+    if: ${{ inputs.job == 'build' }}
+    runs-on: ubuntu-latest
+    needs: [install]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+            .yarn/cache
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+      - name: build
+        run: yarn run build

--- a/.github/workflows/rpc-health-nightly.yml
+++ b/.github/workflows/rpc-health-nightly.yml
@@ -1,0 +1,48 @@
+name: RPC Health Nightly Checks
+
+on:
+  schedule:
+    # Run at 00:00 UTC every day
+    - cron: '0 0 * * *'
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  install:
+    uses: ./.github/workflows/reusable-install-build.yml
+    with:
+      job: install
+
+  build:
+    uses: ./.github/workflows/reusable-install-build.yml
+    with:
+      job: build
+    needs: [install]
+
+  rpc-health-mainnet:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+            .yarn/cache
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+      - name: test
+        run: yarn run test:rpc-health-mainnet
+
+  rpc-health-testnet:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+            .yarn/cache
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+      - name: test
+        run: yarn run test:rpc-health-testnet


### PR DESCRIPTION
### Description

Healthchecks fail frequently when they don't have anything to do with the PR in question

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined continuous integration workflow for improved maintainability.
	- Introduced a reusable workflow for installation and build steps.
	- Moved RPC health checks to a new nightly workflow, running daily and on demand.
	- Removed RPC health checks from the main CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->