### PR TITLE
feat: add USDC/arbitrum-base-polygon warp route deploy artifacts

### DIFF
--- a/.changset/dirty-waves-cut.md
+++ b/.changset/dirty-waves-cut.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add USDC/arbitrum-base-polygon warp route deploy artifacts

--- a/deployments/warp_routes/USDC/arbitrum-base-polygon-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-base-polygon-config.yaml
@@ -1,0 +1,29 @@
+tokens:
+  - addressOrDenom: "0xd1dCD1C07310a9C681651dAe6777b76C557d8fb8"
+    chainName: arbitrum
+    connections:
+      - token: ethereum|polygon|0xd1dCD1C07310a9C681651dAe6777b76C557d8fb8
+      - token: ethereum|base|0x2A37aA7d175bC4951C4B5163eC9D0174f9B2a3F6
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC
+  - addressOrDenom: "0xd1dCD1C07310a9C681651dAe6777b76C557d8fb8"
+    chainName: polygon
+    connections:
+      - token: ethereum|arbitrum|0xd1dCD1C07310a9C681651dAe6777b76C557d8fb8
+      - token: ethereum|base|0x2A37aA7d175bC4951C4B5163eC9D0174f9B2a3F6
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC
+  - addressOrDenom: "0x2A37aA7d175bC4951C4B5163eC9D0174f9B2a3F6"
+    chainName: base
+    collateralAddressOrDenom: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+    connections:
+      - token: ethereum|arbitrum|0xd1dCD1C07310a9C681651dAe6777b76C557d8fb8
+      - token: ethereum|polygon|0xd1dCD1C07310a9C681651dAe6777b76C557d8fb8
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDC

--- a/deployments/warp_routes/USDC/arbitrum-base-polygon-deploy.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-base-polygon-deploy.yaml
@@ -1,0 +1,19 @@
+arbitrum:
+  decimals: 6
+  name: USD Coin
+  owner: "0x3Fb137161365f273Ebb8262a26569C117b6CBAfb"
+  symbol: USDC
+  type: synthetic
+base:
+  decimals: 6
+  name: USD Coin
+  owner: "0x3Fb137161365f273Ebb8262a26569C117b6CBAfb"
+  symbol: USDC
+  token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+  type: collateral
+polygon:
+  decimals: 6
+  name: USD Coin
+  owner: "0x3Fb137161365f273Ebb8262a26569C117b6CBAfb"
+  symbol: USDC
+  type: synthetic


### PR DESCRIPTION
This PR was created from the deploy app to add USDC/arbitrum-base-polygon warp route deploy artifacts.

This config was provided by Xaroz from hyperlane.