### PR TITLE
chore: remove neutron connection TIA/arbitrum-celestia-neutron

### DIFF
--- a/.changeset/orange-hornets-hide.md
+++ b/.changeset/orange-hornets-hide.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Remove neutron connection for TIA/arbitrum-celestia-neutron

--- a/deployments/warp_routes/TIA/arbitrum-celestia-neutron-config.yaml
+++ b/deployments/warp_routes/TIA/arbitrum-celestia-neutron-config.yaml
@@ -10,7 +10,6 @@ tokens:
     chainName: arbitrum
     connections:
       - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000010000000000000005
-      - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA.n
@@ -30,8 +29,6 @@ tokens:
     chainName: neutron
     coinGeckoId: celestia
     collateralAddressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-    connections:
-      - token: ethereum|arbitrum|0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA.n

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -4262,7 +4262,6 @@ TIA/arbitrum-celestia-neutron:
       chainName: arbitrum
       connections:
         - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000010000000000000005
-        - token: cosmos|neutron|neutron1jyyjd3x0jhgswgm6nnctxvzla8ypx50tew3ayxxwkrjfxhvje6kqzvzudq
       decimals: 6
       logoURI: /deployments/warp_routes/TIA/logo.svg
       name: TIA.n
@@ -4282,8 +4281,6 @@ TIA/arbitrum-celestia-neutron:
       chainName: neutron
       coinGeckoId: celestia
       collateralAddressOrDenom: ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7
-      connections:
-        - token: ethereum|arbitrum|0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C
       decimals: 6
       logoURI: /deployments/warp_routes/TIA/logo.svg
       name: TIA.n


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Remove neutron connection for TIA/arbitrum-celestia-neutron route
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
UI testing