### PR TITLE
chore: add smol solana collateralAddressOrDenom

### DIFF
--- a/deployments/warp_routes/ETH/basesepolia-sepolia-config.yaml
+++ b/deployments/warp_routes/ETH/basesepolia-sepolia-config.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x5c12ADC734699C07b095fe30B8312F1A7bbaA788"
+    chainName: basesepolia
+    connections:
+      - token: ethereum|sepolia|0x95878Fd41bC26f7045C0b98e381c22f010745A75
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: "0x95878Fd41bC26f7045C0b98e381c22f010745A75"
+    chainName: sepolia
+    connections:
+      - token: ethereum|basesepolia|0x5c12ADC734699C07b095fe30B8312F1A7bbaA788
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH

--- a/deployments/warp_routes/ETH/basesepolia-sepolia-deploy.yaml
+++ b/deployments/warp_routes/ETH/basesepolia-sepolia-deploy.yaml
@@ -1,0 +1,8 @@
+basesepolia:
+  isNft: false
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  type: native
+sepolia:
+  isNft: false
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  type: native

--- a/deployments/warp_routes/SMOL/arbitrum-abstract-ethereum-solanamainnet-config.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-abstract-ethereum-solanamainnet-config.yaml
@@ -37,6 +37,7 @@ tokens:
     symbol: SMOL
   - addressOrDenom: 7Z7mZ4d31sfC3mcQYQXUNo6j9snByT2gs5eDkXYmZAyn
     chainName: solanamainnet
+    collateralAddressOrDenom: 5KHQeeQvM4qBtmX3WnaCMGpM3Th7jYpqcHf3c6qzPodM
     connections:
       - token: ethereum|abstract|0xcbfb6dBeb6C06DdCd345781a0ADc711A86a77f7c
       - token: ethereum|ethereum|0x53ccE6d10e43d1B3D11872Ad22eC2aCd8d2537B8


### PR DESCRIPTION
### Description
Add missing `collateralAddressOrDenom` for SMOL route 
<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
