### PR TITLE
chore: update safe tx service url for metal

### DIFF
--- a/.changeset/lucky-hotels-teach.md
+++ b/.changeset/lucky-hotels-teach.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update metal safe tx service url.

--- a/chains/metal/metadata.yaml
+++ b/chains/metal/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: Metal L2
 domainId: 1000001750
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://txs.safe.metall2.com/
+gnosisSafeTransactionServiceUrl: https://metall2.superchain.safe.protofire.io
 isTestnet: false
 name: metal
 nativeToken:


### PR DESCRIPTION
### Description

chore: update safe tx service url for metal
- now moved to the superchain safe ui

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
