### PR TITLE
chore: apr 29 deprecations

### DIFF
--- a/.changeset/apr-29-deprecations.md
+++ b/.changeset/apr-29-deprecations.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Mark molten, artela, fluence, and zoramainnet as deprecated.

--- a/chains/artela/metadata.yaml
+++ b/chains/artela/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://artscan.artela.network/api
     family: blockscout

--- a/chains/fluence/metadata.yaml
+++ b/chains/fluence/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://blockscout.mainnet.fluence.dev/api
     family: blockscout

--- a/chains/molten/metadata.yaml
+++ b/chains/molten/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://molten.calderaexplorer.xyz/api
     family: blockscout

--- a/chains/zoramainnet/metadata.yaml
+++ b/chains/zoramainnet/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.zora.energy/api
     family: blockscout


### PR DESCRIPTION
## Summary
- Set `availability.status: disabled` (reason: deprecated) for molten, artela, fluence, zoramainnet. Other chains in the apr 29 deprecation batch already had this flag.

Companion: hyperlane-xyz/hyperlane-monorepo#8684 (disables agent roles + dedupes `chainsToSkip`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only deprecation flags plus a release changeset; low blast radius, with the main impact being consumers now treating these chains as unavailable.
> 
> **Overview**
> Marks the `molten`, `artela`, `fluence`, and `zoramainnet` chain entries as **deprecated/disabled** by adding `availability: { status: disabled, reasons: [deprecated] }` to their `metadata.yaml`.
> 
> Adds a changeset to publish a minor bump of `@hyperlane-xyz/registry` reflecting these deprecations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48036c8eef175523ce6b4e059fcb48c54cea376d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->