### PR TITLE
chore: extend `TIA/mantapacific`

### DIFF
--- a/.changeset/little-shirts-kneel.md
+++ b/.changeset/little-shirts-kneel.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Extend TIA/mantapacific

--- a/deployments/warp_routes/TIA/mantapacific-config.yaml
+++ b/deployments/warp_routes/TIA/mantapacific-config.yaml
@@ -6,9 +6,20 @@ options:
       destination: mantapacific
       origin: neutron
 tokens:
+  - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000007"
+    chainName: celestia
+    collateralAddressOrDenom: utia
+    connections:
+      - token: ethereum|mantapacific|0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA
+    standard: CosmosNativeHypCollateral
+    symbol: TIA
   - addressOrDenom: "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa"
     chainName: mantapacific
     connections:
+      - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000010000000000000007
       - token: cosmos|neutron|neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa
     decimals: 6
     logoURI: /deployments/warp_routes/TIA/logo.svg

--- a/deployments/warp_routes/TIA/mantapacific-deploy.yaml
+++ b/deployments/warp_routes/TIA/mantapacific-deploy.yaml
@@ -1,3 +1,10 @@
+celestia:
+  decimals: 6
+  name: TIA
+  owner: celestia1lcl2vhj4rsalr9qqyg4tkkdk8laqfmz5xqgl5k
+  symbol: TIA
+  token: utia
+  type: collateral
 mantapacific:
   decimals: 6
   gas: 600000


### PR DESCRIPTION
### Description

chore: extend `TIA/mantapacific`

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
