### PR TITLE
feat: extend USDC/eclipsemainnet-ethereum-solanamainnet to arbitrum, base and enable rebalancing

### DIFF
--- a/deployments/warp_routes/USDC/eclipsemainnet-ethereum-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/USDC/eclipsemainnet-ethereum-solanamainnet-deploy.yaml
@@ -1,0 +1,47 @@
+arbitrum:
+  allowedRebalancers:
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+  allowedRebalancingBridges:
+    base:
+      - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
+    ethereum:
+      - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
+  contractVersion: 8.1.1
+  owner: "0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e"
+  token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+  type: collateral
+base:
+  allowedRebalancers:
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+  allowedRebalancingBridges:
+    arbitrum:
+      - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
+    ethereum:
+      - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
+  contractVersion: 8.1.1
+  owner: "0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF"
+  token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  type: collateral
+eclipsemainnet:
+  foreignDeployment: EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m
+  gas: 300000
+  owner: E4TncCw3WMqQZbkACVcomX3HqcSzLfNyhTnqKN1DimGr
+  type: synthetic
+ethereum:
+  allowedRebalancers:
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+  allowedRebalancingBridges:
+    arbitrum:
+      - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
+    base:
+      - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
+  contractVersion: 8.1.1
+  owner: "0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6"
+  token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+  type: collateral
+solanamainnet:
+  foreignDeployment: 3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm
+  gas: 300000
+  owner: BNGDJ1h9brgt6FFVd8No1TVAH48Fp44d7jkuydr1URwJ
+  token: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+  type: collateral


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
