### PR TITLE
feat: add PUMP/eclipsemainnet warp route

### DIFF
--- a/.changeset/yellow-kings-taste.md
+++ b/.changeset/yellow-kings-taste.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Added the PUMP/eclipsemainnet warp route

--- a/deployments/warp_routes/PUMP/eclipsemainnet-config.yaml
+++ b/deployments/warp_routes/PUMP/eclipsemainnet-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: Ba5PvcUQPjDTqNe6dtqf4tYMungrBF6BhD7fCM27jQxh
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: 2qLEN4Gu7MkBevJMeTbQKgnwdgvxNvwQ6ufH7L8fjzHs
+    connections:
+      - token: sealevel|solanamainnet|9u6JS1qxnNogAwqtjkpdeLGhQmt5wxyHAjP1511S3ExL
+    decimals: 6
+    logoURI: /deployments/warp_routes/PUMP/logo.png
+    name: Pump
+    standard: SealevelHypSynthetic
+    symbol: PUMP
+  - addressOrDenom: 9u6JS1qxnNogAwqtjkpdeLGhQmt5wxyHAjP1511S3ExL
+    chainName: solanamainnet
+    coinGeckoId: pump-fun
+    collateralAddressOrDenom: pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn
+    connections:
+      - token: sealevel|eclipsemainnet|Ba5PvcUQPjDTqNe6dtqf4tYMungrBF6BhD7fCM27jQxh
+    decimals: 6
+    logoURI: /deployments/warp_routes/PUMP/logo.png
+    name: Pump
+    standard: SealevelHypCollateral
+    symbol: PUMP


### PR DESCRIPTION
### Description

This PR adds the PUMP/eclipsemainnet warp route.

### Backward compatibility

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for the PUMP token warp route between eclipsemainnet and solanamainnet networks, enabling cross-chain functionality.

* **Chores**
  * Updated documentation to reflect a minor version bump for the package and the addition of the new warp route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->