### PR TITLE
chore: update SVM decimals

### DIFF
--- a/.changeset/new-beans-laugh.md
+++ b/.changeset/new-beans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+updated decimals in some SOL warp routes to satisfy stricter warp checker rules

--- a/deployments/warp_routes/SOL/apechain-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/SOL/apechain-solanamainnet-deploy.yaml
@@ -6,6 +6,7 @@ apechain:
   symbol: SOL
   type: synthetic
 solanamainnet:
+  decimals: 9
   foreignDeployment: BwD1LvMvofVZAAWyG318S17zqKMXXeeNeVHQimaWG6qt
   gas: 300000
   owner: B1q2dsjCE4F6wi5ktn4anmFq9572JpziBUg2TqCS2dFn

--- a/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/SOL/hyperevm-solanamainnet-deploy.yaml
@@ -9,6 +9,7 @@ hyperevm:
   symbol: SOL
   type: synthetic
 solanamainnet:
+  decimals: 9
   foreignDeployment: 4CMbJtieJ7EboZZGSbXTQjW5i2sL638jFvE3dWTYG3SK
   gas: 300000
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"

--- a/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-deploy.yaml
+++ b/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-deploy.yaml
@@ -53,6 +53,7 @@ optimism:
   symbol: TRUMP
   type: synthetic
 solanamainnet:
+  decimals: 6
   foreignDeployment: 21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
   gas: 64000
   name: OFFICIAL TRUMP

--- a/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-deploy.yaml
+++ b/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-deploy.yaml
@@ -58,6 +58,7 @@ solanamainnet:
   gas: 64000
   name: OFFICIAL TRUMP
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale: 1000000000000
   symbol: TRUMP
   token: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
   type: collateral


### PR DESCRIPTION
### Description

This PR sets SOL decimals in a couple SVM-EVM warp routes to satisfy stricter rules in our warp route checker.

### Backward compatibility

Yes, these are the actual decimals

### Testing

Manually run `check-deploy.sh` for these routes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted decimal precision for Solana Mainnet warp routes to satisfy stricter validation: several routes set to 9, and one route set to 6 for correct token handling and smoother validation.

* **Chores**
  * Added a changeset to publish a patch release for @hyperlane-xyz/registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->