### PR TITLE
chore: update Zero Network RPC URLs

### DIFF
--- a/.changeset/zeronetwork-rpcs.md
+++ b/.changeset/zeronetwork-rpcs.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Updated Zero Network RPC URLs to use Zerion and dRPC providers.

--- a/chains/zeronetwork/metadata.yaml
+++ b/chains/zeronetwork/metadata.yaml
@@ -26,5 +26,6 @@ nativeToken:
   symbol: ETH
 protocol: ethereum
 rpcUrls:
-  - http: https://zero-network.calderachain.xyz
+  - http: https://rpc.zerion.io/v1/zero
+  - http: https://zero.drpc.org
 technicalStack: zksync


### PR DESCRIPTION
## Summary
- Replace ZeroNetwork's Caldera RPC with Zerion (`https://rpc.zerion.io/v1/zero`) and dRPC (`https://zero.drpc.org`) endpoints

## Test plan
- [ ] CI passes (lint, build, RPC health checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that swaps RPC endpoints for `zeronetwork`; main risk is connectivity/availability differences with the new providers.
> 
> **Overview**
> Updates `chains/zeronetwork/metadata.yaml` to remove the Caldera RPC and use Zerion (`https://rpc.zerion.io/v1/zero`) and dRPC (`https://zero.drpc.org`) as the configured `rpcUrls`.
> 
> Adds a Changeset to publish a patch release of `@hyperlane-xyz/registry` documenting the RPC provider switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18657b9bd51764782c29cd730c95ee13f13a9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->