### PR TITLE
chore: enable new chains on ousdt UI

### DIFF
--- a/.changeset/rude-beans-swim.md
+++ b/.changeset/rude-beans-swim.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Enable oUSDT on UI for bitlayer, mantle, ronin, sonic.

--- a/deployments/warp_routes/oUSDT/production-config.yaml
+++ b/deployments/warp_routes/oUSDT/production-config.yaml
@@ -4,6 +4,7 @@ tokens:
     chainName: base
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -12,11 +13,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -28,6 +32,27 @@ tokens:
   - addressOrDenom: "0xC58eeC72352b04358b0b6979ba10462190f0d54C"
     chainName: bitlayer
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
     name: OpenUSDT
@@ -38,6 +63,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
@@ -45,11 +71,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -63,6 +92,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
@@ -70,11 +100,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -89,6 +122,7 @@ tokens:
     collateralAddressOrDenom: "0x5e5F4d6B03db16E7f00dE7C9AFAA53b92C8d1D42"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
@@ -96,11 +130,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -115,6 +152,7 @@ tokens:
     collateralAddressOrDenom: "0x6D265C7dD8d76F25155F1a7687C693FDC1220D12"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -122,11 +160,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -140,6 +181,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -147,11 +189,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -165,6 +210,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -172,11 +218,14 @@ tokens:
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -190,6 +239,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -197,11 +247,14 @@ tokens:
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -223,6 +276,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -230,11 +284,14 @@ tokens:
       - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -246,6 +303,27 @@ tokens:
   - addressOrDenom: "0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683"
     chainName: mantle
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
     name: OpenUSDT
@@ -256,6 +334,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -264,10 +343,13 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -281,6 +363,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -289,10 +372,13 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -306,6 +392,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -314,10 +401,13 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -331,6 +421,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -339,10 +430,13 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -354,6 +448,27 @@ tokens:
   - addressOrDenom: "0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d"
     chainName: ronin
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
     name: OpenUSDT
@@ -364,6 +479,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -372,10 +488,13 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
@@ -387,6 +506,27 @@ tokens:
   - addressOrDenom: "0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C"
     chainName: sonic
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
+      - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
     name: OpenUSDT
@@ -397,6 +537,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -405,11 +546,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
@@ -422,6 +566,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -430,11 +575,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
     decimals: 6
@@ -447,6 +595,7 @@ tokens:
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bitlayer|0xC58eeC72352b04358b0b6979ba10462190f0d54C
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|botanix|0xec7717156610ab8Bf657b800038a37D9472D23bd
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -455,11 +604,14 @@ tokens:
       - token: ethereum|hashkey|0x9C6e8d989ea7F212e679191BEb44139d83ac927a
       - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
       - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mantle|0x6E77A2991Ea996Af182b9a6Dc8C942fC6A106683
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|metis|0x6267Dbfc38f7Af897536563c15f07B89634cb656
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|ronin|0xffa403dD3ff592e42475f0B3f6F57fB0F02Be52d
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|sonic|0x3adf8f4219BdCcd4B727B9dD67E277C58799b57C
       - token: ethereum|superseed|0x5beADE696E12aBE2839FEfB41c7EE6DA1f074C55
       - token: ethereum|swell|0xD70568C28D55da0403B194c24c9c70C3f9fCf02a
     decimals: 6


### PR DESCRIPTION
### Description

Enable oUSDT on UI for bitlayer, mantle, ronin, sonic.

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
