### PR TITLE
chore: remove zan RPC url from starknet metadata

### DIFF
--- a/.changeset/shy-bugs-draw.md
+++ b/.changeset/shy-bugs-draw.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Remove zan RPC from starknet metadata because it causes issues when getting tx status

--- a/chains/starknet/metadata.yaml
+++ b/chains/starknet/metadata.yaml
@@ -26,5 +26,4 @@ protocol: starknet
 rpcUrls:
   - http: https://starknet-mainnet.public.blastapi.io/rpc/v0_8
   - http: https://rpc.starknet.lava.build:443/
-  - http: https://api.zan.top/public/starknet-mainnet/rpc/v0_8
 technicalStack: other


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Removed RPC url from starknet because it fails when trying to get transaction status
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
