### PR TITLE
fix: update paradex chainId

### DIFF
--- a/.changeset/quiet-berries-cough.md
+++ b/.changeset/quiet-berries-cough.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Fix paradex `chainId` in metadata

--- a/chains/paradex/metadata.yaml
+++ b/chains/paradex/metadata.yaml
@@ -8,7 +8,7 @@ blocks:
   confirmations: 1
   estimateBlockTime: 30
   reorgPeriod: 1
-chainId: "0x534e5f4d41494e"
+chainId: "0x505249564154455f534e5f50415241434c4541525f4d41494e4e4554"
 deployer:
   name: Abacus Works
   url: https://www.hyperlane.xyz


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Fix paradex `chainId` and change it to `0x505249564154455f534e5f50415241434c4541525f4d41494e4e4554`
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
