### PR TITLE
fix(registry): avoid sdk root runtime imports

### DIFF
--- a/.changeset/lightweight-sdk-imports.md
+++ b/.changeset/lightweight-sdk-imports.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Avoid importing the SDK root from registry runtime modules so bundled services do not pull unused SDK protocol artifacts.

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@faker-js/faker": "^9.6.0",
-    "@hyperlane-xyz/sdk": "33.1.1",
-    "@hyperlane-xyz/utils": "33.1.1",
+    "@hyperlane-xyz/sdk": "34.0.0",
+    "@hyperlane-xyz/utils": "34.0.0",
     "@types/chai-as-promised": "^8",
     "@types/mocha": "^10.0.1",
     "@types/node": "^24.10.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,11 +25,11 @@ importers:
         specifier: ^9.6.0
         version: 9.6.0
       '@hyperlane-xyz/sdk':
-        specifier: 33.1.1
-        version: 33.1.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
+        specifier: 34.0.0
+        version: 34.0.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/utils':
-        specifier: 33.1.1
-        version: 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+        specifier: 34.0.0
+        version: 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@types/chai-as-promised':
         specifier: ^8
         version: 8.0.1
@@ -603,8 +603,8 @@ packages:
     resolution: {integrity: sha512-xyR4SqS4MjDmQIrIQmqPWLNgwM6Ul6G8UWQsFKZw6PLv8pxVk1nYj2WJrdZ+Ecs9+qY/NYQItv8KVMXge3gFKQ==}
     engines: {node: '>=16.0.0'}
 
-  '@hyperlane-xyz/aleo-sdk@33.1.1':
-    resolution: {integrity: sha512-O5u2x1a1Yu1dLCQPqe1kYPrDBrWtzRnxyzLuUv816VYFQOUkJFKIEErKzA9/0rTXg4WegkIEV80psDX6R+HEIw==}
+  '@hyperlane-xyz/aleo-sdk@34.0.0':
+    resolution: {integrity: sha512-q+Tivu4NNHf/0NM6Wf8TdhGxBF9/mq9a+H4fpNZkbj2Vcwvjr7OKzlITbDA42pn8aUiMGIo/22jjWnGSGLcRIw==}
     peerDependencies:
       testcontainers: 11.12.0
     peerDependenciesMeta:
@@ -619,45 +619,45 @@ packages:
       '@ethersproject/providers': '*'
       '@types/sinon-chai': '*'
 
-  '@hyperlane-xyz/cosmos-sdk@33.1.1':
-    resolution: {integrity: sha512-Cl2Gq20JvEJ1GVvoXVD4Y+OH57rrs7e762utsoNDt4N2zIckmzXI36kKKf15x3zVTZEYnSChRqE7mGSyXPscQA==}
+  '@hyperlane-xyz/cosmos-sdk@34.0.0':
+    resolution: {integrity: sha512-zibbTIlr66VJQ+4xDlx4uGCa+pmSxLxS4i5kAp4dnxgHF69Zx96ryr3pJDDVA1ijTT8+oLCO6eGs1YShgw2vTg==}
 
-  '@hyperlane-xyz/cosmos-types@33.1.1':
-    resolution: {integrity: sha512-sA/wRAik6zhOfEHaSSVHZtEdNgOY9ohckI6uS+x1ndSOpkEIJ5XTalu3UudVXut4PfuUbSPABWoGnQAWObY39g==}
+  '@hyperlane-xyz/cosmos-types@34.0.0':
+    resolution: {integrity: sha512-apXNyXeKBShnjsdSOjgoIYgI96/4MzFKH6lFPdSm/67sAlojkrSUbbYZRkilHCH0c6ssKJxCloLPgTFCfvjvdQ==}
 
-  '@hyperlane-xyz/deploy-sdk@6.0.1':
-    resolution: {integrity: sha512-UzjGAO5nfPbWQL+FtKpPjgtEl0c5LVG4lvjKjGFDdCEHhRiN/nrMNPQ7kcEJI9YLJZwLl5Ja2OzRaSfGQsmvpA==}
+  '@hyperlane-xyz/deploy-sdk@6.0.2':
+    resolution: {integrity: sha512-zeKnG9mk5cQewlvwF9aznv7rAH/u4vitsovd0foE6a3BzSncODADW13ZKI1eHV/TmQ8jbdLDKtlSSZvMn2n3/w==}
 
-  '@hyperlane-xyz/provider-sdk@6.0.1':
-    resolution: {integrity: sha512-bt/aYYPB4U+MPla+VvN65mc3ZlPJU7KGmE7jFNXNecSb+RC/F8FoQLqtVwFYptZRkohyp5bBc7jziidfZZU7QA==}
+  '@hyperlane-xyz/provider-sdk@6.0.2':
+    resolution: {integrity: sha512-0PaChy11H2xlma/hZBnjCIZYLR6rVU9L0qIhGWE0dRrudJXIC26aL9mtSaZQAYt+ouVR61RKn4aWnbGcGA6oow==}
 
-  '@hyperlane-xyz/radix-sdk@33.1.1':
-    resolution: {integrity: sha512-qB1BRDRb42//NGCEz/EZ9UsmO0MkFHH3TQgdA2vm43yp9ZTQgwAw4rcwem9fKgiiLA623/9JzWIadShccgbREQ==}
+  '@hyperlane-xyz/radix-sdk@34.0.0':
+    resolution: {integrity: sha512-1EZKZbLKdbKMzS7g0MFIT2J8W8zG26r3soMtYAaQnOv4YWRj5XPBEmRldU6FJUzom9hMa77HqNBYvmeAolV4Kg==}
 
   '@hyperlane-xyz/registry@24.3.0':
     resolution: {integrity: sha512-nd0ndJf7HmakuFCwm0gKOZoVXQukEaVponXecjCuIGM8apGA0M9AhhBbsRD2f+JjKmOcZ2vehQaQfd270tGBXQ==}
     engines: {node: '>=24'}
 
-  '@hyperlane-xyz/sdk@33.1.1':
-    resolution: {integrity: sha512-ao/iMrlNSuZZGo7Jn7nfI4Xir/UqtG3v9nbIfBQbi6ThfTqEtKDHc96CyoFpc4eNWnddrBZAzAhHaqLa1h1bpQ==}
+  '@hyperlane-xyz/sdk@34.0.0':
+    resolution: {integrity: sha512-Q09DGiu0jFTGn1T04g7pm8Wcc57iZmHtwrnF4CSJZffiggp/jJk4hCLhFZm14rrHA/9Tap3SBo1xN2OxQzMGjA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@ethersproject/abi': '*'
 
-  '@hyperlane-xyz/sealevel-sdk@33.1.1':
-    resolution: {integrity: sha512-DsvI/6eDAm1QorHXxlGwnIUhlIzY27DBCOCTziJ3h7uQbLDtqsQqhTiztTlzlLiJ51L3r//63LO3rplP8l1yTA==}
+  '@hyperlane-xyz/sealevel-sdk@34.0.0':
+    resolution: {integrity: sha512-YVCqKELDIB7dzbax2i64KkCxfwrrAcY6JVrkDXPY+8mI+F9YrQBLAjDV7i71PFcoQ+R/Xhpg9gnxd1dWKP1Kcw==}
 
-  '@hyperlane-xyz/starknet-core@33.1.1':
-    resolution: {integrity: sha512-E19k2KYybgULv/5Nrh9lW7h6KFEnzQc1D38Y/pEfehZDS9FoQepdcrtRdqI8pjd8lwuSXpfHMMzvvRvDVUgbUQ==}
+  '@hyperlane-xyz/starknet-core@34.0.0':
+    resolution: {integrity: sha512-NyRSSBrIgKYkWcO5N1NGGv9xZBZpGQe05zQuU1m4CHjazyKG2Tt6oijn/Wns6dcw1b0LbKpCNQH5mgvhTSKhjQ==}
 
-  '@hyperlane-xyz/starknet-sdk@28.0.6':
-    resolution: {integrity: sha512-WpJNnTgxZokMd1V9gIa+NumFtb4s2ZDCzJpF2f+Nl4+EuR0CydJo/VU3HDBw8XzSYb8c5LgGVpumgrJafMFJvg==}
+  '@hyperlane-xyz/starknet-sdk@28.0.7':
+    resolution: {integrity: sha512-z4kWpXXNNOpeiLqvBRIvhci1gGxBUyI5DFJonI8HAeCEdq4a++vdTVk2d35vtZPGPv81/4TOy3xKTsVaAplymQ==}
 
-  '@hyperlane-xyz/tron-sdk@23.0.6':
-    resolution: {integrity: sha512-ab3JzvwQQeoIyAJcsL+ovRlTR8RQXb91SnENzEbudlTVPRI3fdHceLLXufBDf4o/brfr4cnSZb+VqcjkWqeFGA==}
+  '@hyperlane-xyz/tron-sdk@23.0.7':
+    resolution: {integrity: sha512-fxf5g7HXH+QSntBKYKYBdlu7FY2hPwUKUakEwKJoTQE4/a/3LlweRZGKc+hmmJzH7o71BJunqU/TUSgcSRF9SA==}
 
-  '@hyperlane-xyz/utils@33.1.1':
-    resolution: {integrity: sha512-oiX8LGyNhrCWv8ZT2Z16NoUVm8dVptEdir9YAVO1zO7rMGcGZ9AnauHVrv9pCtAw6j8F05oJoeYpAHV1oEcTgw==}
+  '@hyperlane-xyz/utils@34.0.0':
+    resolution: {integrity: sha512-wb55zdMF41+pVA6os5NaNio9PCL15/WimzWE3OSn1if/xPF983vaLSt9EGP+M2oW/holTo00ORqp/gzS34uKvA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@google-cloud/pino-logging-gcp-config': ^1.3.0
@@ -4944,10 +4944,10 @@ snapshots:
     dependencies:
       '@hpke/common': 1.8.1
 
-  '@hyperlane-xyz/aleo-sdk@33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/aleo-sdk@34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@provablehq/sdk': 0.9.15
       bignumber.js: 9.1.2
       unzipper: 0.12.3
@@ -4965,16 +4965,16 @@ snapshots:
       '@ethersproject/providers': 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@types/sinon-chai': 4.0.0
 
-  '@hyperlane-xyz/cosmos-sdk@33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/cosmos-sdk@34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@cosmjs/amino': 0.32.4
       '@cosmjs/math': 0.32.4
       '@cosmjs/proto-signing': 0.32.4
       '@cosmjs/stargate': 0.32.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@cosmjs/tendermint-rpc': 0.32.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/cosmos-types': 33.1.1
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/cosmos-types': 34.0.0
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -4984,21 +4984,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/cosmos-types@33.1.1':
+  '@hyperlane-xyz/cosmos-types@34.0.0':
     dependencies:
       long: 5.3.2
       protobufjs: 7.5.0
 
-  '@hyperlane-xyz/deploy-sdk@6.0.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/deploy-sdk@6.0.2(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/aleo-sdk': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/cosmos-sdk': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/radix-sdk': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/sealevel-sdk': 33.1.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/starknet-sdk': 28.0.6(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/tron-sdk': 23.0.6(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/aleo-sdk': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/cosmos-sdk': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/radix-sdk': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/sealevel-sdk': 34.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/starknet-sdk': 28.0.7(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/tron-sdk': 23.0.7(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       zod: 3.22.4
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
@@ -5012,9 +5012,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/provider-sdk@6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/provider-sdk@6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       pino: 8.20.0
       zod: 3.22.4
     transitivePeerDependencies:
@@ -5025,10 +5025,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/radix-sdk@33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/radix-sdk@34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@radixdlt/babylon-core-api-sdk': 1.3.0
       '@radixdlt/babylon-gateway-api-sdk': 1.10.1
       '@radixdlt/radix-engine-toolkit': 1.0.5
@@ -5049,7 +5049,7 @@ snapshots:
       yaml: 2.4.5
       zod: 3.22.4
 
-  '@hyperlane-xyz/sdk@33.1.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/sdk@34.0.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@arbitrum/sdk': 4.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@aws-sdk/client-s3': 3.750.0
@@ -5063,15 +5063,15 @@ snapshots:
       '@cosmjs/stargate': 0.32.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@cosmjs/tendermint-rpc': 0.32.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@ethersproject/abi': 5.8.0
-      '@hyperlane-xyz/aleo-sdk': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/aleo-sdk': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/core': 11.3.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)
-      '@hyperlane-xyz/cosmos-sdk': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/deploy-sdk': 6.0.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/radix-sdk': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/starknet-core': 33.1.1
-      '@hyperlane-xyz/tron-sdk': 23.0.6(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/cosmos-sdk': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/deploy-sdk': 6.0.2(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/radix-sdk': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/starknet-core': 34.0.0
+      '@hyperlane-xyz/tron-sdk': 23.0.7(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@safe-global/api-kit': 4.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@safe-global/protocol-kit': 6.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.22.4)
       '@safe-global/safe-core-sdk-types': 5.1.0(typescript@6.0.2)(zod@3.22.4)
@@ -5128,10 +5128,10 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@hyperlane-xyz/sealevel-sdk@33.1.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/sealevel-sdk@34.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.8.0
       '@solana-program/loader-v3': 0.3.0(@solana/kit@6.3.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10))
       '@solana-program/system': 0.12.0(@solana/kit@6.3.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10))
@@ -5146,15 +5146,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/starknet-core@33.1.1':
+  '@hyperlane-xyz/starknet-core@34.0.0':
     dependencies:
       starknet: 7.6.2
 
-  '@hyperlane-xyz/starknet-sdk@28.0.6(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/starknet-sdk@28.0.7(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/starknet-core': 33.1.1
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/starknet-core': 34.0.0
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       starknet: 7.6.2
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
@@ -5164,14 +5164,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/tron-sdk@23.0.6(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/tron-sdk@23.0.7(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/providers': 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/core': 11.3.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)
-      '@hyperlane-xyz/provider-sdk': 6.0.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 6.0.2(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/registry': 24.3.0
-      '@hyperlane-xyz/utils': 33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       bignumber.js: 9.1.2
       ethers: 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tronweb: 6.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -5185,7 +5185,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/utils@33.1.1(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/utils@34.0.0(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@cosmjs/encoding': 0.32.4
       '@ethersproject/bytes': 5.8.0

--- a/src/fs/FileSystemRegistry.ts
+++ b/src/fs/FileSystemRegistry.ts
@@ -1,13 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 
-import type {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 import type { Logger } from 'pino';
 import { parse as yamlParse } from 'yaml';
 

--- a/src/registry/BaseRegistry.ts
+++ b/src/registry/BaseRegistry.ts
@@ -1,11 +1,7 @@
-import {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  HypTokenRouterConfig,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { HypTokenRouterConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 import { assert, objFilter, objLength } from '@hyperlane-xyz/utils';
 import type { Logger } from 'pino';
 

--- a/src/registry/GithubRegistry.ts
+++ b/src/registry/GithubRegistry.ts
@@ -1,10 +1,7 @@
-import type {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 import JSZip from 'jszip';
 import type { Logger } from 'pino';
 import { parse as yamlParse } from 'yaml';

--- a/src/registry/HttpClientRegistry.ts
+++ b/src/registry/HttpClientRegistry.ts
@@ -1,10 +1,7 @@
-import {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 
 import {
   AddWarpRouteConfigOptions,

--- a/src/registry/IRegistry.ts
+++ b/src/registry/IRegistry.ts
@@ -1,10 +1,7 @@
-import type {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 
 import {
   AddWarpRouteConfigOptions,

--- a/src/registry/MergedRegistry.ts
+++ b/src/registry/MergedRegistry.ts
@@ -1,10 +1,7 @@
-import type {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 import type { Logger } from 'pino';
 
 import {

--- a/src/registry/PartialRegistry.ts
+++ b/src/registry/PartialRegistry.ts
@@ -1,10 +1,7 @@
-import type {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 import type { Logger } from 'pino';
 
 import { AddWarpRouteConfigOptions, ChainAddresses, DeepPartial, WarpRouteId } from '../types.js';

--- a/src/registry/SynchronousRegistry.ts
+++ b/src/registry/SynchronousRegistry.ts
@@ -1,10 +1,7 @@
-import type {
-  ChainMap,
-  ChainMetadata,
-  ChainName,
-  WarpCoreConfig,
-  WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 
 import {
   AddWarpRouteConfigOptions,

--- a/src/registry/warp-utils.ts
+++ b/src/registry/warp-utils.ts
@@ -1,9 +1,6 @@
-import {
-  TOKEN_HYP_STANDARDS,
-  TokenStandard,
-  type ChainMap,
-  type WarpCoreConfig,
-} from '@hyperlane-xyz/sdk';
+import { TOKEN_HYP_STANDARDS, TokenStandard } from '@hyperlane-xyz/sdk/token/TokenStandard';
+import type { ChainMap } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 
 import { WARP_ROUTE_CONFIG_FILE_REGEX, WARP_ROUTE_DEPLOY_FILE_REGEX } from '../consts.js';
 import { ChainAddresses, WarpRouteFilterParams, WarpRouteId } from '../types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,7 @@
-import {
-  ChainMetadataSchema,
-  ChainName,
-  type WarpCoreConfig,
-  type WarpRouteDeployConfig,
-} from '@hyperlane-xyz/sdk';
+import { ChainMetadataSchema } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
+import type { ChainName } from '@hyperlane-xyz/sdk/types';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 import { z } from 'zod';
 
 import { WARP_ROUTE_ID_REGEX } from './consts.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
 import {
-  ChainMetadata,
-  NormalizedScale,
-  ScaleInput,
+  type NormalizedScale,
+  type ScaleInput,
   normalizeScale as sdkNormalizeScale,
-} from '@hyperlane-xyz/sdk';
+} from '@hyperlane-xyz/sdk/utils/decimals';
 import { isNullish } from '@hyperlane-xyz/utils';
 import { stringify } from 'yaml';
 


### PR DESCRIPTION
## Summary

- Replace registry runtime imports from the SDK root with SDK subpath imports.
- Keep SDK-only type usage as type imports so compiled registry modules do not load the SDK root.
- Preserve the registry null-vs-identity scale behavior while delegating canonical scale normalization to `@hyperlane-xyz/sdk/utils/decimals`.
- Bump `@hyperlane-xyz/sdk` and `@hyperlane-xyz/utils` to `34.0.0`, which includes the required SDK subpath exports.

## Why

Bundled services that use `@hyperlane-xyz/registry/fs` can otherwise pull in the SDK root graph, including unused protocol artifacts such as Aleo WASM assets. This keeps registry runtime modules lightweight for ncc and other bundlers while avoiding copied SDK logic.

## Upstream

The required SDK export surface shipped in the monorepo release from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/8733.

## Validation

- `pnpm build`
- `pnpm test:unit`
- `git diff --check`
- Verified `@hyperlane-xyz/sdk@34.0.0` exposes `./utils/*` and resolves `@hyperlane-xyz/sdk/utils/decimals`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates registry modules to use `@hyperlane-xyz/sdk` subpath imports and bumps the SDK/utils versions, which could cause build or runtime issues if upstream export paths or types differ from expectations.
> 
> **Overview**
> Reduces bundling weight by **eliminating `@hyperlane-xyz/sdk` root imports** from registry runtime code and switching to targeted SDK subpath imports (metadata, token, warp, utils) so consumers don’t pull in unused protocol artifacts.
> 
> Updates `normalizeScale` to delegate to `@hyperlane-xyz/sdk/utils/decimals` while preserving the registry’s *null vs identity* behavior. Also bumps dev dependencies to `@hyperlane-xyz/sdk@34.0.0` and `@hyperlane-xyz/utils@34.0.0`, and adds a patch changeset documenting the bundle-size motivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 789206925dbdf462fb2cda2188fe0bb3213d77e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->