### PR TITLE
chore: add `TIA/celestia-eclipsemainnet`

### DIFF
--- a/.changeset/clever-lemons-compete.md
+++ b/.changeset/clever-lemons-compete.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add TIA/celestia-eclipsemainnet

--- a/deployments/warp_routes/TIA/celestia-eclipsemainnet-config.yaml
+++ b/deployments/warp_routes/TIA/celestia-eclipsemainnet-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000004"
+    chainName: celestia
+    coinGeckoId: celestia
+    collateralAddressOrDenom: utia
+    connections:
+      - token: sealevel|eclipsemainnet|8gkLoHDNA8VygyCD1T7bbDszYboUjALtrxgSLnKZsYBt
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA
+    standard: CosmosNativeHypCollateral
+    symbol: TIA
+  - addressOrDenom: 8gkLoHDNA8VygyCD1T7bbDszYboUjALtrxgSLnKZsYBt
+    chainName: eclipsemainnet
+    collateralAddressOrDenom: CixfcEPw3aAzmXRcgbkaRKCs2wvuWKP2wRB1sBd7ZrPQ
+    connections:
+      - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000010000000000000004
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: Celestia
+    standard: SealevelHypSynthetic
+    symbol: TIA

--- a/deployments/warp_routes/TIA/celestia-eclipsemainnet-deploy.yaml
+++ b/deployments/warp_routes/TIA/celestia-eclipsemainnet-deploy.yaml
@@ -1,0 +1,12 @@
+celestia:
+  decimals: 6
+  name: TIA
+  owner: celestia1d3ap0qjx08250ltl7cwd0eal4jtvamp3ujtmru
+  symbol: TIA
+  token: utia
+  type: collateral
+eclipsemainnet:
+  foreignDeployment: 8gkLoHDNA8VygyCD1T7bbDszYboUjALtrxgSLnKZsYBt
+  gas: 300000
+  owner: 8GAvyeQyBNwnuxVSpk9drn8TgJLEVWSQEpdcei6JwG8e
+  type: synthetic


### PR DESCRIPTION
### Description

chore: add `TIA/celestia-eclipsemainnet`

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
