### PR TITLE
ci: use the published CLI for warp checks

### DIFF
--- a/.changeset/brave-trains-flow.md
+++ b/.changeset/brave-trains-flow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+CI warp route checks were switched from the Docker-based infra script to the published Hyperlane CLI, with the CLI version pinned to the registry's SDK dependency.

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -27,8 +27,14 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Determine Hyperlane package version
+        id: hyperlane-version
+        run: |
+          VERSION=$(node -p "const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); const version = pkg.dependencies?.['@hyperlane-xyz/sdk'] ?? pkg.devDependencies?.['@hyperlane-xyz/sdk']; if (!version) throw new Error('Missing @hyperlane-xyz/sdk dependency'); version;")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Install Hyperlane CLI
-        run: npm i -g @hyperlane-xyz/cli@latest
+        run: npm i -g @hyperlane-xyz/cli@${{ steps.hyperlane-version.outputs.version }}
 
       - name: Determine Base & Head SHA
         id: determine-base-sha
@@ -39,7 +45,7 @@ jobs:
       - name: Check Warp Deploy
         env:
           # Only set PR_NUMBER for non-fork PRs (enables PR commenting)
-          HYPERLANE_SKIP_VERSION_CHECK: '1'
+          HYPERLANE_SKIP_VERSION_CHECK: "1"
           PR_NUMBER: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.number || '' }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -30,7 +30,15 @@ jobs:
       - name: Determine Hyperlane package version
         id: hyperlane-version
         run: |
-          VERSION=$(node -p "const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); const version = pkg.dependencies?.['@hyperlane-xyz/sdk'] ?? pkg.devDependencies?.['@hyperlane-xyz/sdk']; if (!version) throw new Error('Missing @hyperlane-xyz/sdk dependency'); if (!/^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) throw new Error('Expected exact semver @hyperlane-xyz/sdk version, got ' + version); version;")
+          VERSION="$(jq -r '.dependencies["@hyperlane-xyz/sdk"] // .devDependencies["@hyperlane-xyz/sdk"] // empty' package.json)"
+          if [ -z "$VERSION" ]; then
+            echo "Missing @hyperlane-xyz/sdk dependency"
+            exit 1
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Expected exact semver @hyperlane-xyz/sdk version, got $VERSION"
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Install Hyperlane CLI

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -30,11 +30,13 @@ jobs:
       - name: Determine Hyperlane package version
         id: hyperlane-version
         run: |
-          VERSION=$(node -p "const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); const version = pkg.dependencies?.['@hyperlane-xyz/sdk'] ?? pkg.devDependencies?.['@hyperlane-xyz/sdk']; if (!version) throw new Error('Missing @hyperlane-xyz/sdk dependency'); version;")
+          VERSION=$(node -p "const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); const version = pkg.dependencies?.['@hyperlane-xyz/sdk'] ?? pkg.devDependencies?.['@hyperlane-xyz/sdk']; if (!version) throw new Error('Missing @hyperlane-xyz/sdk dependency'); if (!/^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) throw new Error(\`Expected exact semver @hyperlane-xyz/sdk version, got ${version}\`); version;")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Install Hyperlane CLI
-        run: npm i -g @hyperlane-xyz/cli@${{ steps.hyperlane-version.outputs.version }}
+        env:
+          HYPERLANE_CLI_VERSION: ${{ steps.hyperlane-version.outputs.version }}
+        run: npm i -g "@hyperlane-xyz/cli@${HYPERLANE_CLI_VERSION}"
 
       - name: Determine Base & Head SHA
         id: determine-base-sha

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -35,7 +35,7 @@ jobs:
             echo "Missing @hyperlane-xyz/sdk dependency"
             exit 1
           fi
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "Expected exact semver @hyperlane-xyz/sdk version, got $VERSION"
             exit 1
           fi

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version-file: .nvmrc
 
       - name: Install Hyperlane CLI
         run: npm i -g @hyperlane-xyz/cli@latest

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Determine Hyperlane package version
         id: hyperlane-version
         run: |
-          VERSION=$(node -p "const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); const version = pkg.dependencies?.['@hyperlane-xyz/sdk'] ?? pkg.devDependencies?.['@hyperlane-xyz/sdk']; if (!version) throw new Error('Missing @hyperlane-xyz/sdk dependency'); if (!/^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) throw new Error(\`Expected exact semver @hyperlane-xyz/sdk version, got ${version}\`); version;")
+          VERSION=$(node -p "const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8')); const version = pkg.dependencies?.['@hyperlane-xyz/sdk'] ?? pkg.devDependencies?.['@hyperlane-xyz/sdk']; if (!version) throw new Error('Missing @hyperlane-xyz/sdk dependency'); if (!/^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) throw new Error('Expected exact semver @hyperlane-xyz/sdk version, got ' + version); version;")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Install Hyperlane CLI

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -23,6 +23,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install Hyperlane CLI
+        run: npm i -g @hyperlane-xyz/cli@latest
+
       - name: Determine Base & Head SHA
         id: determine-base-sha
         run: |
@@ -32,6 +39,7 @@ jobs:
       - name: Check Warp Deploy
         env:
           # Only set PR_NUMBER for non-fork PRs (enables PR commenting)
+          HYPERLANE_SKIP_VERSION_CHECK: '1'
           PR_NUMBER: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.number || '' }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |

--- a/.github/workflows/check-warp-deploy.yaml
+++ b/.github/workflows/check-warp-deploy.yaml
@@ -44,7 +44,12 @@ jobs:
       - name: Install Hyperlane CLI
         env:
           HYPERLANE_CLI_VERSION: ${{ steps.hyperlane-version.outputs.version }}
-        run: npm i -g "@hyperlane-xyz/cli@${HYPERLANE_CLI_VERSION}"
+        run: |
+          if ! npm view "@hyperlane-xyz/cli@${HYPERLANE_CLI_VERSION}" version >/dev/null 2>&1; then
+            echo "No published @hyperlane-xyz/cli version ${HYPERLANE_CLI_VERSION}"
+            exit 1
+          fi
+          npm i -g "@hyperlane-xyz/cli@${HYPERLANE_CLI_VERSION}"
 
       - name: Determine Base & Head SHA
         id: determine-base-sha
@@ -54,8 +59,8 @@ jobs:
 
       - name: Check Warp Deploy
         env:
-          # Only set PR_NUMBER for non-fork PRs (enables PR commenting)
           HYPERLANE_SKIP_VERSION_CHECK: "1"
+          # Only set PR_NUMBER for non-fork PRs (enables PR commenting)
           PR_NUMBER: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.number || '' }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |

--- a/scripts/check-warp-deploy.sh
+++ b/scripts/check-warp-deploy.sh
@@ -46,17 +46,12 @@ EXIT_CODE=0
 for WARP_ROUTE_ID in $WARP_ROUTE_IDS; do
     export WARP_ROUTE_ID
     
-    # Check 1: Registry YAML vs on-chain (uses --forceRegistryConfig to read registry directly)
-    if docker run --rm \
-        -e REGISTRY_COMMIT=$HEAD_COMMIT \
-        -e CI=true \
-        ghcr.io/hyperlane-xyz/hyperlane-monorepo:main \
-        ./node_modules/.bin/tsx \
-        ./typescript/infra/scripts/check/check-deploy.ts \
-        -e mainnet3 \
-        -m warp \
-        --warpRouteId "$WARP_ROUTE_ID" \
-        --forceRegistryConfig; then
+    # Check 1: Registry YAML vs on-chain via published CLI
+    if hyperlane \
+        --registry "$(pwd)" \
+        -y \
+        warp check \
+        --warp-route-id "$WARP_ROUTE_ID"; then
       ONCHAIN_STATUS="✅"
     else
       ONCHAIN_STATUS="❌"


### PR DESCRIPTION
## Summary
- replace the registry on-chain warp check with the published Hyperlane CLI, pinned to the checked-in `@hyperlane-xyz/sdk` version
- derive that version from `package.json` with `jq`, validate it is exact semver, and verify the matching CLI version exists on npm before install
- install the CLI through an env var instead of direct shell interpolation and use `.nvmrc` for the workflow node version
- keep the monorepo image only for getter parity export
- skip the CLI startup version check in CI

## Testing
- `bash -n scripts/check-warp-deploy.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CI validation path and introduces dynamic CLI installation/pinning, which could cause workflow failures if version resolution or CLI behavior differs from the prior Docker-based check.
> 
> **Overview**
> **Switches CI warp route validation to the published `hyperlane` CLI.** The `check-warp-deploy` workflow now installs Node, derives an exact `@hyperlane-xyz/sdk` version from `package.json`, verifies a matching `@hyperlane-xyz/cli` release exists, and pins the installed CLI to that version (skipping the CLI startup version check in CI).
> 
> The `scripts/check-warp-deploy.sh` on-chain check is updated to run `hyperlane --registry . warp check` instead of executing the monorepo Docker-based infra script, while keeping the Docker export-based parity check for deploy YAMLs.
> 
> Adds a changeset documenting the CI behavior change for `@hyperlane-xyz/registry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 171102e436907ef816354bc81cb6995ef9b5c270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->