### PR TITLE
fix: `HOLO` decimals

### DIFF
--- a/.changeset/lemon-eggs-rest.md
+++ b/.changeset/lemon-eggs-rest.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Fix `HOLO` decimals.

--- a/deployments/warp_routes/HOLO/bsc-solanamainnet-config.yaml
+++ b/deployments/warp_routes/HOLO/bsc-solanamainnet-config.yaml
@@ -1,22 +1,22 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0xe38c11C02B4f14366175D1276ffBdf00c55A9d41"
+  - addressOrDenom: "0x1c0f11eEcdB19dF8EE2405E4EbCb90683686BCcD"
     chainName: bsc
     coinGeckoId: holoworld
     collateralAddressOrDenom: "0x1a5D7E4c3A7F940B240b7357a4bFED30D17f9497"
     connections:
-      - token: sealevel|solanamainnet|ACUNbqSVgoLjrff9Cy5EqjTxqhfRe5hoZAvfFVvtfiEZ
+      - token: sealevel|solanamainnet|CJVjRp7ndm14RhwGoLFMBWMS2EZ6vCsGhB3YMXaPcPHb
     decimals: 18
     logoURI: /deployments/warp_routes/HOLO/logo.svg
     name: Holoworld AI
     standard: EvmHypCollateral
     symbol: HOLO
-  - addressOrDenom: ACUNbqSVgoLjrff9Cy5EqjTxqhfRe5hoZAvfFVvtfiEZ
+  - addressOrDenom: CJVjRp7ndm14RhwGoLFMBWMS2EZ6vCsGhB3YMXaPcPHb
     chainName: solanamainnet
-    collateralAddressOrDenom: 4UnRvsP6GGxgagQcP4RGwt9AQyPky9cFoygf8xQ11ZHC
+    collateralAddressOrDenom: 69RX85eQoEsnZvXGmLNjYcWgVkp9r2JjahVm99KbJETU
     connections:
-      - token: ethereum|bsc|0xe38c11C02B4f14366175D1276ffBdf00c55A9d41
-    decimals: 18
+      - token: ethereum|bsc|0x1c0f11eEcdB19dF8EE2405E4EbCb90683686BCcD
+    decimals: 9
     logoURI: /deployments/warp_routes/HOLO/logo.svg
     name: Holoworld AI
     standard: SealevelHypSynthetic

--- a/deployments/warp_routes/HOLO/bsc-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/HOLO/bsc-solanamainnet-deploy.yaml
@@ -1,10 +1,10 @@
 bsc:
-  decimals: 18
   name: Holoworld AI
+  owner: "0xd8A863460a4C78B41eC1B68604130e694358BD32"
   symbol: HOLO
   token: "0x1a5D7E4c3A7F940B240b7357a4bFED30D17f9497"
   type: collateral
 solanamainnet:
   foreignDeployment: CJVjRp7ndm14RhwGoLFMBWMS2EZ6vCsGhB3YMXaPcPHb
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: 6d3vKAcmi7XRtG8jWAKJj8VPDaiprT56bVSkVW2eCxCp
   type: synthetic

--- a/deployments/warp_routes/HOLO/bsc-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/HOLO/bsc-solanamainnet-deploy.yaml
@@ -1,12 +1,10 @@
 bsc:
   decimals: 18
   name: Holoworld AI
-  owner: "0xd8A863460a4C78B41eC1B68604130e694358BD32"
   symbol: HOLO
   token: "0x1a5D7E4c3A7F940B240b7357a4bFED30D17f9497"
   type: collateral
 solanamainnet:
-  decimals: 18
-  foreignDeployment: ACUNbqSVgoLjrff9Cy5EqjTxqhfRe5hoZAvfFVvtfiEZ
-  owner: 6d3vKAcmi7XRtG8jWAKJj8VPDaiprT56bVSkVW2eCxCp
+  foreignDeployment: CJVjRp7ndm14RhwGoLFMBWMS2EZ6vCsGhB3YMXaPcPHb
+  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
   type: synthetic


### PR DESCRIPTION
### Description

fix: `HOLO` decimals

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

BSC -> Solana: https://explorer.hyperlane.xyz/message/0xdddf6c2a6b1616afadeb16573f7572dc08ecfe6547eff30f7e7fc89d38cd03f8 ✅ 

Solana -> BSC: https://explorer.hyperlane.xyz/message/0x09600b6512f7fd0a3d9f3586bc857acf606d6ad2dc3f48bb49bde35adeef79ce ✅ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected HOLO token decimals across BSC ↔ Solana Mainnet routes to ensure accurate balances, pricing, and transfers.
  - Updated cross-chain route configuration to align with the canonical token and collateral, preventing mismatches.

- Chores
  - Bumped the registry package minor version.
  - Refreshed deployment metadata and foreign deployment references to reflect current network state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->