### PR TITLE
chore: Add logourl and coinGeckoId to the correct config

### DIFF
--- a/.changeset/cuddly-onions-hope.md
+++ b/.changeset/cuddly-onions-hope.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update the logorUrl and coinGeckoId to the correct config for electroneum USDC

--- a/deployments/warp_routes/USDC/electroneum-config.yaml
+++ b/deployments/warp_routes/USDC/electroneum-config.yaml
@@ -2,23 +2,27 @@
 tokens:
   - addressOrDenom: "0x3187deAd7A2Bd6770F5Fe81495D1B715926AAe6e"
     chainName: avalanche
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
     connections:
       - token: ethereum|base|0xaaDF9558Cf103d394B22b18Ffbaa0D1c0778Ccfa
       - token: ethereum|electroneum|0x3187deAd7A2Bd6770F5Fe81495D1B715926AAe6e
       - token: ethereum|ethereum|0xFC2944e9F1d57Ce82aeD05922887DD660404e50B
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0xaaDF9558Cf103d394B22b18Ffbaa0D1c0778Ccfa"
     chainName: base
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|avalanche|0x3187deAd7A2Bd6770F5Fe81495D1B715926AAe6e
       - token: ethereum|electroneum|0x3187deAd7A2Bd6770F5Fe81495D1B715926AAe6e
       - token: ethereum|ethereum|0xFC2944e9F1d57Ce82aeD05922887DD660404e50B
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC
@@ -34,12 +38,14 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xFC2944e9F1d57Ce82aeD05922887DD660404e50B"
     chainName: ethereum
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|avalanche|0x3187deAd7A2Bd6770F5Fe81495D1B715926AAe6e
       - token: ethereum|base|0xaaDF9558Cf103d394B22b18Ffbaa0D1c0778Ccfa
       - token: ethereum|electroneum|0x3187deAd7A2Bd6770F5Fe81495D1B715926AAe6e
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
     symbol: USDC

--- a/deployments/warp_routes/USDC/electroneum-config.yaml
+++ b/deployments/warp_routes/USDC/electroneum-config.yaml
@@ -33,6 +33,7 @@ tokens:
       - token: ethereum|base|0xaaDF9558Cf103d394B22b18Ffbaa0D1c0778Ccfa
       - token: ethereum|ethereum|0xFC2944e9F1d57Ce82aeD05922887DD660404e50B
     decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypSynthetic
     symbol: USDC

--- a/deployments/warp_routes/USDC/electroneum-deploy.yaml
+++ b/deployments/warp_routes/USDC/electroneum-deploy.yaml
@@ -6,8 +6,6 @@ avalanche:
       - bridge: "0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677"
     ethereum:
       - bridge: "0x0E8Bc62865F539889fe7d8537F2ed6db5aa0F677"
-  coinGeckoId: usd-coin
-  logoURI: /deployments/warp_routes/USDC/logo.svg
   owner: "0xe0eb6194A56cdb6a51BB5855cddEbd61c03a199d"
   token: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
   type: collateral
@@ -19,8 +17,6 @@ base:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
     ethereum:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
-  coinGeckoId: usd-coin
-  logoURI: /deployments/warp_routes/USDC/logo.svg
   owner: "0xe0eb6194A56cdb6a51BB5855cddEbd61c03a199d"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   type: collateral
@@ -36,8 +32,6 @@ ethereum:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
     base:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
-  coinGeckoId: usd-coin
-  logoURI: /deployments/warp_routes/USDC/logo.svg
   owner: "0xe0eb6194A56cdb6a51BB5855cddEbd61c03a199d"
   token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
   type: collateral


### PR DESCRIPTION
### Description
This PR moves the logorUrl and coinGeckoId to the correct config for electroneum USDC

### Backward compatibility
Yes

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
