### PR TITLE
feat: set evmTarget: paris on legacy EVM chains

### DIFF
--- a/.changeset/legacy-evm-targets.md
+++ b/.changeset/legacy-evm-targets.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Set evmTarget: paris on chains whose EVM lacks PUSH0 or MCOPY/transient-storage opcodes (coti, electroneum, viction, chilizmainnet, incentiv, metis, prom, pulsechain, taiko, torus). The Hyperlane SDK uses this field to route IGP deployments through the paris-compatible bundle (MinimalInterchainGasPaymaster) on these chains while preserving the cancun-deployed default elsewhere.

--- a/chains/chilizmainnet/metadata.yaml
+++ b/chains/chilizmainnet/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Chiliz
 domainId: 1000088888
+evmTarget: paris
 gasCurrencyCoinGeckoId: chiliz
 name: chilizmainnet
 nativeToken:

--- a/chains/coti/metadata.yaml
+++ b/chains/coti/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Coti
 domainId: 2632500
+evmTarget: paris
 gasCurrencyCoinGeckoId: coti
 name: coti
 nativeToken:

--- a/chains/electroneum/metadata.yaml
+++ b/chains/electroneum/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Electroneum
 domainId: 52014
+evmTarget: paris
 gasCurrencyCoinGeckoId: electroneum
 name: electroneum
 nativeToken:

--- a/chains/incentiv/metadata.yaml
+++ b/chains/incentiv/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Incentiv
 domainId: 24101
+evmTarget: paris
 gasCurrencyCoinGeckoId: incentiv
 name: incentiv
 nativeToken:

--- a/chains/metis/metadata.yaml
+++ b/chains/metis/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Metis Andromeda
 domainId: 1088
+evmTarget: paris
 gasCurrencyCoinGeckoId: metis-token
 index:
   from: 17966274

--- a/chains/prom/metadata.yaml
+++ b/chains/prom/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Prom
 domainId: 227
+evmTarget: paris
 gasCurrencyCoinGeckoId: prometeus
 name: prom
 nativeToken:

--- a/chains/pulsechain/metadata.yaml
+++ b/chains/pulsechain/metadata.yaml
@@ -22,6 +22,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: PulseChain
 domainId: 369
+evmTarget: paris
 gasCurrencyCoinGeckoId: pulsechain
 name: pulsechain
 nativeToken:

--- a/chains/taiko/metadata.yaml
+++ b/chains/taiko/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Taiko
 domainId: 167000
+evmTarget: paris
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://transaction.safe.taiko.xyz
 name: taiko

--- a/chains/torus/metadata.yaml
+++ b/chains/torus/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Torus
 domainId: 21000
+evmTarget: paris
 gasCurrencyCoinGeckoId: torus
 name: torus
 nativeToken:

--- a/chains/viction/metadata.yaml
+++ b/chains/viction/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Viction
 domainId: 88
+evmTarget: paris
 gasCurrencyCoinGeckoId: tomochain
 name: viction
 nativeToken:


### PR DESCRIPTION
## Summary

Flags 10 chains whose EVM lacks PUSH0 or MCOPY/transient-storage so the Hyperlane SDK routes IGP deployments through the paris-compatible bundle (`MinimalInterchainGasPaymaster`) instead of the cancun default.

| EVM gap | Chains |
|---|---|
| PUSH0 unsupported (Shanghai+) | coti, electroneum, viction |
| MCOPY/transient storage unsupported (Cancun+) | chilizmainnet, incentiv, metis, prom, pulsechain, taiko, torus |

All 10 chains get `evmTarget: paris` (the paris bundle is the lowest common denominator and covers both groups). Cancun-deployed contracts on all other chains remain unchanged.

Three additional chains were flagged by Paul as unverifiable (`artela`, `fluence`, `reactive`) — investigated separately, not in scope here.

## Pairs with

- hyperlane-monorepo#8687 — adds the `MinimalInterchainGasPaymaster` contract, paris build pipeline, `evmTarget` chain metadata field, and `MultiProvider.resolveEvmTargetFactory` matrix routing.

## Test plan

- [ ] Schema validation passes (`pnpm test:unit`)
- [ ] After monorepo PR merges, deploy a fresh IGP on one of the affected chains via the SDK and confirm the slim bytecode lands on chain