### PR TITLE
chore: add `TIA` testnet

### DIFF
--- a/.changeset/odd-needles-drive.md
+++ b/.changeset/odd-needles-drive.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add TIA testnet.

--- a/deployments/warp_routes/TIA/basesepolia-celestiatestnet-config.yaml
+++ b/deployments/warp_routes/TIA/basesepolia-celestiatestnet-config.yaml
@@ -5,6 +5,7 @@ tokens:
     connections:
       - token: cosmosnative|celestiatestnet|0x726f757465725f61707000000000000000000000000000010000000000000000
     decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA
     standard: EvmHypSynthetic
     symbol: TIA

--- a/deployments/warp_routes/TIA/basesepolia-celestiatestnet-config.yaml
+++ b/deployments/warp_routes/TIA/basesepolia-celestiatestnet-config.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xC2455315f69696295b357428fe13970bB5B4eFfA"
+    chainName: basesepolia
+    connections:
+      - token: cosmosnative|celestiatestnet|0x726f757465725f61707000000000000000000000000000010000000000000000
+    decimals: 6
+    name: TIA
+    standard: EvmHypSynthetic
+    symbol: TIA
+  - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
+    chainName: celestiatestnet
+    collateralAddressOrDenom: utia
+    connections:
+      - token: ethereum|basesepolia|0xC2455315f69696295b357428fe13970bB5B4eFfA
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA
+    standard: CosmosNativeHypCollateral
+    symbol: TIA

--- a/deployments/warp_routes/TIA/basesepolia-celestiatestnet-deploy.yaml
+++ b/deployments/warp_routes/TIA/basesepolia-celestiatestnet-deploy.yaml
@@ -6,5 +6,5 @@ basesepolia:
   type: synthetic
 celestiatestnet:
   foreignDeployment: "0x726f757465725f61707000000000000000000000000000010000000000000000"
-  owner: "celestia1zvdlcmplx4gdh4hajwlsegnn2xzzfy470gjw4c"
+  owner: celestia1zvdlcmplx4gdh4hajwlsegnn2xzzfy470gjw4c
   type: native

--- a/deployments/warp_routes/TIA/basesepolia-celestiatestnet-deploy.yaml
+++ b/deployments/warp_routes/TIA/basesepolia-celestiatestnet-deploy.yaml
@@ -1,0 +1,9 @@
+basesepolia:
+  decimals: 6
+  name: TIA
+  owner: "0xfaD1C94469700833717Fa8a3017278BC1cA8031C"
+  symbol: TIA
+  type: synthetic
+celestiatestnet:
+  foreignDeployment: "0x726f757465725f61707000000000000000000000000000010000000000000000"
+  type: native

--- a/deployments/warp_routes/TIA/basesepolia-celestiatestnet-deploy.yaml
+++ b/deployments/warp_routes/TIA/basesepolia-celestiatestnet-deploy.yaml
@@ -6,4 +6,5 @@ basesepolia:
   type: synthetic
 celestiatestnet:
   foreignDeployment: "0x726f757465725f61707000000000000000000000000000010000000000000000"
+  owner: "celestia1zvdlcmplx4gdh4hajwlsegnn2xzzfy470gjw4c"
   type: native


### PR DESCRIPTION
### Description

chore: add `TIA` testnet

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
