### PR TITLE
chore: update claude models

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ on:
     types: [created]
 
 env:
-  CLAUDE_OPUS_MODEL: claude-opus-4-6
+  CLAUDE_OPUS_MODEL: claude-opus-4-7
   CLAUDE_SONNET_MODEL: claude-sonnet-4-5
 
 concurrency:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CLAUDE_OPUS_MODEL: claude-opus-4-7
-  CLAUDE_SONNET_MODEL: claude-sonnet-4-5
+  CLAUDE_SONNET_MODEL: claude-sonnet-4-6
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}


### PR DESCRIPTION
Updates `CLAUDE_OPUS_MODEL` from `claude-opus-4-6` to `claude-opus-4-7`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that just switches model version strings; no product code or data handling logic is modified.
> 
> **Overview**
> Updates `.github/workflows/claude-code-review.yml` to bump the Claude models used by the automation: `CLAUDE_OPUS_MODEL` from `claude-opus-4-6` to `claude-opus-4-7` and `CLAUDE_SONNET_MODEL` from `claude-sonnet-4-5` to `claude-sonnet-4-6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b162211451c801573e98c9bed39ece0319cc908d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->