### PR TITLE
fix: tolerate registry overlay 404 misses

### DIFF
--- a/.changeset/tolerant-merged-registry.md
+++ b/.changeset/tolerant-merged-registry.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': patch
 ---
 
-Allow merged registries to ignore 404 misses from overlay registries during tolerant reads.
+Allow merged registries to ignore not-found misses during reads.

--- a/.changeset/tolerant-merged-registry.md
+++ b/.changeset/tolerant-merged-registry.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/registry': patch
+'@hyperlane-xyz/registry': minor
 ---
 
-Allow merged registries to ignore not-found misses during reads.
+Allow merged registries to tolerate recognized not-found read misses when another registry succeeds, while still throwing when every registry misses.

--- a/.changeset/tolerant-merged-registry.md
+++ b/.changeset/tolerant-merged-registry.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Allow merged registries to ignore 404 misses from overlay registries during tolerant reads.

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -19,10 +19,6 @@ import {
 import { objMerge } from '../utils.js';
 import { IRegistry, IRegistryMethods, RegistryContent, RegistryType } from './IRegistry.js';
 
-interface MultiRegistryReadOptions {
-  tolerateOverlayNotFound?: boolean;
-}
-
 export interface MergedRegistryOptions {
   registries: Array<IRegistry>;
   logger?: Logger;
@@ -52,9 +48,7 @@ export class MergedRegistry implements IRegistry {
   }
 
   async listRegistryContent(): Promise<RegistryContent> {
-    const results = await this.multiRegistryRead((r) => r.listRegistryContent(), {
-      tolerateOverlayNotFound: true,
-    });
+    const results = await this.multiRegistryRead((r) => r.listRegistryContent());
     return results.reduce((acc, content) => objMerge(acc, content), {
       chains: {},
       deployments: {
@@ -69,9 +63,7 @@ export class MergedRegistry implements IRegistry {
   }
 
   async getMetadata(): Promise<ChainMap<ChainMetadata>> {
-    const results = await this.multiRegistryRead((r) => r.getMetadata(), {
-      tolerateOverlayNotFound: true,
-    });
+    const results = await this.multiRegistryRead((r) => r.getMetadata());
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
@@ -80,9 +72,7 @@ export class MergedRegistry implements IRegistry {
   }
 
   async getAddresses(): Promise<ChainMap<ChainAddresses>> {
-    const results = await this.multiRegistryRead((r) => r.getAddresses(), {
-      tolerateOverlayNotFound: true,
-    });
+    const results = await this.multiRegistryRead((r) => r.getAddresses());
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
@@ -120,30 +110,22 @@ export class MergedRegistry implements IRegistry {
   }
 
   async getWarpRoute(id: WarpRouteId): Promise<WarpCoreConfig | null> {
-    const results = await this.multiRegistryRead((r) => r.getWarpRoute(id), {
-      tolerateOverlayNotFound: true,
-    });
+    const results = await this.multiRegistryRead((r) => r.getWarpRoute(id));
     return results.find((r) => !!r) || null;
   }
 
   async getWarpDeployConfig(id: WarpRouteId): Promise<WarpRouteDeployConfig | null> {
-    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfig(id), {
-      tolerateOverlayNotFound: true,
-    });
+    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfig(id));
     return results.find((r) => !!r) || null;
   }
 
   async getWarpRoutes(filter?: WarpRouteFilterParams): Promise<WarpRouteConfigMap> {
-    const results = await this.multiRegistryRead((r) => r.getWarpRoutes(filter), {
-      tolerateOverlayNotFound: true,
-    });
+    const results = await this.multiRegistryRead((r) => r.getWarpRoutes(filter));
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
   async getWarpDeployConfigs(filter?: WarpRouteFilterParams): Promise<WarpDeployConfigMap> {
-    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfigs(filter), {
-      tolerateOverlayNotFound: true,
-    });
+    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfigs(filter));
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
@@ -166,16 +148,13 @@ export class MergedRegistry implements IRegistry {
     );
   }
 
-  protected multiRegistryRead<R>(
-    readFn: (registry: IRegistry) => Promise<R> | R,
-    options?: MultiRegistryReadOptions,
-  ) {
+  protected multiRegistryRead<R>(readFn: (registry: IRegistry) => Promise<R> | R) {
     return Promise.all(
-      this.registries.map(async (registry, index) => {
+      this.registries.map(async (registry) => {
         try {
           return await readFn(registry);
         } catch (error) {
-          if (options?.tolerateOverlayNotFound && index > 0 && isHttpNotFoundError(error)) {
+          if (isNotFoundError(error)) {
             return null as R;
           }
           throw error;
@@ -213,14 +192,20 @@ export class MergedRegistry implements IRegistry {
   }
 }
 
-function isHttpNotFoundError(error: unknown): boolean {
+function isNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
-  const { status, statusCode, response } = error as {
+  const { code, message, status, statusCode, response } = error as {
+    code?: unknown;
+    message?: unknown;
     status?: unknown;
     statusCode?: unknown;
     response?: { status?: unknown; statusCode?: unknown };
   };
-  return [status, statusCode, response?.status, response?.statusCode].some(
-    (candidate) => Number(candidate) === 404,
+  return (
+    [status, statusCode, response?.status, response?.statusCode].some(
+      (candidate) => Number(candidate) === 404,
+    ) ||
+    code === 'ENOENT' ||
+    (typeof message === 'string' && /^File not found(?:\b|:)/i.test(message))
   );
 }

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -155,6 +155,9 @@ export class MergedRegistry implements IRegistry {
           return { ok: true as const, value: await readFn(registry) };
         } catch (error) {
           if (isNotFoundError(error)) {
+            this.logger.debug(
+              `Tolerating not-found read miss from ${registry.type} registry at ${registry.uri}`,
+            );
             return { ok: false as const, error };
           }
           throw error;

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -19,6 +19,10 @@ import {
 import { objMerge } from '../utils.js';
 import { IRegistry, IRegistryMethods, RegistryContent, RegistryType } from './IRegistry.js';
 
+interface MultiRegistryReadOptions {
+  tolerateOverlayNotFound?: boolean;
+}
+
 export interface MergedRegistryOptions {
   registries: Array<IRegistry>;
   logger?: Logger;
@@ -48,7 +52,9 @@ export class MergedRegistry implements IRegistry {
   }
 
   async listRegistryContent(): Promise<RegistryContent> {
-    const results = await this.multiRegistryRead((r) => r.listRegistryContent());
+    const results = await this.multiRegistryRead((r) => r.listRegistryContent(), {
+      tolerateOverlayNotFound: true,
+    });
     return results.reduce((acc, content) => objMerge(acc, content), {
       chains: {},
       deployments: {
@@ -63,7 +69,9 @@ export class MergedRegistry implements IRegistry {
   }
 
   async getMetadata(): Promise<ChainMap<ChainMetadata>> {
-    const results = await this.multiRegistryRead((r) => r.getMetadata());
+    const results = await this.multiRegistryRead((r) => r.getMetadata(), {
+      tolerateOverlayNotFound: true,
+    });
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
@@ -72,7 +80,9 @@ export class MergedRegistry implements IRegistry {
   }
 
   async getAddresses(): Promise<ChainMap<ChainAddresses>> {
-    const results = await this.multiRegistryRead((r) => r.getAddresses());
+    const results = await this.multiRegistryRead((r) => r.getAddresses(), {
+      tolerateOverlayNotFound: true,
+    });
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
@@ -110,22 +120,30 @@ export class MergedRegistry implements IRegistry {
   }
 
   async getWarpRoute(id: WarpRouteId): Promise<WarpCoreConfig | null> {
-    const results = await this.multiRegistryRead((r) => r.getWarpRoute(id));
+    const results = await this.multiRegistryRead((r) => r.getWarpRoute(id), {
+      tolerateOverlayNotFound: true,
+    });
     return results.find((r) => !!r) || null;
   }
 
   async getWarpDeployConfig(id: WarpRouteId): Promise<WarpRouteDeployConfig | null> {
-    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfig(id));
+    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfig(id), {
+      tolerateOverlayNotFound: true,
+    });
     return results.find((r) => !!r) || null;
   }
 
   async getWarpRoutes(filter?: WarpRouteFilterParams): Promise<WarpRouteConfigMap> {
-    const results = await this.multiRegistryRead((r) => r.getWarpRoutes(filter));
+    const results = await this.multiRegistryRead((r) => r.getWarpRoutes(filter), {
+      tolerateOverlayNotFound: true,
+    });
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
   async getWarpDeployConfigs(filter?: WarpRouteFilterParams): Promise<WarpDeployConfigMap> {
-    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfigs(filter));
+    const results = await this.multiRegistryRead((r) => r.getWarpDeployConfigs(filter), {
+      tolerateOverlayNotFound: true,
+    });
     return results.reduce((acc, content) => objMerge(acc, content), {});
   }
 
@@ -148,8 +166,22 @@ export class MergedRegistry implements IRegistry {
     );
   }
 
-  protected multiRegistryRead<R>(readFn: (registry: IRegistry) => Promise<R> | R) {
-    return Promise.all(this.registries.map(readFn));
+  protected multiRegistryRead<R>(
+    readFn: (registry: IRegistry) => Promise<R> | R,
+    options?: MultiRegistryReadOptions,
+  ) {
+    return Promise.all(
+      this.registries.map(async (registry, index) => {
+        try {
+          return await readFn(registry);
+        } catch (error) {
+          if (options?.tolerateOverlayNotFound && index > 0 && isHttpNotFoundError(error)) {
+            return null as R;
+          }
+          throw error;
+        }
+      }),
+    );
   }
 
   protected async multiRegistryWrite(
@@ -179,4 +211,16 @@ export class MergedRegistry implements IRegistry {
       logger: this.logger,
     });
   }
+}
+
+function isHttpNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const { status, statusCode, response } = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown; statusCode?: unknown };
+  };
+  return [status, statusCode, response?.status, response?.statusCode].some(
+    (candidate) => Number(candidate) === 404,
+  );
 }

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -152,15 +152,22 @@ export class MergedRegistry implements IRegistry {
     return Promise.all(
       this.registries.map(async (registry) => {
         try {
-          return await readFn(registry);
+          return { ok: true as const, value: await readFn(registry) };
         } catch (error) {
           if (isNotFoundError(error)) {
-            return null as R;
+            return { ok: false as const, error };
           }
           throw error;
         }
       }),
-    );
+    ).then((results) => {
+      const successResults = results.filter((result) => result.ok);
+      if (!successResults.length) {
+        const notFoundResult = results.find((result) => !result.ok);
+        if (notFoundResult) throw notFoundResult.error;
+      }
+      return results.map((result) => (result.ok ? result.value : (null as R)));
+    });
   }
 
   protected async multiRegistryWrite(

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -248,6 +248,8 @@ describe('Registry utilities', () => {
     const responseNotFoundError = (status: unknown = 404) =>
       Object.assign(new Error('not found'), { response: { status } });
 
+    const enoentError = () => Object.assign(new Error('missing file'), { code: 'ENOENT' });
+
     const httpError = () => Object.assign(new Error('server error'), { status: 500 });
 
     it('Merges metadata from multiple registries', async () => {
@@ -303,17 +305,16 @@ describe('Registry utilities', () => {
       });
     });
 
-    it('propagates 404 misses from the primary registry', async () => {
+    it('ignores 404 misses from the primary registry', async () => {
       const primaryRegistry = new PartialRegistry({});
       const overlayRegistry = new PartialRegistry({});
-      const error = notFoundError();
-      sinon.stub(primaryRegistry, 'getMetadata').throws(error);
+      sinon.stub(primaryRegistry, 'getMetadata').throws(notFoundError());
 
       const registry = new MergedRegistry({
         registries: [primaryRegistry, overlayRegistry],
       });
 
-      await expect(registry.getMetadata()).to.be.rejectedWith(error);
+      expect(await registry.getMetadata()).to.eql({});
     });
 
     it('propagates non-404 errors from overlay registries', async () => {
@@ -327,6 +328,22 @@ describe('Registry utilities', () => {
       });
 
       await expect(registry.getMetadata()).to.be.rejectedWith(error);
+    });
+
+    it('ignores filesystem missing file errors from overlay registries', async () => {
+      const primaryRegistry = new PartialRegistry({
+        chainMetadata: { ethereum: { chainId: 1, displayName: 'Ethereum' } },
+      });
+      const overlayRegistry = new PartialRegistry({});
+      sinon.stub(overlayRegistry, 'getMetadata').throws(enoentError());
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      expect(await registry.getMetadata()).to.eql({
+        ethereum: { chainId: 1, displayName: 'Ethereum' },
+      });
     });
 
     it('ignores 404 misses from overlay registries on collection reads', async () => {
@@ -345,11 +362,24 @@ describe('Registry utilities', () => {
       );
     });
 
-    it('keeps non-tolerant read paths fail-fast', async () => {
+    it('ignores not-found errors on logo reads', async () => {
       const primaryRegistry = new PartialRegistry({});
       const overlayRegistry = new PartialRegistry({});
-      const error = notFoundError();
-      sinon.stub(overlayRegistry, 'getChainLogoUri').rejects(error);
+      sinon.stub(primaryRegistry, 'getChainLogoUri').rejects(notFoundError());
+      sinon.stub(overlayRegistry, 'getChainLogoUri').resolves('logo.svg');
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      expect(await registry.getChainLogoUri('ethereum')).to.eql('logo.svg');
+    });
+
+    it('propagates non-not-found errors on logo reads', async () => {
+      const primaryRegistry = new PartialRegistry({});
+      const overlayRegistry = new PartialRegistry({});
+      const error = new Error('Method not implemented.');
+      sinon.stub(primaryRegistry, 'getChainLogoUri').rejects(error);
 
       const registry = new MergedRegistry({
         registries: [primaryRegistry, overlayRegistry],

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -307,14 +307,18 @@ describe('Registry utilities', () => {
 
     it('ignores 404 misses from the primary registry when another registry succeeds', async () => {
       const primaryRegistry = new PartialRegistry({});
-      const overlayRegistry = new PartialRegistry({});
+      const overlayRegistry = new PartialRegistry({
+        chainMetadata: { ethereum: { chainId: 1, displayName: 'Ethereum' } },
+      });
       sinon.stub(primaryRegistry, 'getMetadata').throws(notFoundError());
 
       const registry = new MergedRegistry({
         registries: [primaryRegistry, overlayRegistry],
       });
 
-      expect(await registry.getMetadata()).to.eql({});
+      expect(await registry.getMetadata()).to.eql({
+        ethereum: { chainId: 1, displayName: 'Ethereum' },
+      });
     });
 
     it('throws if all registries miss with not-found errors', async () => {

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { use as chaiUse, expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import sinon from 'sinon';
+import fs from 'fs';
+
 import { faker } from '@faker-js/faker';
 import {
   type ChainMetadata,
@@ -10,10 +8,18 @@ import {
   TokenType,
   TokenStandard,
 } from '@hyperlane-xyz/sdk';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { use as chaiUse, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import type { Logger } from 'pino';
-import fs from 'fs';
+import RandExp from 'randexp';
+import sinon from 'sinon';
+
 import { CHAIN_FILE_REGEX, WARP_ROUTE_ID_REGEX } from '../../src/consts.js';
+import { DEFAULT_GITHUB_REGISTRY, PROXY_DEPLOYED_URL } from '../../src/consts.js';
 import { FileSystemRegistry } from '../../src/fs/FileSystemRegistry.js';
+import { getRegistry } from '../../src/fs/registry-utils.js';
+import { BaseRegistry } from '../../src/registry/BaseRegistry.js';
 import { GITHUB_API_URL, GithubRegistry } from '../../src/registry/GithubRegistry.js';
 import {
   RegistryType,
@@ -23,11 +29,7 @@ import {
 import { MergedRegistry } from '../../src/registry/MergedRegistry.js';
 import { PartialRegistry } from '../../src/registry/PartialRegistry.js';
 import { ChainAddresses, WarpRouteId } from '../../src/types.js';
-import { getRegistry } from '../../src/fs/registry-utils.js';
-import { DEFAULT_GITHUB_REGISTRY, PROXY_DEPLOYED_URL } from '../../src/consts.js';
 import { parseGitHubPath } from '../../src/utils.js';
-import { BaseRegistry } from '../../src/registry/BaseRegistry.js';
-import RandExp from 'randexp';
 
 const GITHUB_REGISTRY_BRANCH = 'main';
 
@@ -240,6 +242,14 @@ describe('Registry utilities', () => {
   }
 
   describe('MergedRegistry', async () => {
+    const notFoundError = (status: unknown = 404) =>
+      Object.assign(new Error('not found'), { status });
+
+    const responseNotFoundError = (status: unknown = 404) =>
+      Object.assign(new Error('not found'), { response: { status } });
+
+    const httpError = () => Object.assign(new Error('server error'), { status: 500 });
+
     it('Merges metadata from multiple registries', async () => {
       const mergedMetadata = await mergedRegistry.getMetadata();
       const localMetadata = await localRegistry.getMetadata();
@@ -259,6 +269,91 @@ describe('Registry utilities', () => {
       expect(localAddresses['ethereum'].mailbox).to.not.eql(MOCK_ADDRESS);
       // Confirm other chains are not affected
       expect(localAddresses['arbitrum']).to.eql(localAddresses['arbitrum']);
+    });
+
+    it('ignores 404 misses from overlay registries on tolerant reads', async () => {
+      const primaryRegistry = new PartialRegistry({
+        chainMetadata: { ethereum: { chainId: 1, displayName: 'Ethereum' } },
+      });
+      const overlayRegistry = new PartialRegistry({});
+      sinon.stub(overlayRegistry, 'getMetadata').throws(notFoundError());
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      expect(await registry.getMetadata()).to.eql({
+        ethereum: { chainId: 1, displayName: 'Ethereum' },
+      });
+    });
+
+    it('ignores response-shaped string 404 misses from overlay registries', async () => {
+      const primaryRegistry = new PartialRegistry({
+        chainMetadata: { ethereum: { chainId: 1, displayName: 'Ethereum' } },
+      });
+      const overlayRegistry = new PartialRegistry({});
+      sinon.stub(overlayRegistry, 'getMetadata').throws(responseNotFoundError('404'));
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      expect(await registry.getMetadata()).to.eql({
+        ethereum: { chainId: 1, displayName: 'Ethereum' },
+      });
+    });
+
+    it('propagates 404 misses from the primary registry', async () => {
+      const primaryRegistry = new PartialRegistry({});
+      const overlayRegistry = new PartialRegistry({});
+      const error = notFoundError();
+      sinon.stub(primaryRegistry, 'getMetadata').throws(error);
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      await expect(registry.getMetadata()).to.be.rejectedWith(error);
+    });
+
+    it('propagates non-404 errors from overlay registries', async () => {
+      const primaryRegistry = new PartialRegistry({});
+      const overlayRegistry = new PartialRegistry({});
+      const error = httpError();
+      sinon.stub(overlayRegistry, 'getMetadata').throws(error);
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      await expect(registry.getMetadata()).to.be.rejectedWith(error);
+    });
+
+    it('ignores 404 misses from overlay registries on collection reads', async () => {
+      const primaryRegistry = new PartialRegistry({
+        chainMetadata: { ethereum: { chainId: 1 } },
+      });
+      const overlayRegistry = new PartialRegistry({});
+      sinon.stub(overlayRegistry, 'listRegistryContent').throws(notFoundError());
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      expect(await registry.listRegistryContent()).to.eql(primaryRegistry.listRegistryContent());
+    });
+
+    it('keeps non-tolerant read paths fail-fast', async () => {
+      const primaryRegistry = new PartialRegistry({});
+      const overlayRegistry = new PartialRegistry({});
+      const error = notFoundError();
+      sinon.stub(overlayRegistry, 'getChainLogoUri').rejects(error);
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      await expect(registry.getChainLogoUri('ethereum')).to.be.rejectedWith(error);
     });
   });
 

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -305,7 +305,7 @@ describe('Registry utilities', () => {
       });
     });
 
-    it('ignores 404 misses from the primary registry', async () => {
+    it('ignores 404 misses from the primary registry when another registry succeeds', async () => {
       const primaryRegistry = new PartialRegistry({});
       const overlayRegistry = new PartialRegistry({});
       sinon.stub(primaryRegistry, 'getMetadata').throws(notFoundError());
@@ -315,6 +315,20 @@ describe('Registry utilities', () => {
       });
 
       expect(await registry.getMetadata()).to.eql({});
+    });
+
+    it('throws if all registries miss with not-found errors', async () => {
+      const primaryRegistry = new PartialRegistry({});
+      const overlayRegistry = new PartialRegistry({});
+      const error = notFoundError();
+      sinon.stub(primaryRegistry, 'getMetadata').throws(error);
+      sinon.stub(overlayRegistry, 'getMetadata').throws(enoentError());
+
+      const registry = new MergedRegistry({
+        registries: [primaryRegistry, overlayRegistry],
+      });
+
+      await expect(registry.getMetadata()).to.be.rejectedWith(error);
     });
 
     it('propagates non-404 errors from overlay registries', async () => {

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -340,7 +340,9 @@ describe('Registry utilities', () => {
         registries: [primaryRegistry, overlayRegistry],
       });
 
-      expect(await registry.listRegistryContent()).to.eql(primaryRegistry.listRegistryContent());
+      expect(await registry.listRegistryContent()).to.eql(
+        await primaryRegistry.listRegistryContent(),
+      );
     });
 
     it('keeps non-tolerant read paths fail-fast', async () => {


### PR DESCRIPTION
## Summary

- Update `MergedRegistry` merged read paths to tolerate recognized not-found misses across registry types, including HTTP-ish `404` shapes and filesystem-style missing-file errors.
- Return partial results when at least one registry resolves successfully, and throw a representative not-found error when every registry misses.
- Preserve propagation of non-not-found errors, add focused unit coverage, and ship this as a minor registry change.

Context: supersedes the monorepo patch approach from hyperlane-xyz/hyperlane-monorepo#8557 after review feedback to fix the registry package directly.

## Backward compatibility

- Existing successful merged reads continue to merge/return data.
- Recognized not-found misses are now tolerated across merged read paths when another registry has data.
- If every registry misses with a recognized not-found, the merged read still throws instead of silently returning an empty/null result.
- Non-not-found errors still propagate.

## Test plan

- `pnpm run build && pnpm exec mocha --require dotenv/config --config .mocharc.json './test/unit/registry.test.ts' --grep 'MergedRegistry' --exit`
- `pnpm run lint`
- `pnpm exec oxfmt --check src/registry/MergedRegistry.ts test/unit/registry.test.ts`
