### PR TITLE
fix: vra scale

### DIFF
--- a/.changeset/metal-squids-deny.md
+++ b/.changeset/metal-squids-deny.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update scale for bsc in VRA/bsc-ethereum from 10 to 1

--- a/deployments/warp_routes/VRA/bsc-ethereum-config.yaml
+++ b/deployments/warp_routes/VRA/bsc-ethereum-config.yaml
@@ -9,7 +9,7 @@ tokens:
     decimals: 18
     logoURI: /deployments/warp_routes/VRA/logo.png
     name: VERA
-    scale: 10
+    scale: 1
     standard: EvmHypCollateral
     symbol: VRA
   - addressOrDenom: "0xde1bb600f24e9c6E49d51765fB836b070762e45D"


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Update scale for bsc in `VRA/bsc-ethereum` from 10 to 1
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
