### PR TITLE
feat: update zircuit reorgPeriod to 12 hours

### DIFF
--- a/chains/zircuit/metadata.yaml
+++ b/chains/zircuit/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
 blocks:
   confirmations: 1
   estimateBlockTime: 2
-  reorgPeriod: 45
+  reorgPeriod: 21600
 chainId: 48900
 deployer:
   name: Abacus Works


### PR DESCRIPTION
### Description

 - update zircuit's reorgPeriod to 12 hours
   - 12 hours = 43200 seconds = 21600 blocks on zircuit (2s per block)
