### PR TITLE
fix: fluent naming

### DIFF
--- a/.changeset/fix-fluent-naming.md
+++ b/.changeset/fix-fluent-naming.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+rename BLEND token name to Fluent

--- a/deployments/warp_routes/BLEND/metadata.json
+++ b/deployments/warp_routes/BLEND/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "BLEND",
+  "name": "Fluent",
   "symbol": "BLEND",
   "image": "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/deployments/warp_routes/BLEND/logo.svg"
 }


### PR DESCRIPTION
### Description

Rename BLEND to Fluent

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
