### PR TITLE
feat: deprecate infinityvm, game7, alephzero

### DIFF
--- a/.changeset/tidy-ladybugs-divide.md
+++ b/.changeset/tidy-ladybugs-divide.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Deprecate alephzeroevmmainnet, game7, infinityvmmainnet.

--- a/chains/alephzeroevmmainnet/metadata.yaml
+++ b/chains/alephzeroevmmainnet/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [unavailable]
+  status: disabled
 blockExplorers:
   - apiUrl: https://evm-explorer.alephzero.org/api
     family: blockscout

--- a/chains/game7/metadata.yaml
+++ b/chains/game7/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [unavailable]
+  status: disabled
 blockExplorers:
   - apiUrl: https://mainnet.game7.io/api
     family: blockscout

--- a/chains/infinityvmmainnet/metadata.yaml
+++ b/chains/infinityvmmainnet/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [unavailable]
+  status: disabled
 blocks:
   confirmations: 1
   estimateBlockTime: 1


### PR DESCRIPTION
### Description

feat: deprecate infinityvm, game7, alephzero

https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/7099

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Deprecations
  - Marked the following networks as unavailable/disabled: alephzeroevmmainnet, game7, infinityvmmainnet. These networks may no longer appear as selectable or active in supported tooling.

- Chores
  - Minor version bump for the registry package.
  - Updated chain metadata to include explicit availability indicators.
  - No functional or API changes for other networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->