### PR TITLE
chore: update EZETH/renzo route

### DIFF
--- a/.changeset/five-trainers-switch.md
+++ b/.changeset/five-trainers-switch.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': minor
 ---
 
-Remove deposit capabilities for zircuit, blast, swell, taiko, berachain and sei for EZETH/renzo
+Remove withdrawal capabilities for zircuit, blast, swell, taiko, berachain and sei for EZETH/renzo

--- a/.changeset/five-trainers-switch.md
+++ b/.changeset/five-trainers-switch.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Remove deposit capabilities for zircuit, blast, swell, taiko, berachain and sei for EZETH/renzo

--- a/deployments/warp_routes/EZETH/renzo-prod-config.yaml
+++ b/deployments/warp_routes/EZETH/renzo-prod-config.yaml
@@ -63,28 +63,7 @@ tokens:
   - addressOrDenom: "0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD"
     chainName: berachain
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections:
-      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
-      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
-      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
-      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
-      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
-      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
-      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
-      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
+    connections: []
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -93,28 +72,7 @@ tokens:
   - addressOrDenom: "0x486b39378f99f073A3043C6Aabe8666876A8F3C5"
     chainName: blast
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections:
-      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
-      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
-      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
-      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
-      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
-      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
-      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
+    connections: []
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -424,28 +382,7 @@ tokens:
   - addressOrDenom: "0xE5163F148C82a0818545d5D34e30BC1EDA870cB9"
     chainName: sei
     collateralAddressOrDenom: "0x6DCfbF4729890043DFd34A93A2694E5303BA2703"
-    connections:
-      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
-      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
-      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
-      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
-      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
-      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
-      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
+    connections: []
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Restaked ETH on Sei
@@ -484,28 +421,7 @@ tokens:
   - addressOrDenom: "0xA166219dF110BDA97b91e65D4BB4Aae4159978b9"
     chainName: swell
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections:
-      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
-      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
-      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
-      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
-      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
-      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
-      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
-      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
+    connections: []
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -514,28 +430,7 @@ tokens:
   - addressOrDenom: "0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78"
     chainName: taiko
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections:
-      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
-      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
-      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
-      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
-      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
-      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
-      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
+    connections: []
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -634,28 +529,7 @@ tokens:
   - addressOrDenom: "0x2552516453368e42705D791F674b312b8b87CD9e"
     chainName: zircuit
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections:
-      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
-      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
-      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
-      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
-      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
-      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
-      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
-      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
-      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
+    connections: []
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH

--- a/deployments/warp_routes/EZETH/renzo-prod-config.yaml
+++ b/deployments/warp_routes/EZETH/renzo-prod-config.yaml
@@ -5,8 +5,6 @@ tokens:
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
     connections:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -17,14 +15,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -35,8 +29,6 @@ tokens:
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -47,14 +39,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -63,7 +51,23 @@ tokens:
   - addressOrDenom: "0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD"
     chainName: berachain
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections: []
+    connections:
+      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
+      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
+      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
+      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
+      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
+      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
+      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
+      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
+      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
+      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
+      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -72,7 +76,23 @@ tokens:
   - addressOrDenom: "0x486b39378f99f073A3043C6Aabe8666876A8F3C5"
     chainName: blast
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections: []
+    connections:
+      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
+      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
+      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
+      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
+      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
+      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
+      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
+      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
+      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
+      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
+      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -84,8 +104,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
@@ -95,14 +113,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -115,8 +129,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
@@ -126,14 +138,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -145,8 +153,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
@@ -156,14 +162,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -175,8 +177,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -186,14 +186,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -205,8 +201,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -216,14 +210,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -235,8 +225,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -246,14 +234,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restake ETH
@@ -265,8 +249,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -276,14 +258,10 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -295,8 +273,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -306,14 +282,10 @@ tokens:
       - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -325,8 +297,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -336,14 +306,10 @@ tokens:
       - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -355,8 +321,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -366,14 +330,10 @@ tokens:
       - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -382,7 +342,23 @@ tokens:
   - addressOrDenom: "0xE5163F148C82a0818545d5D34e30BC1EDA870cB9"
     chainName: sei
     collateralAddressOrDenom: "0x6DCfbF4729890043DFd34A93A2694E5303BA2703"
-    connections: []
+    connections:
+      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
+      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
+      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
+      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
+      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
+      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
+      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
+      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
+      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
+      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
+      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Restaked ETH on Sei
@@ -394,8 +370,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -406,13 +380,9 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -421,7 +391,23 @@ tokens:
   - addressOrDenom: "0xA166219dF110BDA97b91e65D4BB4Aae4159978b9"
     chainName: swell
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections: []
+    connections:
+      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
+      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
+      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
+      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
+      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
+      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
+      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
+      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
+      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
+      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
+      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -430,7 +416,23 @@ tokens:
   - addressOrDenom: "0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78"
     chainName: taiko
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections: []
+    connections:
+      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
+      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
+      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
+      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
+      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
+      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
+      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
+      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
+      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
+      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
+      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -442,8 +444,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -454,13 +454,9 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -472,8 +468,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -484,13 +478,9 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -502,8 +492,6 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
-      - token: ethereum|berachain|0x50105110D9e14Eb3d1e4BA7C32daC7f002AC50FD
-      - token: ethereum|blast|0x486b39378f99f073A3043C6Aabe8666876A8F3C5
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
@@ -514,13 +502,9 @@ tokens:
       - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
       - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
       - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
-      - token: ethereum|sei|0xE5163F148C82a0818545d5D34e30BC1EDA870cB9
       - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
-      - token: ethereum|swell|0xA166219dF110BDA97b91e65D4BB4Aae4159978b9
-      - token: ethereum|taiko|0x5eAFB1D4b5BDFaFE81715EeBcC7713e418C80E78
       - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
       - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
-      - token: ethereum|zircuit|0x2552516453368e42705D791F674b312b8b87CD9e
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH
@@ -529,7 +513,23 @@ tokens:
   - addressOrDenom: "0x2552516453368e42705D791F674b312b8b87CD9e"
     chainName: zircuit
     collateralAddressOrDenom: "0x2416092f143378750bb29b79eD961ab195CcEea5"
-    connections: []
+    connections:
+      - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
+      - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
+      - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
+      - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
+      - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
+      - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
+      - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
+      - token: ethereum|monad|0x7A911b0bD4F067FB8DAFF734A78E7A72865100d8
+      - token: ethereum|optimism|0xacEB607CdF59EB8022Cc0699eEF3eCF246d149e2
+      - token: ethereum|plasma|0xcD78A32Da8cfe9452cD2F50F547c11B979Afcf1b
+      - token: ethereum|stable|0x44664e635F803d75CeE68324Db4a23eb9B82eEA2
+      - token: ethereum|unichain|0xFf0247f72b0d7ceD319D8457dD30622a2bed78B5
+      - token: ethereum|worldchain|0x530b6596af6B6aB4D355d7Af2b5FF12eAeef8261
+      - token: ethereum|xlayer|0xB0A73DBA15454B3f84CeC0f88CFc7D88B6De59B3
     decimals: 18
     logoURI: /deployments/warp_routes/EZETH/logo.svg
     name: Renzo Restaked ETH


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Remove withdrawal capabilities for zircuit, blast, swell, taiko, berachain and sei for EZETH/renzo
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
