### PR TITLE
fix: fluent naming in configs

### DIFF
--- a/.changeset/fix-fluent-naming-configs.md
+++ b/.changeset/fix-fluent-naming-configs.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+rename BLEND token name to Fluent in configs

--- a/deployments/warp_routes/BLEND/fluent-config.yaml
+++ b/deployments/warp_routes/BLEND/fluent-config.yaml
@@ -3,7 +3,7 @@ tokens:
     standard: EvmHypCollateral
     decimals: 18
     symbol: BLEND
-    name: BLEND
+    name: Fluent
     addressOrDenom: "0x2bef59e84615371304bd731601f6344F5F304504"
     collateralAddressOrDenom: "0x1385B8f55A84f2BdA13EeD4099d29Eae03d553b2"
     logoURI: /deployments/warp_routes/BLEND/logo.svg
@@ -16,7 +16,7 @@ tokens:
       numerator: 1000000000
       denominator: 1
     symbol: BLEND
-    name: BLEND
+    name: Fluent
     addressOrDenom: 4iQfUG5RC58qAdwiLUUv3xmUnADviy4TQ1pqJVrSR2fE
     collateralAddressOrDenom: BWsnyEa1XtsNRdgPaDoA1WVUonF7BBGZTd2zc72NQsWT
     logoURI: /deployments/warp_routes/BLEND/logo.svg

--- a/deployments/warp_routes/BLEND/fluent-deploy.yaml
+++ b/deployments/warp_routes/BLEND/fluent-deploy.yaml
@@ -1,7 +1,7 @@
 fluent:
   decimals: 18
   mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
-  name: BLEND
+  name: Fluent
   owner: "0x0fE6B0dBaAD63CA2b967976149CcE29cF0B80b9e"
   symbol: BLEND
   token: "0x1385B8f55A84f2BdA13EeD4099d29Eae03d553b2"
@@ -12,7 +12,7 @@ solanamainnet:
   hook: "BhNcatUDC2D5JTyeaqrdSukiVFsEHK7e3hVmKMztwefv"
   mailbox: E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi
   metadataUri: "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/deployments/warp_routes/BLEND/metadata.json"
-  name: BLEND
+  name: Fluent
   owner: 8vEnzmRYSb8SuG371u4fj7mVS6ZGJbDmW3Vy36p2u4nE
   scale: 1000000000
   symbol: BLEND


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
