### PR TITLE
chore: Remove arbitrum connections

### DIFF
--- a/deployments/warp_routes/CARR/carrchain-config.yaml
+++ b/deployments/warp_routes/CARR/carrchain-config.yaml
@@ -2,10 +2,7 @@
 tokens:
   - addressOrDenom: "0xc7B42d83255ac2874F39370101a9DBD4Ed219D84"
     chainName: arbitrum
-    connections:
-      - token: ethereum|carrchain|0x810db1ea27946aCDdc40ca98B6A6380Af6c7b89A
-      - token: ethereum|polygon|0x810db1ea27946aCDdc40ca98B6A6380Af6c7b89A
-      - token: ethereum|solanamainnet|B1dBmaEFGMbLvNn3UsrayxQBTVF7K9XFBS66M1csyUz1
+    connections: []
     decimals: 18
     logoURI: /deployments/warp_routes/CARR/logo.svg
     name: CARR
@@ -25,7 +22,6 @@ tokens:
     chainName: carrchain
     coinGeckoId: carrchain
     connections:
-      - token: ethereum|arbitrum|0xc7B42d83255ac2874F39370101a9DBD4Ed219D84
       - token: ethereum|polygon|0x810db1ea27946aCDdc40ca98B6A6380Af6c7b89A
       - token: ethereum|solanamainnet|B1dBmaEFGMbLvNn3UsrayxQBTVF7K9XFBS66M1csyUz1
     decimals: 18
@@ -38,7 +34,6 @@ tokens:
     coinGeckoId: carnomaly
     collateralAddressOrDenom: "0x9b765735C82BB00085e9DBF194F20E3Fa754258E"
     connections:
-      - token: ethereum|arbitrum|0xc7B42d83255ac2874F39370101a9DBD4Ed219D84
       - token: ethereum|carrchain|0x810db1ea27946aCDdc40ca98B6A6380Af6c7b89A
       - token: ethereum|solanamainnet|B1dBmaEFGMbLvNn3UsrayxQBTVF7K9XFBS66M1csyUz1
     decimals: 18
@@ -51,7 +46,6 @@ tokens:
     coinGeckoId: carnomaly
     collateralAddressOrDenom: CDwKAreA1ipd1hUDBKsfVXVFWqNEeGDdvmZ7RHdiQk1U
     connections:
-      - token: ethereum|arbitrum|0xc7B42d83255ac2874F39370101a9DBD4Ed219D84
       - token: ethereum|carrchain|0x810db1ea27946aCDdc40ca98B6A6380Af6c7b89A
       - token: ethereum|polygon|0x810db1ea27946aCDdc40ca98B6A6380Af6c7b89A
     decimals: 6


### PR DESCRIPTION
### Description
Removing arbitrum connections as Requested by carrchain team

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
