### PR TITLE
feat: add WETH/ethereum-igra warp route

### DIFF
--- a/.changeset/add-weth-ethereum-igra.md
+++ b/.changeset/add-weth-ethereum-igra.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+added WETH warp route on ethereum and igra

--- a/deployments/warp_routes/WETH/ethereum-igra-config.yaml
+++ b/deployments/warp_routes/WETH/ethereum-igra-config.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x69790024D44504F05973E127197E6df17e283859"
+    chainName: igra
+    connections:
+      - token: ethereum|ethereum|0x4eB3afF1A39a6477CA84b01B8e26B0f7aEEAE9D2
+    decimals: 18
+    logoURI: /deployments/warp_routes/WETH/logo.svg
+    name: Wrapped Ether
+    standard: EvmHypSynthetic
+    symbol: WETH
+  - addressOrDenom: "0x4eB3afF1A39a6477CA84b01B8e26B0f7aEEAE9D2"
+    chainName: ethereum
+    coinGeckoId: weth
+    collateralAddressOrDenom: "0x2371e134e3455e0593363cBF89d3b6cf53740618"
+    connections:
+      - token: ethereum|igra|0x69790024D44504F05973E127197E6df17e283859
+    decimals: 18
+    logoURI: /deployments/warp_routes/WETH/logo.svg
+    name: Wrapped Ether
+    standard: EvmHypOwnerCollateral
+    symbol: WETH

--- a/deployments/warp_routes/WETH/ethereum-igra-deploy.yaml
+++ b/deployments/warp_routes/WETH/ethereum-igra-deploy.yaml
@@ -1,0 +1,24 @@
+ethereum:
+  decimals: 18
+  gas: 300000
+  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
+  name: Wrapped Ether
+  owner: "0x442f580802aDa1B1E83DCaf103682C59dAEe904E"
+  symbol: WETH
+  token: "0x2371e134e3455e0593363cBF89d3b6cf53740618"
+  type: collateralVault
+igra:
+  decimals: 18
+  mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
+  name: Wrapped Ether
+  owner: "0xe1C9B631fD776442b7E2c91a58C6d713Bb13FF03"
+  symbol: WETH
+  tokenFee:
+    feeContracts:
+      ethereum:
+        bps: 6
+        owner: "0x42cb788529463B1F41de9E3cd3d2906930aCd32F"
+        type: LinearFee
+    owner: "0x42cb788529463B1F41de9E3cd3d2906930aCd32F"
+    type: RoutingFee
+  type: synthetic


### PR DESCRIPTION
## Summary

Adds the `WETH/ethereum-igra` warp route.

| Field | Value |
| ----- | ----- |
| **Linear** | https://linear.app/hyperlane-xyz/issue/AW-551/igra-owner-yield-morpho-gauntlet-weth |
| **Token** | Wrapped Ether (WETH) |
| **Route type** | collateralVault (ethereum) → synthetic (igra) |
| **Chains** | ethereum (collateralVault), igra (synthetic) |
| **Decimals** | 18 |
| **Warp fee** | 6bps (igra → ethereum) |
| **Owners** | ethereum: `0x442f580802aDa1B1E83DCaf103682C59dAEe904E`, igra: `0xe1C9B631fD776442b7E2c91a58C6d713Bb13FF03` |

### Contracts deployed

| Chain | Contract | Address |
| ----- | -------- | ------- |
| ethereum | HypERC4626OwnerCollateral (collateralVault) | `0x4eB3afF1A39a6477CA84b01B8e26B0f7aEEAE9D2` |
| igra | HypSynthetic | `0x69790024D44504F05973E127197E6df17e283859` |

### Test transfers

| From | To | Status |
| ---- | -- | ------ |
| ethereum | igra | ✅ |
| igra | ethereum | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)