### PR TITLE
chore: update celo chain metadata

### DIFF
--- a/.changeset/heavy-pumpkins-rhyme.md
+++ b/.changeset/heavy-pumpkins-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update celo metadata

--- a/chains/celo/metadata.yaml
+++ b/chains/celo/metadata.yaml
@@ -11,8 +11,8 @@ blockExplorers:
     url: https://explorer.celo.org
 blocks:
   confirmations: 1
-  estimateBlockTime: 5
-  reorgPeriod: 0
+  estimateBlockTime: 1
+  reorgPeriod: 5
 chainId: 42220
 deployer:
   name: Abacus Works
@@ -29,4 +29,6 @@ nativeToken:
 protocol: ethereum
 rpcUrls:
   - http: https://forno.celo.org
-technicalStack: other
+  - http: https://rpc.ankr.com/celo
+  - http: https://celo.drpc.org
+technicalStack: opstack


### PR DESCRIPTION
### Description

applying metadata changes now that celo has stabilised as an L2

- update reorg period 
- update technical stack
- update block time

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
