### PR TITLE
feat: add missing scale fields to warp route config files

### DIFF
--- a/.changeset/add-missing-scale-configs.md
+++ b/.changeset/add-missing-scale-configs.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Added missing scale fields to warp route config files for TRUMP, USDC (aleo, carrchain, matchain), USDT (aleo, carrchain, eclipsemainnet), and WBTC (carrchain) routes. These are needed by the UI and SDK to correctly compute destination amounts for routes with different decimals.

--- a/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-config.yaml
+++ b/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-config.yaml
@@ -91,6 +91,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/TRUMP/logo.png
     name: OFFICIAL TRUMP
+    scale: 1000000000000
     standard: SealevelHypCollateral
     symbol: TRUMP
   - addressOrDenom: "0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922"

--- a/deployments/warp_routes/USDC/aleo-config.yaml
+++ b/deployments/warp_routes/USDC/aleo-config.yaml
@@ -13,6 +13,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: AleoHypSynthetic
     symbol: USDC
   - addressOrDenom: "0x1FdA66FA15A261F01F1E09228D41bD0A806d7529"
@@ -31,6 +32,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0x1FdA66FA15A261F01F1E09228D41bD0A806d7529"
@@ -49,6 +51,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0xB46930ca998587A95D9Ee000FA73A071ADD56B64"
@@ -67,6 +70,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0x5284D803a4563DC5eE83feA80c688b096d70eb75"
@@ -85,6 +89,7 @@ tokens:
     decimals: 18
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0x78Ac7FECD1857f5BEEe98AB39096c9781F976D97"
@@ -103,6 +108,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0x1FdA66FA15A261F01F1E09228D41bD0A806d7529"
@@ -121,6 +127,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0x1FdA66FA15A261F01F1E09228D41bD0A806d7529"
@@ -139,6 +146,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: EiUymjh3vJ2486ozY24s1A1YWXoH6QnSGjWuP95ph35G
@@ -157,5 +165,6 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: SealevelHypCollateral
     symbol: USDC

--- a/deployments/warp_routes/USDC/carrchain-config.yaml
+++ b/deployments/warp_routes/USDC/carrchain-config.yaml
@@ -19,6 +19,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypSynthetic
     symbol: USDC
   - addressOrDenom: "0x4c8adAde648D26d2c3245b2067ab08c5A3f9e998"
@@ -31,5 +32,6 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC

--- a/deployments/warp_routes/USDC/matchain-config.yaml
+++ b/deployments/warp_routes/USDC/matchain-config.yaml
@@ -11,6 +11,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0x1Bf82F7C3238d37d31bAc741DE95bbbf47E42001"
@@ -37,6 +38,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDC
   - addressOrDenom: "0x6D1a81c6CB65B1f892FD0eb8624e90B102628C94"

--- a/deployments/warp_routes/USDT/aleo-config.yaml
+++ b/deployments/warp_routes/USDT/aleo-config.yaml
@@ -9,6 +9,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale: 1000000000000
     standard: AleoHypSynthetic
     symbol: USDT
   - addressOrDenom: "0x1FdA66FA15A261F01F1E09228D41bD0A806d7529"
@@ -23,6 +24,7 @@ tokens:
     decimals: 18
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale: 1
     standard: EvmHypCollateral
     symbol: USDT
   - addressOrDenom: "0x3C2064D78e4578E8F936E3db42aEF044E33FBF31"
@@ -37,6 +39,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDT
   - addressOrDenom: "0x36E437699E3658396Bf6229ddDaE54884cf28779"
@@ -51,6 +54,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USD₮0
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USD₮0
   - addressOrDenom: GZ5zWtLNbQ2qJPymkS9My4AYatQx5HV7MQ9f68vG6GNi
@@ -65,5 +69,6 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale: 1000000000000
     standard: SealevelHypCollateral
     symbol: USDT

--- a/deployments/warp_routes/USDT/carrchain-config.yaml
+++ b/deployments/warp_routes/USDT/carrchain-config.yaml
@@ -19,6 +19,7 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale: 1000000000000
     standard: EvmHypSynthetic
     symbol: USDT
   - addressOrDenom: "0xC4aE629ABe0ce3de55B7DB8F6BeBf97d52AfE9f7"
@@ -31,5 +32,6 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDT

--- a/deployments/warp_routes/USDT/eclipsemainnet-config.yaml
+++ b/deployments/warp_routes/USDT/eclipsemainnet-config.yaml
@@ -14,6 +14,9 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USD₮0
+    scale:
+      numerator: 1
+      denominator: 1
     standard: EvmHypCollateral
     symbol: USD₮0
   - addressOrDenom: "0xc13d466B9E196AfdE472856923E857cc298EDf1b"
@@ -62,6 +65,9 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale:
+      numerator: 1
+      denominator: 1
     standard: EvmHypCollateral
     symbol: USDT
   - addressOrDenom: "0xa119087116aDC61ade063105644795cb7BC0009D"
@@ -77,6 +83,9 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT0
+    scale:
+      numerator: 1
+      denominator: 1
     standard: EvmHypCollateral
     symbol: USDT0
   - addressOrDenom: Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
@@ -107,5 +116,8 @@ tokens:
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    scale:
+      numerator: 1
+      denominator: 1
     standard: TronHypCollateral
     symbol: USDT

--- a/deployments/warp_routes/WBTC/carrchain-config.yaml
+++ b/deployments/warp_routes/WBTC/carrchain-config.yaml
@@ -19,6 +19,7 @@ tokens:
     decimals: 8
     logoURI: /deployments/warp_routes/WBTC/logo.svg
     name: Wrapped BTC
+    scale: 10000000000
     standard: EvmHypSynthetic
     symbol: WBTC
   - addressOrDenom: "0x7f3Ab91a586C34b7E0a7C0fDd2241C5F29d89a6e"
@@ -31,5 +32,6 @@ tokens:
     decimals: 8
     logoURI: /deployments/warp_routes/WBTC/logo.svg
     name: Wrapped BTC
+    scale: 10000000000
     standard: EvmHypCollateral
     symbol: WBTC


### PR DESCRIPTION
## Summary
Added missing `scale` fields from deploy configs to their corresponding warp route config files. The deploy configs had scale set for chains with different decimals, but the config files (used by the UI and SDK) were missing them.

Without scale in the config, the UI cannot correctly compute destination amounts for cross-decimal routes (e.g., BSC USDT 18-dec → Solana USDT 6-dec).

## Changes
28 scale fields added across 8 config files:

| Route | Chains | Scale |
|-------|--------|-------|
| TRUMP | solanamainnet | `1000000000000` |
| USDC/aleo | aleo, arbitrum, avalanche, base, bsc, ethereum, optimism, polygon, solanamainnet | `1000000000000` (bsc: `1`) |
| USDC/carrchain | carrchain, ethereum | `1000000000000` |
| USDC/matchain | base, ethereum | `1000000000000` |
| USDT/aleo | aleo, bsc, ethereum, hyperevm, solanamainnet | `1000000000000` (bsc: `1`) |
| USDT/carrchain | carrchain, ethereum | `1000000000000` |
| USDT/eclipsemainnet | arbitrum, ethereum, plasma, tron | `{numerator: 1, denominator: 1}` |
| WBTC/carrchain | carrchain, ethereum | `10000000000` |

## Related
- hyperlane-xyz/hyperlane-monorepo#8594 — SDK scale helpers
- hyperlane-xyz/hyperlane-warp-ui-template#1053 — UI scale display fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)