### PR TITLE
chore: extend `TIA/arbitrum-celestia-neutron`

### DIFF
--- a/.changeset/angry-pianos-happen.md
+++ b/.changeset/angry-pianos-happen.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add Celestia to TIA/arbitrum-neutron.

--- a/deployments/warp_routes/TIA/arbitrum-celestia-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/arbitrum-celestia-neutron-config.yaml
@@ -9,11 +9,22 @@ tokens:
   - addressOrDenom: "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C"
     chainName: arbitrum
     connections:
+      - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000010000000000000005
       - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA.n
     standard: EvmHypSynthetic
+    symbol: TIA.n
+  - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000005"
+    chainName: celestia
+    collateralAddressOrDenom: utia
+    connections:
+      - token: ethereum|arbitrum|0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA.n
+    standard: CosmosNativeHypCollateral
     symbol: TIA.n
   - addressOrDenom: neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
     chainName: neutron

--- a/deployments/warp_routes/TIA/arbitrum-celestia-neutron-deploy.yaml
+++ b/deployments/warp_routes/TIA/arbitrum-celestia-neutron-deploy.yaml
@@ -9,8 +9,20 @@ arbitrum:
     proxyAdmin: "0xAC98b0cD1B64EA4fe133C6D2EDaf842cE5cF4b01"
     testRecipient: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
     validatorAnnounce: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  remoteRouters:
+    celestia:
+      address: "0x726f757465725f61707000000000000000000000000000010000000000000005"
+    neutron:
+      address: "0x910926c4cf95d107237a9cf0b3305fe9c81351ebcba3d218ceb0e4935d92ceac"
   symbol: TIA.n
   type: synthetic
+celestia:
+  decimals: 6
+  name: TIA
+  owner: celestia1d3ap0qjx08250ltl7cwd0eal4jtvamp3ujtmru
+  symbol: TIA
+  token: utia
+  type: collateral
 neutron:
   foreignDeployment: 910926c4cf95d107237a9cf0b3305fe9c81351ebcba3d218ceb0e4935d92ceac
   gas: 600000


### PR DESCRIPTION
### Description

chore: extend `TIA/arbitrum-celestia-neutron`

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
