### PR TITLE
feat: Add electroneum usdt configs

### DIFF
--- a/.changeset/cyan-planets-pump.md
+++ b/.changeset/cyan-planets-pump.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add Electroneum USDT

--- a/deployments/warp_routes/USDT/electroneum-config.yaml
+++ b/deployments/warp_routes/USDT/electroneum-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x48E722f1458b253c2FB0E573F939318D7Dbd54e7"
+    chainName: electroneum
+    coinGeckoId: tether
+    connections:
+      - token: ethereum|ethereum|0x97B80b1d89d10E5d2c9396B0ea0BA2dAf917Dc96
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    standard: EvmHypSynthetic
+    symbol: USDT
+  - addressOrDenom: "0x97B80b1d89d10E5d2c9396B0ea0BA2dAf917Dc96"
+    chainName: ethereum
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+    connections:
+      - token: ethereum|electroneum|0x48E722f1458b253c2FB0E573F939318D7Dbd54e7
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    standard: EvmHypCollateral
+    symbol: USDT

--- a/deployments/warp_routes/USDT/electroneum-deploy.yaml
+++ b/deployments/warp_routes/USDT/electroneum-deploy.yaml
@@ -1,0 +1,8 @@
+electroneum:
+  isNft: false
+  owner: "0xa7eccdb9be08178f896c26b7bbd8c3d4e844d9ba"
+  type: synthetic
+ethereum:
+  owner: "0xe0eb6194A56cdb6a51BB5855cddEbd61c03a199d"
+  token: "0xdac17f958d2ee523a2206206994597c13d831ec7"
+  type: collateral

--- a/deployments/warp_routes/USDT/electroneum-deploy.yaml
+++ b/deployments/warp_routes/USDT/electroneum-deploy.yaml
@@ -1,5 +1,4 @@
 electroneum:
-  isNft: false
   owner: "0x75BC257549A48Ee12624645Ad4a5E847A2537E66"
   type: synthetic
 ethereum:

--- a/deployments/warp_routes/USDT/electroneum-deploy.yaml
+++ b/deployments/warp_routes/USDT/electroneum-deploy.yaml
@@ -1,6 +1,6 @@
 electroneum:
   isNft: false
-  owner: "0xa7eccdb9be08178f896c26b7bbd8c3d4e844d9ba"
+  owner: "0x75BC257549A48Ee12624645Ad4a5E847A2537E66"
   type: synthetic
 ethereum:
   owner: "0xe0eb6194A56cdb6a51BB5855cddEbd61c03a199d"


### PR DESCRIPTION
### Description
This PR Add electroneum usdt configs

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added USDT support on Electroneum as a synthetic token paired with Ethereum-backed collateral.
  - Enabled bi-directional bridging between Ethereum and Electroneum for USDT.
  - Included token metadata (name, symbol, decimals) and logo for improved display.

- **Chores**
  - Added a changeset entry marking a minor release noting Electroneum USDT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->