### PR TITLE
feat: extend oxaut to avalanche

### DIFF
--- a/.changeset/dry-mayflies-ring.md
+++ b/.changeset/dry-mayflies-ring.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Extend oXAUT to Avalanche

--- a/deployments/warp_routes/oXAUT/production-config.yaml
+++ b/deployments/warp_routes/oXAUT/production-config.yaml
@@ -1,9 +1,22 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  - addressOrDenom: "0x118b30d28e5dB274f2376910038F66b1C33bD00a"
+    chainName: avalanche
+    collateralAddressOrDenom: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"
+    connections:
+      - token: ethereum|celo|0x53a81819DFD46730116B89dBCb096DAcC4e73cEA
+      - token: ethereum|ethereum|0x9A9C33115455a929D3d821CEE4A01e38241bF375
+      - token: ethereum|worldchain|0xEa0ad8Fc869f5Ab97a859c3af110367865699a8d
+    decimals: 6
+    logoURI: /deployments/warp_routes/oXAUT/logo.svg
+    name: OpenXAUT
+    standard: EvmHypXERC20
+    symbol: oXAUT
   - addressOrDenom: "0x53a81819DFD46730116B89dBCb096DAcC4e73cEA"
     chainName: celo
     collateralAddressOrDenom: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"
     connections:
+      - token: ethereum|avalanche|0x118b30d28e5dB274f2376910038F66b1C33bD00a
       - token: ethereum|ethereum|0x9A9C33115455a929D3d821CEE4A01e38241bF375
       - token: ethereum|worldchain|0xEa0ad8Fc869f5Ab97a859c3af110367865699a8d
     decimals: 6
@@ -16,17 +29,18 @@ tokens:
     coinGeckoId: tether-gold
     collateralAddressOrDenom: "0x0797c6f55f5c9005996A55959A341018cF69A963"
     connections:
+      - token: ethereum|avalanche|0x118b30d28e5dB274f2376910038F66b1C33bD00a
       - token: ethereum|celo|0x53a81819DFD46730116B89dBCb096DAcC4e73cEA
       - token: ethereum|worldchain|0xEa0ad8Fc869f5Ab97a859c3af110367865699a8d
     decimals: 6
-    logoURI: /deployments/warp_routes/oXAUT/logo.svg
-    name: OpenXAUT
+    name: Tether Gold
     standard: EvmHypXERC20Lockbox
-    symbol: oXAUT
+    symbol: XAUt
   - addressOrDenom: "0xEa0ad8Fc869f5Ab97a859c3af110367865699a8d"
     chainName: worldchain
     collateralAddressOrDenom: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"
     connections:
+      - token: ethereum|avalanche|0x118b30d28e5dB274f2376910038F66b1C33bD00a
       - token: ethereum|celo|0x53a81819DFD46730116B89dBCb096DAcC4e73cEA
       - token: ethereum|ethereum|0x9A9C33115455a929D3d821CEE4A01e38241bF375
     decimals: 6

--- a/deployments/warp_routes/oXAUT/production-config.yaml
+++ b/deployments/warp_routes/oXAUT/production-config.yaml
@@ -33,6 +33,7 @@ tokens:
       - token: ethereum|celo|0x53a81819DFD46730116B89dBCb096DAcC4e73cEA
       - token: ethereum|worldchain|0xEa0ad8Fc869f5Ab97a859c3af110367865699a8d
     decimals: 6
+    logoURI: /deployments/warp_routes/oXAUT/logo.svg
     name: Tether Gold
     standard: EvmHypXERC20Lockbox
     symbol: XAUt

--- a/deployments/warp_routes/oXAUT/production-deploy.yaml
+++ b/deployments/warp_routes/oXAUT/production-deploy.yaml
@@ -1,3 +1,7 @@
+avalanche:
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  token: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"
+  type: xERC20
 celo:
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"


### PR DESCRIPTION
### Description
This PR extends oxaut to avalanche. Uses https://github.com/hyperlane-xyz/xERC20/pull/2/commits/8c318856f3b151bfc25313a6acb57a240c5745a4 to deploy the xerc20

### Backward compatibility
Yes

### Testing
Checkers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenXAUT token on the Avalanche network.

* **Updates**
  * Updated token connections across Celo, Ethereum, and Worldchain to include Avalanche.
  * Renamed the Ethereum token to "Tether Gold" with symbol "XAUt" and updated its standard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->