### PR TITLE
chore: add coinGeckoId to USDC/lukso

### DIFF
--- a/.changeset/three-cows-thank.md
+++ b/.changeset/three-cows-thank.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added coinGeckoId to USDC/lukso

--- a/deployments/warp_routes/USDC/lukso-config.yaml
+++ b/deployments/warp_routes/USDC/lukso-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0xE0C2e4F894D4Cd33626e33b24582559F3156E1Ab"
     chainName: ethereum
+    coinGeckoId: usd-coin
     collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|lukso|0xE0C2e4F894D4Cd33626e33b24582559F3156E1Ab


### PR DESCRIPTION
### Description

<!--
Summary of change.
Example: Add sepolia chain
-->
Added `coinGeckoId` to `USDC/lukso`
### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->
Yes
### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
