### PR TITLE
fix: point WARD/ward-base at the production Base↔Warden route

### DIFF
--- a/.changeset/ward-base-canonical-addresses.md
+++ b/.changeset/ward-base-canonical-addresses.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The WARD/ward-base route now points at the production Base↔Warden deployment (Base 0xf09e4C8193F16019F0573F370F9A997b11f56638 ↔ Warden 0xc5ADACe5E2250e5497CF1eF7B4f100e10099e4c4).

--- a/deployments/warp_routes/WARD/ward-base-config.yaml
+++ b/deployments/warp_routes/WARD/ward-base-config.yaml
@@ -1,18 +1,18 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x6252BefAc2E1a8f7CbD3d43C6B8479790F37a98f"
+  - addressOrDenom: "0xf09e4C8193F16019F0573F370F9A997b11f56638"
     chainName: base
     connections:
-      - token: ethereum|wardenprotocol|0x6252BefAc2E1a8f7CbD3d43C6B8479790F37a98f
+      - token: ethereum|wardenprotocol|0xc5ADACe5E2250e5497CF1eF7B4f100e10099e4c4
     decimals: 18
     logoURI: /deployments/warp_routes/WARD/logo.svg
     name: WARD
     standard: EvmHypSynthetic
     symbol: WARD
-  - addressOrDenom: "0x6252BefAc2E1a8f7CbD3d43C6B8479790F37a98f"
+  - addressOrDenom: "0xc5ADACe5E2250e5497CF1eF7B4f100e10099e4c4"
     chainName: wardenprotocol
     connections:
-      - token: ethereum|base|0x6252BefAc2E1a8f7CbD3d43C6B8479790F37a98f
+      - token: ethereum|base|0xf09e4C8193F16019F0573F370F9A997b11f56638
     decimals: 18
     logoURI: /deployments/warp_routes/WARD/logo.svg
     name: WARD


### PR DESCRIPTION
### Description

`WARD/ward-base` currently resolves to `0x6252BefAc2E1a8f7CbD3d43C6B8479790F37a98f` on both Base and Warden, which holds only ~595 WARD of bridged supply. The route that's actually in production use is a separate deployment with **18.5M WARD of bridged volume**:

- Base: `0xf09e4C8193F16019F0573F370F9A997b11f56638` (HypSynthetic, owned by the Base Safe `0x026AA469…`)
- Warden: `0xc5ADACe5E2250e5497CF1eF7B4f100e10099e4c4` (HypNative, owned by the Warden Safe `0x873f6699…`)

This PR updates the yaml so `WARD/ward-base` resolves to the production pair. Both routes use the same Mailbox (`0x15eECB28…`) and verify through the same 2-of-4 multisig (`0xE8935e…`), so the security model is unchanged. The original `0x6252…` deployment is left untouched on-chain.

### Backward compatibility

No. Tooling that previously dispatched through `WARD/ward-base` will now hit a different on-chain pair. Holders of synthetic WARD on the old Base `0x6252…` contract are not affected at the contract level — they can still bridge back by interacting with that contract directly — but the route ID will no longer resolve to it. Outstanding supply on that route is small (~595 WARD).

### Testing

Yes. End-to-end verified with a live Warden→Base transfer using the new addresses: native escrow on `0xc5ADACe5…` and synthetic mint on `0xf09e4C81…` both incremented as expected.

- Origin transaction (dispatch on Warden): https://explorer.wardenprotocol.org/tx/0xcdfcdfed5dd006743b5d6e51a1c975a9e6da15137ee31927950b64636132e0a3
- Destination transaction (mint on Base): https://basescan.org/tx/0xbabf53194317d56c8e99445c94659ffb5b8b87f1f5860ad85fdf46aa6cc2f8d7