### PR TITLE
chore: Update oxaut core name and symbol for lockbox

### DIFF
--- a/.changeset/little-years-knock.md
+++ b/.changeset/little-years-knock.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update oXAUT core config name and symbol for ethereum

--- a/deployments/warp_routes/oXAUT/production-config.yaml
+++ b/deployments/warp_routes/oXAUT/production-config.yaml
@@ -20,9 +20,9 @@ tokens:
       - token: ethereum|worldchain|0xEa0ad8Fc869f5Ab97a859c3af110367865699a8d
     decimals: 6
     logoURI: /deployments/warp_routes/oXAUT/logo.svg
-    name: Tether Gold
+    name: OpenXAUT
     standard: EvmHypXERC20Lockbox
-    symbol: XAUt
+    symbol: oXAUT
   - addressOrDenom: "0xEa0ad8Fc869f5Ab97a859c3af110367865699a8d"
     chainName: worldchain
     collateralAddressOrDenom: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"


### PR DESCRIPTION
### Description
Since it used the underlying, it used the original name. This PR updates it to match the other chains

