### PR TITLE
chore: update mitosis and MITO route

### DIFF
--- a/.changeset/pink-eagles-happen.md
+++ b/.changeset/pink-eagles-happen.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add blockExplorers for mitosis and update owners for MITO/mitosis route

--- a/chains/mitosis/metadata.yaml
+++ b/chains/mitosis/metadata.yaml
@@ -1,4 +1,9 @@
 # yaml-language-server: $schema=../schema.json
+blockExplorers:
+  - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/124816/etherscan/api
+    family: routescan
+    name: Mitosis Explorer
+    url: https://mitoscan.io/
 blocks:
   confirmations: 1
   estimateBlockTime: 2

--- a/deployments/warp_routes/MITO/mitosis-deploy.yaml
+++ b/deployments/warp_routes/MITO/mitosis-deploy.yaml
@@ -36,7 +36,7 @@ bsc:
         type: pausableIsm
     threshold: 2
     type: staticAggregationIsm
-  owner: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+  owner: "0x1248163214D9A0D6F02932A245370D3fD9613A82"
   symbol: MITO
   type: synthetic
 mitosis:
@@ -57,5 +57,5 @@ mitosis:
         type: pausableIsm
     threshold: 2
     type: staticAggregationIsm
-  owner: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+  owner: "0x1248163200964459971c7cC9631909132AD28C27"
   type: native


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

- Add mitosis `blockExplorers` information
- Update `MITO/mitosis` route with new owners

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
`hyperlane warp read`