### PR TITLE
feat: deprecate milkyway

### DIFF
--- a/.changeset/deprecate-milkyway.md
+++ b/.changeset/deprecate-milkyway.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Mark milkyway as deprecated.

--- a/chains/milkyway/metadata.yaml
+++ b/chains/milkyway/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 bech32Prefix: milk
 blocks:
   confirmations: 1


### PR DESCRIPTION
## Summary
- mark milkyway as deprecated (availability: disabled, reasons: [deprecated])
- add changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that disables the `milkyway` chain via `availability.status: disabled` and adds a changeset for a minor registry release.
> 
> **Overview**
> Marks `milkyway` as **deprecated** by adding `availability: { status: disabled, reasons: [deprecated] }` to its chain metadata, signaling consumers to treat it as unavailable.
> 
> Adds a Changesets entry to publish a *minor* bump of `@hyperlane-xyz/registry` documenting the deprecation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7709275849423a73e0dd2ac715fc78ec55920cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->