### PR TITLE
feat: update wM and USDSC config on Mantra and Soneium

### DIFF
--- a/.changeset/mighty-pens-provide.md
+++ b/.changeset/mighty-pens-provide.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Migrate wM (Mantra, Soneium) and USDSC (Ethereum, Soneium) warp routes to the new EvmM0Portal. wM on BSC, Ethereum, and Linea remain on the existing EvmM0PortalLite portal.

--- a/.changeset/mighty-pens-provide.md
+++ b/.changeset/mighty-pens-provide.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': patch
 ---
 
-Migrate wM (Mantra, Soneium) and USDSC (Ethereum, Soneium) warp routes to the new EvmM0Portal. wM on BSC, Ethereum, and Linea remain on the existing EvmM0PortalLite portal.
+Migrate wM (Mantra, Soneium) and USDSC (Ethereum, Soneium) warp routes to the new EvmM0Portal. Split wM into two route configs: wrapped-m (Ethereum/Mantra/Soneium on EvmM0Portal) and wrapped-m-portal-lite (BSC/Ethereum/Linea on EvmM0PortalLite, to be deprecated).

--- a/deployments/warp_routes/USDSC/usdsc-config.yaml
+++ b/deployments/warp_routes/USDSC/usdsc-config.yaml
@@ -1,26 +1,26 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
   # M0 USDSC on Ethereum (HubPortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+  - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
     chainName: ethereum
     collateralAddressOrDenom: "0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a"
     connections:
-      - token: ethereum|soneium|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|soneium|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
     decimals: 6
     logoURI: /deployments/warp_routes/USDSC/logo.svg
     name: Startale USD
-    standard: EvmM0PortalLite
+    standard: EvmM0Portal
     symbol: USDSC
     warpRouteId: USDSC/usdsc
   # M0 USDSC on Soneium (SpokePortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+  - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
     chainName: soneium
     collateralAddressOrDenom: "0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a"
     connections:
-      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
     decimals: 6
     logoURI: /deployments/warp_routes/USDSC/logo.svg
     name: Startale USD
-    standard: EvmM0PortalLite
+    standard: EvmM0Portal
     symbol: USDSC
     warpRouteId: USDSC/usdsc

--- a/deployments/warp_routes/wM/wrapped-m-config.yaml
+++ b/deployments/warp_routes/wM/wrapped-m-config.yaml
@@ -19,12 +19,23 @@ tokens:
     collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
     connections:
       - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      - token: ethereum|mantra|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      - token: ethereum|soneium|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
     decimals: 6
     logoURI: /deployments/warp_routes/wM/logo.svg
     name: WrappedM by M^0
     standard: EvmM0PortalLite
+    symbol: wM
+    warpRouteId: wM/wrapped-m
+  # M0 wM on Ethereum (HubPortal)
+  - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
+    chainName: ethereum
+    collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+    connections:
+      - token: ethereum|mantra|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
+      - token: ethereum|soneium|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
+    decimals: 6
+    logoURI: /deployments/warp_routes/wM/logo.svg
+    name: WrappedM by M^0
+    standard: EvmM0Portal
     symbol: wM
     warpRouteId: wM/wrapped-m
   # M0 wM on Linea (SpokePortal)
@@ -40,26 +51,26 @@ tokens:
     symbol: wM
     warpRouteId: wM/wrapped-m
   # M0 wM on Mantra (SpokePortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+  - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
     chainName: mantra
     collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
     connections:
-      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
     decimals: 6
     logoURI: /deployments/warp_routes/wM/logo.svg
     name: WrappedM by M^0
-    standard: EvmM0PortalLite
+    standard: EvmM0Portal
     symbol: wM
     warpRouteId: wM/wrapped-m
   # M0 wM on Soneium (SpokePortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+  - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
     chainName: soneium
     collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
     connections:
-      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
     decimals: 6
     logoURI: /deployments/warp_routes/wM/logo.svg
     name: WrappedM by M^0
-    standard: EvmM0PortalLite
+    standard: EvmM0Portal
     symbol: wM
     warpRouteId: wM/wrapped-m

--- a/deployments/warp_routes/wM/wrapped-m-config.yaml
+++ b/deployments/warp_routes/wM/wrapped-m-config.yaml
@@ -1,30 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  # M0 wM on BSC (SpokePortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-    chainName: bsc
-    collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-    connections:
-      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-    decimals: 6
-    logoURI: /deployments/warp_routes/wM/logo.svg
-    name: WrappedM by M^0
-    standard: EvmM0PortalLite
-    symbol: wM
-    warpRouteId: wM/wrapped-m
-  # M0 wM on Ethereum (HubPortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-    chainName: ethereum
-    collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-    connections:
-      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-    decimals: 6
-    logoURI: /deployments/warp_routes/wM/logo.svg
-    name: WrappedM by M^0
-    standard: EvmM0PortalLite
-    symbol: wM
-    warpRouteId: wM/wrapped-m
   # M0 wM on Ethereum (HubPortal)
   - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
     chainName: ethereum
@@ -36,18 +11,6 @@ tokens:
     logoURI: /deployments/warp_routes/wM/logo.svg
     name: WrappedM by M^0
     standard: EvmM0Portal
-    symbol: wM
-    warpRouteId: wM/wrapped-m
-  # M0 wM on Linea (SpokePortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-    chainName: linea
-    collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-    connections:
-      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-    decimals: 6
-    logoURI: /deployments/warp_routes/wM/logo.svg
-    name: WrappedM by M^0
-    standard: EvmM0PortalLite
     symbol: wM
     warpRouteId: wM/wrapped-m
   # M0 wM on Mantra (SpokePortal)

--- a/deployments/warp_routes/wM/wrapped-m-portal-lite-config.yaml
+++ b/deployments/warp_routes/wM/wrapped-m-portal-lite-config.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  # M0 wM on BSC (SpokePortal)
+  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    chainName: bsc
+    collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+    connections:
+      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+    decimals: 6
+    logoURI: /deployments/warp_routes/wM/logo.svg
+    name: WrappedM by M^0
+    standard: EvmM0PortalLite
+    symbol: wM
+    warpRouteId: wM/wrapped-m-portal-lite
+  # M0 wM on Ethereum (HubPortal)
+  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    chainName: ethereum
+    collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+    connections:
+      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+    decimals: 6
+    logoURI: /deployments/warp_routes/wM/logo.svg
+    name: WrappedM by M^0
+    standard: EvmM0PortalLite
+    symbol: wM
+    warpRouteId: wM/wrapped-m-portal-lite
+  # M0 wM on Linea (SpokePortal)
+  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    chainName: linea
+    collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+    connections:
+      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+    decimals: 6
+    logoURI: /deployments/warp_routes/wM/logo.svg
+    name: WrappedM by M^0
+    standard: EvmM0PortalLite
+    symbol: wM
+    warpRouteId: wM/wrapped-m-portal-lite

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -10276,26 +10276,26 @@ USDS/ethereum-igra:
       symbol: USDS
 USDSC/usdsc:
   tokens:
-    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
+    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
       chainName: ethereum
       collateralAddressOrDenom: "0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a"
       connections:
-        - token: ethereum|soneium|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
+        - token: ethereum|soneium|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
       decimals: 6
       logoURI: /deployments/warp_routes/USDSC/logo.svg
       name: Startale USD
-      standard: EvmM0Portal
+      standard: EvmM0PortalLite
       symbol: USDSC
       warpRouteId: USDSC/usdsc
-    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
+    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
       chainName: soneium
       collateralAddressOrDenom: "0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a"
       connections:
-        - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
+        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
       decimals: 6
       logoURI: /deployments/warp_routes/USDSC/logo.svg
       name: Startale USD
-      standard: EvmM0Portal
+      standard: EvmM0PortalLite
       symbol: USDSC
       warpRouteId: USDSC/usdsc
 USDStar/solanamainnet-sonicsvm:
@@ -14136,42 +14136,6 @@ tUSD/eclipsemainnet-ethereum:
       symbol: tUSD
 wM/wrapped-m:
   tokens:
-    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-      connections:
-        - token: ethereum|mantra|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
-        - token: ethereum|soneium|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
-      decimals: 6
-      logoURI: /deployments/warp_routes/wM/logo.svg
-      name: WrappedM by M^0
-      standard: EvmM0Portal
-      symbol: wM
-      warpRouteId: wM/wrapped-m
-    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
-      chainName: mantra
-      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-      connections:
-        - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
-      decimals: 6
-      logoURI: /deployments/warp_routes/wM/logo.svg
-      name: WrappedM by M^0
-      standard: EvmM0Portal
-      symbol: wM
-      warpRouteId: wM/wrapped-m
-    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
-      chainName: soneium
-      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-      connections:
-        - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
-      decimals: 6
-      logoURI: /deployments/warp_routes/wM/logo.svg
-      name: WrappedM by M^0
-      standard: EvmM0Portal
-      symbol: wM
-      warpRouteId: wM/wrapped-m
-wM/wrapped-m-portal-lite:
-  tokens:
     - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
       chainName: bsc
       collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
@@ -14183,18 +14147,20 @@ wM/wrapped-m-portal-lite:
       name: WrappedM by M^0
       standard: EvmM0PortalLite
       symbol: wM
-      warpRouteId: wM/wrapped-m-portal-lite
+      warpRouteId: wM/wrapped-m
     - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
       chainName: ethereum
       collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
       connections:
         - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+        - token: ethereum|mantra|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+        - token: ethereum|soneium|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
       decimals: 6
       logoURI: /deployments/warp_routes/wM/logo.svg
       name: WrappedM by M^0
       standard: EvmM0PortalLite
       symbol: wM
-      warpRouteId: wM/wrapped-m-portal-lite
+      warpRouteId: wM/wrapped-m
     - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
       chainName: linea
       collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
@@ -14205,7 +14171,29 @@ wM/wrapped-m-portal-lite:
       name: WrappedM by M^0
       standard: EvmM0PortalLite
       symbol: wM
-      warpRouteId: wM/wrapped-m-portal-lite
+      warpRouteId: wM/wrapped-m
+    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+      chainName: mantra
+      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+      connections:
+        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      decimals: 6
+      logoURI: /deployments/warp_routes/wM/logo.svg
+      name: WrappedM by M^0
+      standard: EvmM0PortalLite
+      symbol: wM
+      warpRouteId: wM/wrapped-m
+    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+      chainName: soneium
+      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+      connections:
+        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      decimals: 6
+      logoURI: /deployments/warp_routes/wM/logo.svg
+      name: WrappedM by M^0
+      standard: EvmM0PortalLite
+      symbol: wM
+      warpRouteId: wM/wrapped-m
 weETHs/eclipsemainnet-ethereum:
   tokens:
     - addressOrDenom: 7Zx4wU1QAw98MfvnPFqRh1oyumek7G5VAX6TKB3U1tcn

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -10276,26 +10276,26 @@ USDS/ethereum-igra:
       symbol: USDS
 USDSC/usdsc:
   tokens:
-    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
       chainName: ethereum
       collateralAddressOrDenom: "0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a"
       connections:
-        - token: ethereum|soneium|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+        - token: ethereum|soneium|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
       decimals: 6
       logoURI: /deployments/warp_routes/USDSC/logo.svg
       name: Startale USD
-      standard: EvmM0PortalLite
+      standard: EvmM0Portal
       symbol: USDSC
       warpRouteId: USDSC/usdsc
-    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
       chainName: soneium
       collateralAddressOrDenom: "0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a"
       connections:
-        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+        - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
       decimals: 6
       logoURI: /deployments/warp_routes/USDSC/logo.svg
       name: Startale USD
-      standard: EvmM0PortalLite
+      standard: EvmM0Portal
       symbol: USDSC
       warpRouteId: USDSC/usdsc
 USDStar/solanamainnet-sonicsvm:
@@ -14153,12 +14153,22 @@ wM/wrapped-m:
       collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
       connections:
         - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-        - token: ethereum|mantra|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-        - token: ethereum|soneium|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
       decimals: 6
       logoURI: /deployments/warp_routes/wM/logo.svg
       name: WrappedM by M^0
       standard: EvmM0PortalLite
+      symbol: wM
+      warpRouteId: wM/wrapped-m
+    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+      connections:
+        - token: ethereum|mantra|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
+        - token: ethereum|soneium|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
+      decimals: 6
+      logoURI: /deployments/warp_routes/wM/logo.svg
+      name: WrappedM by M^0
+      standard: EvmM0Portal
       symbol: wM
       warpRouteId: wM/wrapped-m
     - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
@@ -14172,26 +14182,26 @@ wM/wrapped-m:
       standard: EvmM0PortalLite
       symbol: wM
       warpRouteId: wM/wrapped-m
-    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
       chainName: mantra
       collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
       connections:
-        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+        - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
       decimals: 6
       logoURI: /deployments/warp_routes/wM/logo.svg
       name: WrappedM by M^0
-      standard: EvmM0PortalLite
+      standard: EvmM0Portal
       symbol: wM
       warpRouteId: wM/wrapped-m
-    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
       chainName: soneium
       collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
       connections:
-        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+        - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
       decimals: 6
       logoURI: /deployments/warp_routes/wM/logo.svg
       name: WrappedM by M^0
-      standard: EvmM0PortalLite
+      standard: EvmM0Portal
       symbol: wM
       warpRouteId: wM/wrapped-m
 weETHs/eclipsemainnet-ethereum:

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -14136,29 +14136,6 @@ tUSD/eclipsemainnet-ethereum:
       symbol: tUSD
 wM/wrapped-m:
   tokens:
-    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-      chainName: bsc
-      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-      connections:
-        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-        - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      decimals: 6
-      logoURI: /deployments/warp_routes/wM/logo.svg
-      name: WrappedM by M^0
-      standard: EvmM0PortalLite
-      symbol: wM
-      warpRouteId: wM/wrapped-m
-    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-      chainName: ethereum
-      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-      connections:
-        - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      decimals: 6
-      logoURI: /deployments/warp_routes/wM/logo.svg
-      name: WrappedM by M^0
-      standard: EvmM0PortalLite
-      symbol: wM
-      warpRouteId: wM/wrapped-m
     - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
       chainName: ethereum
       collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
@@ -14169,17 +14146,6 @@ wM/wrapped-m:
       logoURI: /deployments/warp_routes/wM/logo.svg
       name: WrappedM by M^0
       standard: EvmM0Portal
-      symbol: wM
-      warpRouteId: wM/wrapped-m
-    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-      chainName: linea
-      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
-      connections:
-        - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      decimals: 6
-      logoURI: /deployments/warp_routes/wM/logo.svg
-      name: WrappedM by M^0
-      standard: EvmM0PortalLite
       symbol: wM
       warpRouteId: wM/wrapped-m
     - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
@@ -14204,6 +14170,42 @@ wM/wrapped-m:
       standard: EvmM0Portal
       symbol: wM
       warpRouteId: wM/wrapped-m
+wM/wrapped-m-portal-lite:
+  tokens:
+    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+      chainName: bsc
+      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+      connections:
+        - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+        - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      decimals: 6
+      logoURI: /deployments/warp_routes/wM/logo.svg
+      name: WrappedM by M^0
+      standard: EvmM0PortalLite
+      symbol: wM
+      warpRouteId: wM/wrapped-m-portal-lite
+    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+      chainName: ethereum
+      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+      connections:
+        - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      decimals: 6
+      logoURI: /deployments/warp_routes/wM/logo.svg
+      name: WrappedM by M^0
+      standard: EvmM0PortalLite
+      symbol: wM
+      warpRouteId: wM/wrapped-m-portal-lite
+    - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+      chainName: linea
+      collateralAddressOrDenom: "0x437cc33344a0B27A429f795ff6B469C72698B291"
+      connections:
+        - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      decimals: 6
+      logoURI: /deployments/warp_routes/wM/logo.svg
+      name: WrappedM by M^0
+      standard: EvmM0PortalLite
+      symbol: wM
+      warpRouteId: wM/wrapped-m-portal-lite
 weETHs/eclipsemainnet-ethereum:
   tokens:
     - addressOrDenom: 7Zx4wU1QAw98MfvnPFqRh1oyumek7G5VAX6TKB3U1tcn


### PR DESCRIPTION
### Description

- update WrappedM route between Ethereum and Mantra to use `EvmM0Portal` instead of  `EvmM0PortalLite`
- update WrappedM route between Ethereum and Soneium to use `EvmM0Portal` instead of  `EvmM0PortalLite`
- update USDSC route between Ethereum and Soneium to use `EvmM0Portal` instead of  `EvmM0PortalLite`

### Backward compatibility
No,  WrappedM route configs was split into 2: 
 - `wrapped-m` used on Ethereum, Mantra, Soneium via `EvmM0Portal`
 - `wrapped-m-portal-lite` used on Ethereum, BSC, and Linea via `EvmM0PortalLite`
 
 Eventually `EvmM0PortalLite` and `wrapped-m-portal-lite` will be deprecated, and all chains will migrate to `EvmM0Portal`
 
 ### Testing
