### PR TITLE
feat: update zircuit reorgPeriod to 10 mins

### DIFF
--- a/.changeset/rare-bulldogs-shake.md
+++ b/.changeset/rare-bulldogs-shake.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+update zircuit reorg to 10mins

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -8304,7 +8304,7 @@ zircuit:
   blocks:
     confirmations: 1
     estimateBlockTime: 2
-    reorgPeriod: 21600
+    reorgPeriod: 300
   chainId: 48900
   deployer:
     name: Abacus Works

--- a/chains/zircuit/metadata.yaml
+++ b/chains/zircuit/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
 blocks:
   confirmations: 1
   estimateBlockTime: 2
-  reorgPeriod: 21600
+  reorgPeriod: 300
 chainId: 48900
 deployer:
   name: Abacus Works

--- a/test/unit/chains.test.ts
+++ b/test/unit/chains.test.ts
@@ -80,9 +80,7 @@ describe('Chain metadata', () => {
         expect(Object.values(EthJsonRpcBlockParameterTag)).to.include(reorgPeriod);
       } else if (typeof reorgPeriod === 'number') {
         expect(reorgPeriod).to.be.at.least(0);
-        if (chain !== "zircuit") {
-          expect(reorgPeriod).to.be.at.most(500);
-        }
+        expect(reorgPeriod).to.be.at.most(500);
       } else {
         throw new Error(`Invalid reorgPeriod type for ${chain}`);
       }
@@ -128,7 +126,7 @@ describe('Chain metadata', () => {
             } else if (chain === 'mantle') {
               expect(metadata.blocks?.reorgPeriod).to.equal(2);
             } else if (chain === 'zircuit') {
-              expect(metadata.blocks?.reorgPeriod).to.equal(21600);
+              expect(metadata.blocks?.reorgPeriod).to.equal(300);
             } else {
               expect(metadata.blocks?.reorgPeriod).to.equal(5);
             }


### PR DESCRIPTION
### Description

Update zircuit reorgPeriod to 10mins

### Backward compatibility

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added deployer URL to Zircuit chain metadata.
* Bug Fixes
  * Updated Zircuit reorg period to 10 minutes.
* Tests
  * Updated tests to reflect Zircuit’s new reorg period and enforce a maximum reorg period of 500 across all chains.
* Chores
  * Added patch release entry for the registry package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->