### PR TITLE
chore: remove fraxtal connection in EZETH/renzo route

### DIFF
--- a/.changeset/wise-onions-bake.md
+++ b/.changeset/wise-onions-bake.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Removed connections to fraxtal in EZETH/renzo

--- a/deployments/warp_routes/EZETH/renzo-prod-config.yaml
+++ b/deployments/warp_routes/EZETH/renzo-prod-config.yaml
@@ -7,7 +7,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -31,7 +30,6 @@ tokens:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -56,7 +54,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -81,7 +78,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -105,7 +101,6 @@ tokens:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -130,7 +125,6 @@ tokens:
       - token: ethereum|arbitrum|0xB26bBfC6d1F469C821Ea25099017862e7368F4E8
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -179,7 +173,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
       - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
@@ -203,7 +196,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
       - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
@@ -227,7 +219,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|mode|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
@@ -251,7 +242,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -275,7 +265,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -299,7 +288,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -323,7 +311,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -347,7 +334,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -372,7 +358,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -396,7 +381,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -421,7 +405,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -446,7 +429,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -470,7 +452,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -494,7 +475,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8
@@ -518,7 +498,6 @@ tokens:
       - token: ethereum|base|0x2552516453368e42705D791F674b312b8b87CD9e
       - token: ethereum|bsc|0xE00C6185a5c19219F1FFeD213b4406a254968c26
       - token: ethereum|ethereum|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
-      - token: ethereum|fraxtal|0x3aE8635A4D581d40a6Edfb3f2ED480f9532994F5
       - token: ethereum|ink|0x698f0Acd19F4795B6C187d5187E1d0b62f6e257b
       - token: ethereum|linea|0xC59336D8edDa9722B4f1Ec104007191Ec16f7087
       - token: ethereum|megaeth|0xfCfF0E671624353414545Caf8330708c391cfcB8


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Removed connections to fraxtal in EZETH/renzo
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
