### PR TITLE
chore: update Zero Network explorer URL

### DIFF
--- a/.changeset/update-zeronetwork-explorer.md
+++ b/.changeset/update-zeronetwork-explorer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Update Zero Network block explorer to https://explorer.zero.network

--- a/chains/zeronetwork/metadata.yaml
+++ b/chains/zeronetwork/metadata.yaml
@@ -3,10 +3,10 @@ availability:
   reasons: [deprecated]
   status: disabled
 blockExplorers:
-  - apiUrl: https://zero-network.calderaexplorer.xyz/verification/contract_verification
-    family: etherscan
+  - apiUrl: https://explorer.zero.network
+    family: other
     name: Zero Network Explorer
-    url: https://zerion-explorer.vercel.app
+    url: https://explorer.zero.network
 blocks:
   confirmations: 1
   estimateBlockTime: 1


### PR DESCRIPTION
## Summary
- Update Zero Network block explorer to https://explorer.zero.network (both `url` and `apiUrl`)
- Change explorer `family` from `etherscan` to `other`

## Test plan
- [ ] CI lint/build passes