### PR TITLE
chore: add collateralAddressOrDenom and logoURI to USDC cctp configs

### DIFF
--- a/.changeset/brave-cobras-remember.md
+++ b/.changeset/brave-cobras-remember.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': patch
 ---
 
-Add logoURI to USDC mainnet cctp config
+Add collateralAddressOrDenom and logoURI to USDC mainnet cctp config

--- a/.changeset/brave-cobras-remember.md
+++ b/.changeset/brave-cobras-remember.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add logoURI to USDC mainnet cctp config

--- a/deployments/warp_routes/USDC/mainnet-cctp-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-config.yaml
@@ -10,6 +10,7 @@ tokens:
       - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
       - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -23,6 +24,7 @@ tokens:
       - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
       - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -36,6 +38,7 @@ tokens:
       - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
       - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -49,6 +52,7 @@ tokens:
       - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
       - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -62,6 +66,7 @@ tokens:
       - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
       - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -75,6 +80,7 @@ tokens:
       - token: ethereum|optimism|0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE
       - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -88,6 +94,7 @@ tokens:
       - token: ethereum|optimism|0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE
       - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
     symbol: USDC

--- a/deployments/warp_routes/USDC/mainnet-cctp-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
     chainName: arbitrum
+    collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|avalanche|0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677
       - token: ethereum|base|0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975
@@ -16,6 +17,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677"
     chainName: avalanche
+    collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
     connections:
       - token: ethereum|arbitrum|0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2
       - token: ethereum|base|0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975
@@ -30,6 +32,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
     chainName: base
+    collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|arbitrum|0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2
       - token: ethereum|avalanche|0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677
@@ -44,6 +47,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xedCBAa585FD0F80f20073F9958246476466205b8"
     chainName: ethereum
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|arbitrum|0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2
       - token: ethereum|avalanche|0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677
@@ -58,6 +62,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE"
     chainName: optimism
+    collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
     connections:
       - token: ethereum|arbitrum|0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2
       - token: ethereum|avalanche|0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677
@@ -72,6 +77,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
     chainName: polygon
+    collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
     connections:
       - token: ethereum|arbitrum|0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2
       - token: ethereum|avalanche|0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677
@@ -86,6 +92,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x296aF86bff91b23cF980f6a443bc15A3A5d30682"
     chainName: unichain
+    collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
     connections:
       - token: ethereum|arbitrum|0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2
       - token: ethereum|avalanche|0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677

--- a/deployments/warp_routes/USDC/testnet-cctp-config.yaml
+++ b/deployments/warp_routes/USDC/testnet-cctp-config.yaml
@@ -8,6 +8,7 @@ tokens:
       - token: ethereum|optimismsepolia|0xB0A06A5f47D335F5d94D4D8620BCaDF320a159AC
       - token: ethereum|sepolia|0x352f1c7ffa598d0698c1D8D2fCAb02511c6fF3e9
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -19,6 +20,7 @@ tokens:
       - token: ethereum|optimismsepolia|0xB0A06A5f47D335F5d94D4D8620BCaDF320a159AC
       - token: ethereum|sepolia|0x352f1c7ffa598d0698c1D8D2fCAb02511c6fF3e9
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
     symbol: USDC
@@ -30,6 +32,7 @@ tokens:
       - token: ethereum|basesepolia|0x020dEE96414703c457322eed8504946583a7dd24
       - token: ethereum|sepolia|0x352f1c7ffa598d0698c1D8D2fCAb02511c6fF3e9
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
     symbol: USDC
@@ -41,6 +44,7 @@ tokens:
       - token: ethereum|basesepolia|0x020dEE96414703c457322eed8504946583a7dd24
       - token: ethereum|optimismsepolia|0xB0A06A5f47D335F5d94D4D8620BCaDF320a159AC
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
     symbol: USDC

--- a/deployments/warp_routes/USDC/testnet-cctp-config.yaml
+++ b/deployments/warp_routes/USDC/testnet-cctp-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x61714300b991Cfc2BD336cb1745F01463163A988"
     chainName: arbitrumsepolia
+    collateralAddressOrDenom: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"
     connections:
       - token: ethereum|basesepolia|0x020dEE96414703c457322eed8504946583a7dd24
       - token: ethereum|optimismsepolia|0xB0A06A5f47D335F5d94D4D8620BCaDF320a159AC
@@ -12,6 +13,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x020dEE96414703c457322eed8504946583a7dd24"
     chainName: basesepolia
+    collateralAddressOrDenom: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
     connections:
       - token: ethereum|arbitrumsepolia|0x61714300b991Cfc2BD336cb1745F01463163A988
       - token: ethereum|optimismsepolia|0xB0A06A5f47D335F5d94D4D8620BCaDF320a159AC
@@ -22,6 +24,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xB0A06A5f47D335F5d94D4D8620BCaDF320a159AC"
     chainName: optimismsepolia
+    collateralAddressOrDenom: "0x5fd84259d66Cd46123540766Be93DFE6D43130D7"
     connections:
       - token: ethereum|arbitrumsepolia|0x61714300b991Cfc2BD336cb1745F01463163A988
       - token: ethereum|basesepolia|0x020dEE96414703c457322eed8504946583a7dd24
@@ -32,6 +35,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x352f1c7ffa598d0698c1D8D2fCAb02511c6fF3e9"
     chainName: sepolia
+    collateralAddressOrDenom: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     connections:
       - token: ethereum|arbitrumsepolia|0x61714300b991Cfc2BD336cb1745F01463163A988
       - token: ethereum|basesepolia|0x020dEE96414703c457322eed8504946583a7dd24

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -5263,6 +5263,7 @@ USDC/mainnet-cctp:
         - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
         - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
       decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
@@ -5276,6 +5277,7 @@ USDC/mainnet-cctp:
         - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
         - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
       decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
@@ -5289,6 +5291,7 @@ USDC/mainnet-cctp:
         - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
         - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
       decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
@@ -5302,6 +5305,7 @@ USDC/mainnet-cctp:
         - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
         - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
       decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
@@ -5315,6 +5319,7 @@ USDC/mainnet-cctp:
         - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
         - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
       decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
@@ -5328,6 +5333,7 @@ USDC/mainnet-cctp:
         - token: ethereum|optimism|0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE
         - token: ethereum|unichain|0x296aF86bff91b23cF980f6a443bc15A3A5d30682
       decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
@@ -5341,6 +5347,7 @@ USDC/mainnet-cctp:
         - token: ethereum|optimism|0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE
         - token: ethereum|polygon|0xa62F45662809f5F6535b58bae9A572a2EC4A1f84
       decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Add collateralAddressOrDenom and logo to `USDC/mainnet-cctp` and `USDC/testnet-cctp`
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
