### PR TITLE
feat: add USDC deploy artifacts

### DIFF
--- a/deployments/warp_routes/USDC/arbitrum-polygon-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-polygon-config.yaml
@@ -1,0 +1,18 @@
+tokens:
+  - addressOrDenom: "0x2A37aA7d175bC4951C4B5163eC9D0174f9B2a3F6"
+    chainName: arbitrum
+    collateralAddressOrDenom: "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+    connections:
+      - token: ethereum|polygon|0x2A37aA7d175bC4951C4B5163eC9D0174f9B2a3F6
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDC
+  - addressOrDenom: "0x2A37aA7d175bC4951C4B5163eC9D0174f9B2a3F6"
+    chainName: polygon
+    connections:
+      - token: ethereum|arbitrum|0x2A37aA7d175bC4951C4B5163eC9D0174f9B2a3F6
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC

--- a/deployments/warp_routes/USDC/arbitrum-polygon-deploy.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-polygon-deploy.yaml
@@ -1,0 +1,13 @@
+arbitrum:
+  decimals: 6
+  name: USD Coin
+  owner: "0x3Fb137161365f273Ebb8262a26569C117b6CBAfb"
+  symbol: USDC
+  token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+  type: collateral
+polygon:
+  decimals: 6
+  name: USD Coin
+  owner: "0x3Fb137161365f273Ebb8262a26569C117b6CBAfb"
+  symbol: USDC
+  type: synthetic


### PR DESCRIPTION
This PR was created from the deploy app to add USDC deploy artifacts.

This config was provided by Xaroz from hyperlane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration support for USDC token on Arbitrum and Polygon networks, enabling detailed token settings and deployment parameters for both chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->