### PR TITLE
fix: ousdt ethereum symbol

### DIFF
--- a/.changeset/tiny-cooks-deny.md
+++ b/.changeset/tiny-cooks-deny.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Replace USD₮ for USDT in ethereum ouSDT/production route

--- a/deployments/warp_routes/oUSDT/production-config.yaml
+++ b/deployments/warp_routes/oUSDT/production-config.yaml
@@ -134,7 +134,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT
     standard: EvmHypVSXERC20Lockbox
-    symbol: USD₮
+    symbol: USDT
   - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
     chainName: fraxtal
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Replace USDT symbol for ethereum with the correct one on chain
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
