### PR TITLE
feat: add mUSD (Ethereum, Monad) warp route

### DIFF
--- a/.changeset/cyan-badgers-serve.md
+++ b/.changeset/cyan-badgers-serve.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add mUSD (Ethereum, Monad) warp route on the new EvmM0Portal. Split mUSD into two route configs: musd (Ethereum/Monad on EvmM0Portal) and musd-portal-lite (BSC/Ethereum/Linea on EvmM0PortalLite, to be deprecated).

--- a/deployments/warp_routes/mUSD/musd-config.yaml
+++ b/deployments/warp_routes/mUSD/musd-config.yaml
@@ -1,41 +1,26 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  # M0 mUSD on BSC (SpokePortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-    chainName: bsc
-    collateralAddressOrDenom: "0xaca92e438df0b2401ff60da7e4337b687a2435da"
-    connections:
-      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-    decimals: 6
-    logoURI: /deployments/warp_routes/mUSD/logo.svg
-    name: MetaMask USD
-    standard: EvmM0PortalLite
-    symbol: mUSD
-    warpRouteId: mUSD/musd
   # M0 mUSD on Ethereum (HubPortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+  - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
     chainName: ethereum
     collateralAddressOrDenom: "0xaca92e438df0b2401ff60da7e4337b687a2435da"
     connections:
-      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|monad|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
     decimals: 6
     logoURI: /deployments/warp_routes/mUSD/logo.svg
     name: MetaMask USD
-    standard: EvmM0PortalLite
+    standard: EvmM0Portal
     symbol: mUSD
     warpRouteId: mUSD/musd
-  # M0 mUSD on Linea (SpokePortal)
-  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
-    chainName: linea
+  # M0 mUSD on Monad (SpokePortal)
+  - addressOrDenom: "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
+    chainName: monad
     collateralAddressOrDenom: "0xaca92e438df0b2401ff60da7e4337b687a2435da"
     connections:
-      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
-      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|ethereum|0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd
     decimals: 6
     logoURI: /deployments/warp_routes/mUSD/logo.svg
     name: MetaMask USD
-    standard: EvmM0PortalLite
+    standard: EvmM0Portal
     symbol: mUSD
     warpRouteId: mUSD/musd

--- a/deployments/warp_routes/mUSD/musd-portal-lite-config.yaml
+++ b/deployments/warp_routes/mUSD/musd-portal-lite-config.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  # M0 mUSD on BSC (SpokePortal)
+  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    chainName: bsc
+    collateralAddressOrDenom: "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    connections:
+      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+    decimals: 6
+    logoURI: /deployments/warp_routes/mUSD/logo.svg
+    name: MetaMask USD
+    standard: EvmM0PortalLite
+    symbol: mUSD
+    warpRouteId: mUSD/musd-portal-lite
+  # M0 mUSD on Ethereum (HubPortal)
+  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    chainName: ethereum
+    collateralAddressOrDenom: "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    connections:
+      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|linea|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+    decimals: 6
+    logoURI: /deployments/warp_routes/mUSD/logo.svg
+    name: MetaMask USD
+    standard: EvmM0PortalLite
+    symbol: mUSD
+    warpRouteId: mUSD/musd-portal-lite
+  # M0 mUSD on Linea (SpokePortal)
+  - addressOrDenom: "0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE"
+    chainName: linea
+    collateralAddressOrDenom: "0xaca92e438df0b2401ff60da7e4337b687a2435da"
+    connections:
+      - token: ethereum|bsc|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+      - token: ethereum|ethereum|0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE
+    decimals: 6
+    logoURI: /deployments/warp_routes/mUSD/logo.svg
+    name: MetaMask USD
+    standard: EvmM0PortalLite
+    symbol: mUSD
+    warpRouteId: mUSD/musd-portal-lite


### PR DESCRIPTION
### Description

Add mUSD (Ethereum, Monad) warp route on the new EvmM0Portal. Split mUSD into two route configs: musd (Ethereum/Monad on EvmM0Portal) and musd-portal-lite (BSC/Ethereum/Linea on EvmM0PortalLite, to be deprecated).

### Backward compatibility

No, mUSD route configs was split into 2:

mUSD used on Ethereum and Monad via EvmM0Portal
mUSD used on Ethereum, BSC, and Linea via EvmM0PortalLite
Eventually EvmM0PortalLite will be deprecated, and all chains will migrate to EvmM0Portal
### Testing
