### PR TITLE
Dreamchain

### DIFF
--- a/chains/dreamchain/metadata.yaml
+++ b/chains/dreamchain/metadata.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../schema.json
+chainId: 7474
+displayName: Dreamchain
+domainId: 7474
+isTestnet: false
+name: dreamchain
+nativeToken:
+  decimals: 18
+  name: Dream Coin
+  symbol: DXC
+protocol: ethereum
+rpcUrls:
+  - http: https://dream-mainnet.creator74.com/
+technicalStack: other


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Dreamchain network.
    - Mainnet (not a testnet), chainId/domainId: 7474
    - RPC endpoint: https://dream-mainnet.creator74.com/
    - Protocol: Ethereum-compatible
    - Native token: Dream Coin (DXC), 18 decimals
    - Display name: Dreamchain

<!-- end of auto-generated comment: release notes by coderabbit.ai -->