### PR TITLE
chore: Update oXAUT's xerc20 owners

### DIFF
--- a/.changeset/dirty-jobs-sleep.md
+++ b/.changeset/dirty-jobs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update oXAUT ownerOverrides.collateralToken to the top-level owners

--- a/deployments/warp_routes/oXAUT/production-deploy.yaml
+++ b/deployments/warp_routes/oXAUT/production-deploy.yaml
@@ -1,16 +1,24 @@
 avalanche:
   owner: "0x5bE94B17112B8F18eA9Ac8e559377B467556a3c3"
+  ownerOverrides:
+    collateralToken: "0x5bE94B17112B8F18eA9Ac8e559377B467556a3c3"
   token: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"
   type: xERC20
 celo:
   owner: "0x879038d6Fc9F6D5e2BA73188bd078486d77e1156"
+  ownerOverrides:
+    collateralToken: "0x879038d6Fc9F6D5e2BA73188bd078486d77e1156"
   token: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"
   type: xERC20
 ethereum:
   owner: "0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6"
+  ownerOverrides:
+    collateralToken: "0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6"
   token: "0x0797c6f55f5c9005996A55959A341018cF69A963"
   type: xERC20Lockbox
 worldchain:
   owner: "0x95b1634566663117322999ce42cDEaEF18c089Be"
+  ownerOverrides:
+    collateralToken: "0x95b1634566663117322999ce42cDEaEF18c089Be"
   token: "0x30974f73A4ac9E606Ed80da928e454977ac486D2"
   type: xERC20


### PR DESCRIPTION
### Description
This PR adds the ownerOverride.collateralToken such that it transfers over the underlying xerc20 owners using check-warp-deploy

### Backward compatibility
Yes

