### PR TITLE
fix: update Safe transaction service URLs

### DIFF
--- a/.changeset/safe-service-urls.md
+++ b/.changeset/safe-service-urls.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Updated Safe transaction service URLs to current Safe-supported API endpoints.

--- a/chains/arbitrum/metadata.yaml
+++ b/chains/arbitrum/metadata.yaml
@@ -16,7 +16,7 @@ deployer:
 displayName: Arbitrum
 domainId: 42161
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-arbitrum.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/arb1
 index:
   # Arbitrum Nitro flavored chains record the L1 block number they were deployed at,
   # not the L2 block number. See https://docs.arbitrum.io/build-decentralized-apps/arbitrum-vs-ethereum/block-numbers-and-time#ethereum-block-numbers-within-arbitrum.

--- a/chains/avalanche/metadata.yaml
+++ b/chains/avalanche/metadata.yaml
@@ -16,7 +16,7 @@ deployer:
 displayName: Avalanche
 domainId: 43114
 gasCurrencyCoinGeckoId: avalanche-2
-gnosisSafeTransactionServiceUrl: https://safe-transaction-avalanche.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/avax
 name: avalanche
 nativeToken:
   decimals: 18

--- a/chains/base/metadata.yaml
+++ b/chains/base/metadata.yaml
@@ -24,7 +24,7 @@ deployer:
 displayName: Base
 domainId: 8453
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-base.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/base
 name: base
 nativeToken:
   decimals: 18

--- a/chains/berachain/metadata.yaml
+++ b/chains/berachain/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: Berachain
 domainId: 80094
 gasCurrencyCoinGeckoId: berachain-bera
-gnosisSafeTransactionServiceUrl: https://transaction.safe.berachain.com
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/berachain
 name: berachain
 nativeToken:
   decimals: 18

--- a/chains/bsc/metadata.yaml
+++ b/chains/bsc/metadata.yaml
@@ -17,7 +17,7 @@ displayName: Binance Smart Chain
 displayNameShort: Binance
 domainId: 56
 gasCurrencyCoinGeckoId: binancecoin
-gnosisSafeTransactionServiceUrl: https://safe-transaction-bsc.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/bnb
 name: bsc
 nativeToken:
   decimals: 18

--- a/chains/celo/metadata.yaml
+++ b/chains/celo/metadata.yaml
@@ -20,7 +20,7 @@ deployer:
 displayName: Celo
 domainId: 42220
 gasCurrencyCoinGeckoId: celo
-gnosisSafeTransactionServiceUrl: https://safe-transaction-celo.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/celo
 name: celo
 nativeToken:
   decimals: 18

--- a/chains/cyber/metadata.yaml
+++ b/chains/cyber/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
 displayName: Cyber
 domainId: 7560
 gasCurrencyCoinGeckoId: ethereum
+gnosisSafeTransactionServiceUrl: https://transaction-cyber.safe.optimism.io
 name: cyber
 nativeToken:
   decimals: 18

--- a/chains/ethereum/metadata.yaml
+++ b/chains/ethereum/metadata.yaml
@@ -24,7 +24,7 @@ deployer:
 displayName: Ethereum
 domainId: 1
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-mainnet.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/eth
 name: ethereum
 nativeToken:
   decimals: 18

--- a/chains/gnosis/metadata.yaml
+++ b/chains/gnosis/metadata.yaml
@@ -16,7 +16,7 @@ deployer:
 displayName: Gnosis
 domainId: 100
 gasCurrencyCoinGeckoId: xdai
-gnosisSafeTransactionServiceUrl: https://safe-transaction-gnosis-chain.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/gno
 name: gnosis
 nativeToken:
   decimals: 18

--- a/chains/hyperevm/metadata.yaml
+++ b/chains/hyperevm/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: HyperEVM
 domainId: 999
 gasCurrencyCoinGeckoId: hyperliquid
-gnosisSafeTransactionServiceUrl: https://prod.hyperliquid.keypersafe.xyz
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/hyper
 name: hyperevm
 nativeToken:
   decimals: 18

--- a/chains/ink/metadata.yaml
+++ b/chains/ink/metadata.yaml
@@ -19,7 +19,7 @@ deployer:
 displayName: Ink
 domainId: 57073
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-ink.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/ink
 name: ink
 nativeToken:
   decimals: 18

--- a/chains/inksepolia/metadata.yaml
+++ b/chains/inksepolia/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Ink Sepolia
 domainId: 763373
+gnosisSafeTransactionServiceUrl: https://kraken-sepolia.superchain.safe.protofire.io
 isTestnet: true
 name: inksepolia
 nativeToken:

--- a/chains/linea/metadata.yaml
+++ b/chains/linea/metadata.yaml
@@ -20,7 +20,7 @@ deployer:
 displayName: Linea
 domainId: 59144
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-linea.safe.global
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/linea
 name: linea
 nativeToken:
   decimals: 18

--- a/chains/lisksepolia/metadata.yaml
+++ b/chains/lisksepolia/metadata.yaml
@@ -10,6 +10,7 @@ deployer:
   url: https://github.com/guy93354
 displayName: Lisk Sepolia
 domainId: 4202
+gnosisSafeTransactionServiceUrl: https://transaction-lisk-sepolia.safe.optimism.io
 isTestnet: true
 name: lisksepolia
 nativeToken:

--- a/chains/mantle/metadata.yaml
+++ b/chains/mantle/metadata.yaml
@@ -19,7 +19,7 @@ deployer:
 displayName: Mantle
 domainId: 5000
 gasCurrencyCoinGeckoId: mantle
-gnosisSafeTransactionServiceUrl: https://safe-transaction-mantle.safe.global
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/mantle
 name: mantle
 nativeToken:
   decimals: 18

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -366,7 +366,7 @@ arbitrum:
   displayName: Arbitrum
   domainId: 42161
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-arbitrum.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/arb1
   index:
     from: 143649797
   name: arbitrum
@@ -772,7 +772,7 @@ avalanche:
   displayName: Avalanche
   domainId: 43114
   gasCurrencyCoinGeckoId: avalanche-2
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-avalanche.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/avax
   name: avalanche
   nativeToken:
     decimals: 18
@@ -844,7 +844,7 @@ base:
   displayName: Base
   domainId: 8453
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-base.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/base
   name: base
   nativeToken:
     decimals: 18
@@ -964,7 +964,7 @@ berachain:
   displayName: Berachain
   domainId: 80094
   gasCurrencyCoinGeckoId: berachain-bera
-  gnosisSafeTransactionServiceUrl: https://transaction.safe.berachain.com
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/berachain
   name: berachain
   nativeToken:
     decimals: 18
@@ -1226,7 +1226,7 @@ bsc:
   displayNameShort: Binance
   domainId: 56
   gasCurrencyCoinGeckoId: binancecoin
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-bsc.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/bnb
   name: bsc
   nativeToken:
     decimals: 18
@@ -1573,7 +1573,7 @@ celo:
   displayName: Celo
   domainId: 42220
   gasCurrencyCoinGeckoId: celo
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-celo.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/celo
   name: celo
   nativeToken:
     decimals: 18
@@ -2083,6 +2083,7 @@ cyber:
   displayName: Cyber
   domainId: 7560
   gasCurrencyCoinGeckoId: ethereum
+  gnosisSafeTransactionServiceUrl: https://transaction-cyber.safe.optimism.io
   name: cyber
   nativeToken:
     decimals: 18
@@ -2866,7 +2867,7 @@ ethereum:
   displayName: Ethereum
   domainId: 1
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-mainnet.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/eth
   name: ethereum
   nativeToken:
     decimals: 18
@@ -3633,7 +3634,7 @@ gnosis:
   displayName: Gnosis
   domainId: 100
   gasCurrencyCoinGeckoId: xdai
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-gnosis-chain.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/gno
   name: gnosis
   nativeToken:
     decimals: 18
@@ -3949,7 +3950,7 @@ hyperevm:
   displayName: HyperEVM
   domainId: 999
   gasCurrencyCoinGeckoId: hyperliquid
-  gnosisSafeTransactionServiceUrl: https://prod.hyperliquid.keypersafe.xyz
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/hyper
   name: hyperevm
   nativeToken:
     decimals: 18
@@ -4303,7 +4304,7 @@ ink:
   displayName: Ink
   domainId: 57073
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-ink.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/ink
   name: ink
   nativeToken:
     decimals: 18
@@ -4333,6 +4334,7 @@ inksepolia:
     url: https://www.hyperlane.xyz
   displayName: Ink Sepolia
   domainId: 763373
+  gnosisSafeTransactionServiceUrl: https://kraken-sepolia.superchain.safe.protofire.io
   isTestnet: true
   name: inksepolia
   nativeToken:
@@ -4703,7 +4705,7 @@ linea:
   displayName: Linea
   domainId: 59144
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-linea.safe.global
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/linea
   name: linea
   nativeToken:
     decimals: 18
@@ -4781,6 +4783,7 @@ lisksepolia:
     url: https://github.com/guy93354
   displayName: Lisk Sepolia
   domainId: 4202
+  gnosisSafeTransactionServiceUrl: https://transaction-lisk-sepolia.safe.optimism.io
   isTestnet: true
   name: lisksepolia
   nativeToken:
@@ -5002,7 +5005,7 @@ mantle:
   displayName: Mantle
   domainId: 5000
   gasCurrencyCoinGeckoId: mantle
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-mantle.safe.global
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/mantle
   name: mantle
   nativeToken:
     decimals: 18
@@ -5584,6 +5587,7 @@ modetestnet:
     url: https://www.hyperlane.xyz
   displayName: Mode Testnet
   domainId: 919
+  gnosisSafeTransactionServiceUrl: https://transaction-mode-sepolia.safe.optimism.io
   isTestnet: true
   name: modetestnet
   nativeToken:
@@ -6282,7 +6286,7 @@ optimism:
   displayName: Optimism
   domainId: 10
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-optimism.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/oeth
   name: optimism
   nativeToken:
     decimals: 18
@@ -6313,6 +6317,7 @@ optimismsepolia:
   displayName: Optimism Sepolia
   domainId: 11155420
   gasCurrencyCoinGeckoId: ethereum
+  gnosisSafeTransactionServiceUrl: https://transaction-optimism-sepolia.safe.optimism.io
   isTestnet: true
   name: optimismsepolia
   nativeToken:
@@ -6605,7 +6610,7 @@ polygon:
   displayName: Polygon
   domainId: 137
   gasCurrencyCoinGeckoId: polygon-ecosystem-token
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-polygon.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/pol
   name: polygon
   nativeToken:
     decimals: 18
@@ -6670,7 +6675,7 @@ polygonzkevm:
   displayNameShort: zkEVM
   domainId: 1101
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-zkevm.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/zkevm
   name: polygonzkevm
   nativeToken:
     decimals: 18
@@ -7317,7 +7322,7 @@ scroll:
   displayName: Scroll
   domainId: 534352
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-scroll.safe.global
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/scr
   name: scroll
   nativeToken:
     decimals: 18
@@ -7410,7 +7415,7 @@ sepolia:
   displayName: Sepolia
   domainId: 11155111
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-sepolia.safe.global
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/sep
   isTestnet: true
   name: sepolia
   nativeToken:
@@ -7734,7 +7739,7 @@ soneium:
   displayName: Soneium
   domainId: 1868
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://trx-soneium.safe.protofire.io
+  gnosisSafeTransactionServiceUrl: https://soneium.superchain.safe.protofire.io
   name: soneium
   nativeToken:
     decimals: 18
@@ -7792,7 +7797,7 @@ sonic:
   displayName: Sonic
   domainId: 146
   gasCurrencyCoinGeckoId: fantom
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-sonic.safe.global/
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/sonic
   name: sonic
   nativeToken:
     decimals: 18
@@ -8456,7 +8461,7 @@ superseed:
   displayName: Superseed
   domainId: 5330
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://trx-superseed.safe.protofire.io
+  gnosisSafeTransactionServiceUrl: https://superseed.superchain.safe.protofire.io
   name: superseed
   nativeToken:
     decimals: 18
@@ -8534,7 +8539,7 @@ swell:
   displayName: Swell
   domainId: 1923
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://trx-swell.safe.protofire.io
+  gnosisSafeTransactionServiceUrl: https://swell.superchain.safe.protofire.io
   name: swell
   nativeToken:
     decimals: 18
@@ -9046,7 +9051,7 @@ unichain:
   displayName: Unichain
   domainId: 130
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-unichain.safe.global
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/unichain
   name: unichain
   nativeToken:
     decimals: 18
@@ -9245,7 +9250,7 @@ worldchain:
   displayName: World Chain
   domainId: 480
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-worldchain.safe.global
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/wc
   name: worldchain
   nativeToken:
     decimals: 18
@@ -9527,7 +9532,7 @@ zksync:
   displayName: zkSync
   domainId: 324
   gasCurrencyCoinGeckoId: ethereum
-  gnosisSafeTransactionServiceUrl: https://safe-transaction-zksync.safe.global
+  gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/zksync
   name: zksync
   nativeToken:
     decimals: 18
@@ -9602,6 +9607,7 @@ zoratestnet:
     url: https://github.com/guy93354
   displayName: Zora Testnet
   domainId: 999999999
+  gnosisSafeTransactionServiceUrl: https://transaction-zora-sepolia.safe.optimism.io
   isTestnet: true
   name: zoratestnet
   nativeToken:

--- a/chains/modetestnet/metadata.yaml
+++ b/chains/modetestnet/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Mode Testnet
 domainId: 919
+gnosisSafeTransactionServiceUrl: https://transaction-mode-sepolia.safe.optimism.io
 isTestnet: true
 name: modetestnet
 nativeToken:

--- a/chains/optimism/metadata.yaml
+++ b/chains/optimism/metadata.yaml
@@ -24,7 +24,7 @@ deployer:
 displayName: Optimism
 domainId: 10
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-optimism.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/oeth
 name: optimism
 nativeToken:
   decimals: 18

--- a/chains/optimismsepolia/metadata.yaml
+++ b/chains/optimismsepolia/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
 displayName: Optimism Sepolia
 domainId: 11155420
 gasCurrencyCoinGeckoId: ethereum
+gnosisSafeTransactionServiceUrl: https://transaction-optimism-sepolia.safe.optimism.io
 isTestnet: true
 name: optimismsepolia
 nativeToken:

--- a/chains/polygon/metadata.yaml
+++ b/chains/polygon/metadata.yaml
@@ -16,7 +16,7 @@ deployer:
 displayName: Polygon
 domainId: 137
 gasCurrencyCoinGeckoId: polygon-ecosystem-token
-gnosisSafeTransactionServiceUrl: https://safe-transaction-polygon.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/pol
 name: polygon
 nativeToken:
   decimals: 18

--- a/chains/polygonzkevm/metadata.yaml
+++ b/chains/polygonzkevm/metadata.yaml
@@ -20,7 +20,7 @@ displayName: Polygon zkEVM
 displayNameShort: zkEVM
 domainId: 1101
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-zkevm.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/zkevm
 name: polygonzkevm
 nativeToken:
   decimals: 18

--- a/chains/scroll/metadata.yaml
+++ b/chains/scroll/metadata.yaml
@@ -19,7 +19,7 @@ deployer:
 displayName: Scroll
 domainId: 534352
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-scroll.safe.global
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/scr
 name: scroll
 nativeToken:
   decimals: 18

--- a/chains/sepolia/metadata.yaml
+++ b/chains/sepolia/metadata.yaml
@@ -16,7 +16,7 @@ deployer:
 displayName: Sepolia
 domainId: 11155111
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-sepolia.safe.global
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/sep
 isTestnet: true
 name: sepolia
 nativeToken:

--- a/chains/soneium/metadata.yaml
+++ b/chains/soneium/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: Soneium
 domainId: 1868
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://trx-soneium.safe.protofire.io
+gnosisSafeTransactionServiceUrl: https://soneium.superchain.safe.protofire.io
 name: soneium
 nativeToken:
   decimals: 18

--- a/chains/sonic/metadata.yaml
+++ b/chains/sonic/metadata.yaml
@@ -16,7 +16,7 @@ deployer:
 displayName: Sonic
 domainId: 146
 gasCurrencyCoinGeckoId: fantom
-gnosisSafeTransactionServiceUrl: https://safe-transaction-sonic.safe.global/
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/sonic
 name: sonic
 nativeToken:
   decimals: 18

--- a/chains/superseed/metadata.yaml
+++ b/chains/superseed/metadata.yaml
@@ -19,7 +19,7 @@ deployer:
 displayName: Superseed
 domainId: 5330
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://trx-superseed.safe.protofire.io
+gnosisSafeTransactionServiceUrl: https://superseed.superchain.safe.protofire.io
 name: superseed
 nativeToken:
   decimals: 18

--- a/chains/swell/metadata.yaml
+++ b/chains/swell/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: Swell
 domainId: 1923
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://trx-swell.safe.protofire.io
+gnosisSafeTransactionServiceUrl: https://swell.superchain.safe.protofire.io
 name: swell
 nativeToken:
   decimals: 18

--- a/chains/unichain/metadata.yaml
+++ b/chains/unichain/metadata.yaml
@@ -20,7 +20,7 @@ deployer:
 displayName: Unichain
 domainId: 130
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-unichain.safe.global
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/unichain
 name: unichain
 nativeToken:
   decimals: 18

--- a/chains/worldchain/metadata.yaml
+++ b/chains/worldchain/metadata.yaml
@@ -20,7 +20,7 @@ deployer:
 displayName: World Chain
 domainId: 480
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-worldchain.safe.global
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/wc
 name: worldchain
 nativeToken:
   decimals: 18

--- a/chains/zksync/metadata.yaml
+++ b/chains/zksync/metadata.yaml
@@ -15,7 +15,7 @@ deployer:
 displayName: zkSync
 domainId: 324
 gasCurrencyCoinGeckoId: ethereum
-gnosisSafeTransactionServiceUrl: https://safe-transaction-zksync.safe.global
+gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/zksync
 name: zksync
 nativeToken:
   decimals: 18

--- a/chains/zoratestnet/metadata.yaml
+++ b/chains/zoratestnet/metadata.yaml
@@ -10,6 +10,7 @@ deployer:
   url: https://github.com/guy93354
 displayName: Zora Testnet
 domainId: 999999999
+gnosisSafeTransactionServiceUrl: https://transaction-zora-sepolia.safe.optimism.io
 isTestnet: true
 name: zoratestnet
 nativeToken:


### PR DESCRIPTION
## Summary

Updates `gnosisSafeTransactionServiceUrl` for registry chains whose `chainId` is present in Safe's current supported-chain APIs:

- Safe default WALLET_WEB list: `https://safe-client.safe.global/v2/chains?serviceKey=WALLET_WEB`
- Optimism/Superchain gateway list: `https://gateway.safe.optimism.io/v1/chains`

The PR prefers Safe's default global API (`https://api.safe.global/tx-service/...`) when a chain is present there, and uses the Optimism gateway values for supported Superchain chains that are not present in the default Safe list.

Notable additions/fixes from the Optimism gateway cross-check:

- Replaces dead DNS hosts for `soneium`, `superseed`, and `swell`
- Adds Safe tx-service URLs for `cyber`, `optimismsepolia`, `inksepolia`, `lisksepolia`, `modetestnet`, and `zoratestnet`

Also updates the aggregate `chains/metadata.yaml` via the registry build and adds a patch changeset.

## Validation

- Fetched all 49 Safe WALLET_WEB chains from Safe client API
- Fetched all 20 Optimism gateway chains
- Compared registry metadata by `chainId`, preferring Safe global when present and Optimism gateway as the fallback source; remaining mismatches: 0
- Spot-checked new Safe tx-service `/api/v1/about/` endpoints for representative global chains: `arb1`, `hyper`, `wc`, `eth` returned 200
- Checked all newly-added/changed Optimism gateway endpoints: `soneium`, `superseed`, `swell`, `cyber`, `optimismsepolia`, `inksepolia`, `lisksepolia`, `modetestnet`, `zoratestnet` returned 200
- `pnpm build`
- `pnpm lint`
- `git diff --check`