### PR TITLE
chore: deprecate legacy lumia mailbox

### DIFF
--- a/.changeset/brave-rivers-camp.md
+++ b/.changeset/brave-rivers-camp.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Officially deprecate legacy lumia mailbox.

--- a/chains/lumia/metadata.yaml
+++ b/chains/lumia/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [unavailable]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.lumia.org/api/eth-rpc
     family: blockscout


### PR DESCRIPTION
### Description

chore: deprecate legacy lumia mailbox

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
