### PR TITLE
fix(chains): fix hyperevm blockexplorer api url + add monadscan explorer info

### DIFF
--- a/.changeset/thick-oranges-dress.md
+++ b/.changeset/thick-oranges-dress.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Removed v2 suffix from hyperevm block explorer api url + added monadscan explorer info

--- a/chains/hyperevm/metadata.yaml
+++ b/chains/hyperevm/metadata.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://www.hyperscan.com/api/
+  - apiUrl: https://www.hyperscan.com/api
     family: blockscout
     name: HyperEVM Explorer
     url: https://www.hyperscan.com

--- a/chains/hyperevm/metadata.yaml
+++ b/chains/hyperevm/metadata.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://www.hyperscan.com/api/v2
+  - apiUrl: https://www.hyperscan.com/api/
     family: blockscout
     name: HyperEVM Explorer
     url: https://www.hyperscan.com

--- a/chains/monad/metadata.yaml
+++ b/chains/monad/metadata.yaml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://api.etherscan.io/v2/api?chainid=143
-    apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
+  - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
+    apiUrl: https://api.etherscan.io/v2/api?chainid=143
     family: etherscan
     name: MonadScan
-    url: https://monadscan.com/
+    url: https://monadscan.com
   - apiUrl: https://mainnet-beta.monvision.io/api
     family: other
     name: Monad Explorer

--- a/chains/monad/metadata.yaml
+++ b/chains/monad/metadata.yaml
@@ -1,5 +1,10 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
+  - apiUrl: https://api.etherscan.io/v2/api?chainid=143
+    apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
+    family: etherscan
+    name: MonadScan
+    url: https://monadscan.com/
   - apiUrl: https://mainnet-beta.monvision.io/api
     family: other
     name: Monad Explorer


### PR DESCRIPTION
### Description

Remove v2 suffix from hyperevm block explorer api + add monadscan info

### Backward compatibility

- yes

### Testing

- Cli locally
