### PR TITLE
chore: enable USDT/eclipsemainnet missing connections

### DIFF
--- a/.changeset/red-pigs-watch.md
+++ b/.changeset/red-pigs-watch.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Enable missing connections for USDT/eclipsemainnet route

--- a/deployments/warp_routes/USDT/eclipsemainnet-config.yaml
+++ b/deployments/warp_routes/USDT/eclipsemainnet-config.yaml
@@ -6,9 +6,9 @@ tokens:
     collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
     connections:
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
+      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
       - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
-      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
@@ -25,6 +25,7 @@ tokens:
     collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
     connections:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
+      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
       - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
@@ -46,6 +47,7 @@ tokens:
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
       - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
+      - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT
@@ -58,8 +60,8 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
-      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
+      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
@@ -77,6 +79,7 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
+      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
@@ -95,9 +98,9 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
+      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
       - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
-      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
@@ -111,8 +114,10 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
+      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
       - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
+      - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Added missing connection for USDT/eclipsemainnet route
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
[bsc -> eclipse ](https://explorer.hyperlane.xyz/message/0xc1ea753f1471da87068eee842f3d49ac89ffb1bdb2adafbba00a9985f015859f)
[plasma -> eclipse](https://explorer.hyperlane.xyz/message/0x12e3108beafc1a54a0c31dd29d644b0d57ee718335569a70892ddba2c5e31ce6)
[tron -> eclipse ](https://explorer.hyperlane.xyz/message/0x8f4f2e21d1e38d17e5ad0ddb19c8d4e76a15ddeacb26b620c5134e4c568ec222)
[eclipse -> tron](https://explorer.hyperlane.xyz/message/0x58874dd41ede14a19c83a4992b77f4e1c14f8854a90d18951572642dc6e6064c)
[solana -> tron](https://explorer.hyperlane.xyz/message/0xa7abe24a8bca62231165a25f42baba9ccaa585c4a1dafb9ef94e85314e37ef6b)