### PR TITLE
feat: add USDC/ctusd-ironbridge-staging deploy artifact

### DIFF
--- a/deployments/warp_routes/USDC/ctusd-ironbridge-staging-deploy.yaml
+++ b/deployments/warp_routes/USDC/ctusd-ironbridge-staging-deploy.yaml
@@ -1,0 +1,44 @@
+arbitrum:
+  destinationConfigs:
+    citrea:
+      "0x00000000000000000000000038e8720ebe02e7c5254f9de9f81440c7a770a9c6":
+        depositAddress: "0xe11a54ad85e4f04962c93f26d2c746f610a61933"
+        feeBps: "0"
+  owner: "0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5"
+  token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+  type: collateralDepositAddress
+base:
+  destinationConfigs:
+    citrea:
+      "0x00000000000000000000000038e8720ebe02e7c5254f9de9f81440c7a770a9c6":
+        depositAddress: "0x99dcac2e06090fc843feb0f36516ac7e0b351fcf"
+        feeBps: "0"
+  owner: "0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5"
+  token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  type: collateralDepositAddress
+citrea:
+  destinationConfigs:
+    arbitrum:
+      "0x00000000000000000000000062fe676dff1e7abbccbedc8babc993827b9fb189":
+        depositAddress: "0x1e9ad719e6dd6c86370d7a0f99430e86fe0f1039"
+        feeBps: "0"
+    base:
+      "0x000000000000000000000000d54a15f8df8c6dd9ef3b5589be0bf37ec6f61f91":
+        depositAddress: "0xdb99b7f572d22429fc9dbde5a32c3f159eb17e30"
+        feeBps: "0"
+    ethereum:
+      "0x000000000000000000000000d4463cb3c90b3f49c673310bec9bc18311134b47":
+        depositAddress: "0x33d51a880f83df9b9560d826e0a6de022d285da1"
+        feeBps: "0"
+  owner: "0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5"
+  token: "0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D"
+  type: collateralDepositAddress
+ethereum:
+  destinationConfigs:
+    citrea:
+      "0x00000000000000000000000038e8720ebe02e7c5254f9de9f81440c7a770a9c6":
+        depositAddress: "0xba16a57c15c95fd89f096e7c9bb98d1fe25583b3"
+        feeBps: "0"
+  owner: "0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5"
+  token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+  type: collateralDepositAddress


### PR DESCRIPTION
## Summary

Adds the deploy artifact for the `USDC/ctusd-ironbridge-staging` warp route. The YAML was generated from the config getter introduced in [hyperlane-monorepo#8702](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/8702) via `pnpm --filter @hyperlane-xyz/infra exec tsx scripts/warp-routes/export-warp-configs.ts --environment mainnet3 --warpRouteIds USDC/ctusd-ironbridge-staging`.

This route is a set of 4 standalone `TokenBridgeDepositAddress` contracts (one per origin chain) that sit alongside the staging `CROSS/ctusd` cross-collateral route on `codex/nambrot-cross-collateral-deploy`. They forward ERC20 deposits to Iron's autoramp addresses, which settle into the destination cross-collateral router via Iron's smart-contract receivers.

The 6 Iron deposit addresses are pinned to autoramps created on 2026-05-01 under the customer "Staging MovableCollateral Market" naming prefix.

## Test plan

- [x] Deploy run on 2026-05-04 produced 4 contract addresses (arb `0x669c…a786`, base `0xc112…16d1`, citrea `0x4833…1FD7`, eth `0x5327…89BD`) with all 6 `addDestinationConfig` calls verified via `cast`.
- [x] End-to-end test arb→citrea (11 USDC) settled by Iron in ~2 min, delivered to the citrea cross-collateral router.
- [ ] PR landed alongside hyperlane-monorepo#8702 for the getter that regenerates this YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)