### PR TITLE
Add Cypherium chain (chainId 16166) + core deployment

### DIFF
--- a/chains/cypherium/addresses.yaml
+++ b/chains/cypherium/addresses.yaml
@@ -1,0 +1,20 @@
+# Hyperlane core deployment for Cypherium
+# Generated manually from deployment logs
+mailbox: "0x17fcEf595646FB1eB94d93B62EE256a2C2a7f337"
+interchainAccountRouter: "0x74c058367ee8A1F748952b6F973BFA9De5bF89A1"
+validatorAnnounce: "0x1eD8634917b1EB02a24e7b1fd630fc6E4121DD2e"
+merkleTreeHook: "0x73404aD208d4079f709723B415BE612BF3550372"
+proxyAdmin: "0xf9F5244ce3Abaf084EE53682f2D76649f98BfD72"
+testRecipient: "0x8dE66b90A215a746B1d8504f3b8d6B809Fd5432A"
+
+# Factories
+staticMerkleRootMultisigIsmFactory: "0xD258adC28084379A75631E0ea55034F4c606f958"
+staticMessageIdMultisigIsmFactory: "0xbd2c55254E31BF78356d7C9AbbC0a37383770AD4"
+staticAggregationIsmFactory: "0xfb1BE491cddca74f5f980939AC2D3F26b17b7207"
+staticAggregationHookFactory: "0x0E420B044d1250C45fFefe9e2D364Fdc060257ba"
+domainRoutingIsmFactory: "0x54245a5cFCBE6519b6991844cd3F48e4456AA35C"
+staticMerkleRootWeightedMultisigIsmFactory: "0xb687c45411a9e58A2e0b6de9dAC49A7abdc221FA"
+staticMessageIdWeightedMultisigIsmFactory: "0x2bDEe87C0c9C5B4F5957e00D954D8AF0252dAa38"
+
+# Optional protocolFee (from logs)
+protocolFee: "0xe970853e4814cdd4c2c2d7d475efb76b36577da0"

--- a/chains/cypherium/metadata.yaml
+++ b/chains/cypherium/metadata.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../schema.json
+chainId: 16166
+displayName: Cypherium
+domainId: 16166
+isTestnet: false
+name: cypherium
+nativeToken:
+  decimals: 18
+  name: cypherium
+  symbol: CPH
+protocol: ethereum
+rpcUrls:
+  - http: https://pubnodes.cypherium.io/rpc
+technicalStack: other

--- a/deployments/core/cypherium-core-deployment.yaml
+++ b/deployments/core/cypherium-core-deployment.yaml
@@ -1,0 +1,20 @@
+# Hyperlane core deployment for Cypherium
+# Generated manually from deployment logs
+mailbox: "0x17fcEf595646FB1eB94d93B62EE256a2C2a7f337"
+interchainAccountRouter: "0x74c058367ee8A1F748952b6F973BFA9De5bF89A1"
+validatorAnnounce: "0x1eD8634917b1EB02a24e7b1fd630fc6E4121DD2e"
+merkleTreeHook: "0x73404aD208d4079f709723B415BE612BF3550372"
+proxyAdmin: "0xf9F5244ce3Abaf084EE53682f2D76649f98BfD72"
+testRecipient: "0x8dE66b90A215a746B1d8504f3b8d6B809Fd5432A"
+
+# Factories
+staticMerkleRootMultisigIsmFactory: "0xD258adC28084379A75631E0ea55034F4c606f958"
+staticMessageIdMultisigIsmFactory: "0xbd2c55254E31BF78356d7C9AbbC0a37383770AD4"
+staticAggregationIsmFactory: "0xfb1BE491cddca74f5f980939AC2D3F26b17b7207"
+staticAggregationHookFactory: "0x0E420B044d1250C45fFefe9e2D364Fdc060257ba"
+domainRoutingIsmFactory: "0x54245a5cFCBE6519b6991844cd3F48e4456AA35C"
+staticMerkleRootWeightedMultisigIsmFactory: "0xb687c45411a9e58A2e0b6de9dAC49A7abdc221FA"
+staticMessageIdWeightedMultisigIsmFactory: "0x2bDEe87C0c9C5B4F5957e00D954D8AF0252dAa38"
+
+# Optional protocolFee (from logs)
+protocolFee: "0x8b7f8b24d559170c8ce8163927e28b215dd67e02e5f17b10a975140c19704001"

--- a/deployments/core/cypherium-core-deployment.yaml
+++ b/deployments/core/cypherium-core-deployment.yaml
@@ -17,4 +17,4 @@ staticMerkleRootWeightedMultisigIsmFactory: "0xb687c45411a9e58A2e0b6de9dAC49A7ab
 staticMessageIdWeightedMultisigIsmFactory: "0x2bDEe87C0c9C5B4F5957e00D954D8AF0252dAa38"
 
 # Optional protocolFee (from logs)
-protocolFee: "0x380Ae1a000eb03930bb2F64d4A75dfE54b3e7e18"
+protocolFee: "0xe970853e4814cdd4c2c2d7d475efb76b36577da0"

--- a/deployments/core/cypherium-core-deployment.yaml
+++ b/deployments/core/cypherium-core-deployment.yaml
@@ -17,4 +17,4 @@ staticMerkleRootWeightedMultisigIsmFactory: "0xb687c45411a9e58A2e0b6de9dAC49A7ab
 staticMessageIdWeightedMultisigIsmFactory: "0x2bDEe87C0c9C5B4F5957e00D954D8AF0252dAa38"
 
 # Optional protocolFee (from logs)
-protocolFee: "0x8b7f8b24d559170c8ce8163927e28b215dd67e02e5f17b10a975140c19704001"
+protocolFee: "0x380Ae1a000eb03930bb2F64d4A75dfE54b3e7e18"


### PR DESCRIPTION
### Description

Add **Cypherium mainnet** (chainId `16166`) to the Hyperlane registry, including metadata and core deployment addresses.

- **RPC**: https://pubnodes.cypherium.io/rpc
- **Native token**: CPH (18 decimals)
- **Mailbox**: 0x17fcEf595646FB1eB94d93B62EE256a2C2a7f337
- **ValidatorAnnounce**: 0x1eD8634917b1EB02a24e7b1fd630fc6E4121DD2e
- **ProxyAdmin**: 0xf9F5244ce3Abaf084EE53682f2D76649f98BfD72
- **InterchainAccountRouter**: 0x74c058367ee8A1F748952b6F973BFA9De5bF89A1
- **MerkleTreeHook**: 0x73404aD208d4079f709723B415BE612BF3550372
- **TestRecipient**: 0x8dE66b90A215a746B1d8504f3b8d6B809Fd5432A

Also included:
- staticMerkleRootMultisigIsmFactory: 0xD258adC28084379A75631E0ea55034F4c606f958  
- staticMessageIdMultisigIsmFactory: 0xbd2c55254E31BF78356d7C9AbbC0a37383770AD4  
- staticAggregationIsmFactory: 0xfb1BE491cddca74f5f980939AC2D3F26b17b7207  
- staticAggregationHookFactory: 0x0E420B044d1250C45fFefe9e2D364Fdc060257ba  
- domainRoutingIsmFactory: 0x54245a5cFCBE6519b6991844cd3F48e4456AA35C  
- staticMerkleRootWeightedMultisigIsmFactory: 0xb687c45411a9e58A2e0b6de9dAC49A7abdc221FA  
- staticMessageIdWeightedMultisigIsmFactory: 0x2bDEe87C0c9C5B4F5957e00D954D8AF0252dAa38  

### Backward compatibility

Yes. This PR only **adds a new chain** and does not modify or break existing configurations.

### Testing

- Created `chains/cypherium/metadata.yaml` with correct chainId, RPC URL, and native token (CPH).  
- Deployed Hyperlane core contracts to Cypherium (chainId 16166) via `hyperlane core deploy`.  
- Verified successful deployment and sufficient balances during CLI preflight checks.  
- Confirmed contracts are functional using Hyperlane CLI (registry, core, and warp commands).  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cypherium (mainnet, chain ID 16166) to the chain registry with native token CPH (18 decimals), protocol and public RPC endpoint; enabled Hyperlane core features including messaging and interchain account support.

- **Chores**
  - Added static deployment and addresses manifests for Cypherium containing fixed core component and factory configurations, plus an optional protocol fee entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->