### PR TITLE
EDGEN: Updated trusted ism and owner addresses

### DIFF
--- a/deployments/warp_routes/EDGEN/bsc-edgenchain-ethereum-deploy.yaml
+++ b/deployments/warp_routes/EDGEN/bsc-edgenchain-ethereum-deploy.yaml
@@ -22,15 +22,15 @@ bsc:
     owner: "0xCC844ddA1e986B92FD2D075bb05Ed21F509CA20c"
     type: interchainGasPaymaster
   interchainSecurityModule:
-    address: "0xa420007CCfFB2af91D08f82C3572eA4C2d693FF0"
-    relayer: "0x115c6d62067084D7ce168bCAe0727a66E732572A"
+    address: "0x296ddC4a97387A593165Ec81238A81Def0d8bB2b"
+    relayer: "0x3cd1bdcbb5032086C93eAf39b0A88909638A544a"
     type: trustedRelayerIsm
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: LayerEdge
-  owner: "0xCC844ddA1e986B92FD2D075bb05Ed21F509CA20c"
+  owner: "0xcf9a65344AEAfE0837B88050dd0cdc6fEa3c38e1"
   proxyAdmin:
     address: "0x1c6cDa35622030FE6821dEc0201583126d2d54e8"
-    owner: "0xCC5d4c9D59230f185e4F7A20Acbf62D59F0d4899"
+    owner: "0x70c3F9A8811D69591D289d34b799128E6F90A993"
   remoteRouters:
     "1":
       address: "0xB8bB85FD0836691a64aFc23199566F898a1d6f4a"
@@ -62,12 +62,12 @@ edgenchain:
     owner: "0xCC844ddA1e986B92FD2D075bb05Ed21F509CA20c"
     type: interchainGasPaymaster
   interchainSecurityModule:
-    address: "0x2bd2962A14C7c416e747B9e893951bAE851E3f3f"
-    relayer: "0x115c6d62067084D7ce168bCAe0727a66E732572A"
+    address: "0x5330BEB327580AFBd18E87D7e4B533da7Aa4c567"
+    relayer: "0x3cd1bdcbb5032086C93eAf39b0A88909638A544a"
     type: trustedRelayerIsm
   mailbox: "0xef07FAE1a6912C8d333F72E01A03CE3bb18E12a1"
   name: EDGEN
-  owner: "0xCC844ddA1e986B92FD2D075bb05Ed21F509CA20c"
+  owner: "0xcf9a65344AEAfE0837B88050dd0cdc6fEa3c38e1"
   proxyAdmin:
     address: "0x1fd173520c0a330E10FDcD16B8256B3714019b04"
     owner: "0xCC844ddA1e986B92FD2D075bb05Ed21F509CA20c"
@@ -102,12 +102,12 @@ ethereum:
     owner: "0xCC844ddA1e986B92FD2D075bb05Ed21F509CA20c"
     type: interchainGasPaymaster
   interchainSecurityModule:
-    address: "0xbD53ba7474126956db921cf3Fe580eB3707fb36A"
-    relayer: "0x115c6d62067084D7ce168bCAe0727a66E732572A"
+    address: "0x02eC3649bB81cE42879ECf98c68F3AE9015124b8"
+    relayer: "0x3cd1bdcbb5032086C93eAf39b0A88909638A544a"
     type: trustedRelayerIsm
   mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
   name: LayerEdge
-  owner: "0xCC844ddA1e986B92FD2D075bb05Ed21F509CA20c"
+  owner: "0xcf9a65344AEAfE0837B88050dd0cdc6fEa3c38e1"
   proxyAdmin:
     address: "0x6F9eD23323849E0E6c387A8B5E1BAe24B333dB6d"
     owner: "0xCC5d4c9D59230f185e4F7A20Acbf62D59F0d4899"


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Updated the onwer and trusted ISM addresses

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

YES

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated interchain security module configurations and relayers for BSC, EDGEN, and Ethereum to current endpoints.
  - Rotated ownership for core contracts across networks; updated proxy admin ownership where applicable.
  - Maintained existing hooks/oracles/mailbox settings; no behavioral changes expected.
  - Improves cross-chain reliability and aligns governance with current operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->