### PR TITLE
fix: removed warp fees from NEX/bsc

### DIFF
--- a/.changeset/cyan-deers-act.md
+++ b/.changeset/cyan-deers-act.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Removed warp fees from NEX/bsc route

--- a/deployments/warp_routes/NEX/bsc-deploy.yaml
+++ b/deployments/warp_routes/NEX/bsc-deploy.yaml
@@ -4,14 +4,6 @@ bsc:
   name: Nexus
   owner: "0x7b255508d4508497f00aaEe7f595f7A18039Cf87"
   symbol: NEX
-  tokenFee:
-    feeContracts:
-      ethereum:
-        bps: 6
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
-    owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-    type: RoutingFee
   type: synthetic
 
 ethereum:


### PR DESCRIPTION
### Description

Removed warp fees from NEX/bsc route

### Backward compatibility

<!--
Are these changes backward compatible? Note that additions are backwards compatible.

Yes/No
-->

### Testing

<!--
Have any new metadata configs and deployment addresses been used with any Hyperlane tooling, such as the CLI?
-->
