### PR TITLE
chore: remove connection to arbitrum in SMOL route and update MAGIC/SMOL owners

### DIFF
--- a/.changeset/long-tigers-swim.md
+++ b/.changeset/long-tigers-swim.md
@@ -1,5 +1,0 @@
----
-'@hyperlane-xyz/registry': minor
----
-
-Add MAGIC arbitrum/abstract/ronin route. Add SMOL arbitrum + abstract routes.

--- a/.changeset/long-ways-camp.md
+++ b/.changeset/long-ways-camp.md
@@ -1,5 +1,0 @@
----
-'@hyperlane-xyz/registry': patch
----
-
-Add solana `collateralAddressOrDenom` to SMOL route

--- a/.changeset/tiny-cooks-deny.md
+++ b/.changeset/tiny-cooks-deny.md
@@ -1,5 +1,0 @@
----
-'@hyperlane-xyz/registry': patch
----
-
-Replace USD₮ for USDT in ethereum ouSDT/production route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @hyperlane-xyz/registry
 
+## 21.1.0
+
+### Minor Changes
+
+- 45eca7d: Add MAGIC arbitrum/abstract/ronin route. Add SMOL arbitrum + abstract routes.
+
+### Patch Changes
+
+- cea2b10: Add solana `collateralAddressOrDenom` to SMOL route
+- 9a36c26: Replace USD₮ for USDT in ethereum ouSDT/production route
+
 ## 21.0.0
 
 ### Major Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperlane-xyz/registry",
   "description": "A collection of configs, artifacts, and schemas for Hyperlane",
-  "version": "21.0.0",
+  "version": "21.1.0",
   "dependencies": {
     "jszip": "^3.10.1",
     "yaml": "2.4.5",


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

- Remove arbitrum connection in other chains for SMOL route
- Update owners for SMOL and MAGIC route

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes, this is already enforced at contract level
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
