### PR TITLE
feat: add HYPER warp deploy configs

### DIFF
--- a/deployments/warp_routes/HYPER/arbitrum-base-bsc-ethereum-optimism-deploy.yaml
+++ b/deployments/warp_routes/HYPER/arbitrum-base-bsc-ethereum-optimism-deploy.yaml
@@ -1,0 +1,36 @@
+arbitrum:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0xB4819e005091c10851bd4f5ECFa91f724FE7E83d"
+  symbol: HYPER
+  type: synthetic
+base:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0xcE1F1eB67477c2Ca49946Bb4f0e676fbA8a5Ad87"
+  symbol: HYPER
+  type: synthetic
+bsc:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0x117E878B9f8b1C2B455d3636380C1ED26e5e826e"
+  symbol: HYPER
+  type: synthetic
+ethereum:
+  contractVersion: 7.0.0
+  decimals: 18
+  initialSupply: "802666667000000000000000000"
+  name: Hyperlane
+  owner: "0x3D079E977d644c914a344Dcb5Ba54dB243Cc4863"
+  symbol: HYPER
+  type: hyperToken
+optimism:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0x9A7E243d6b7B9caA172B39c424A92df8282352Bf"
+  symbol: HYPER
+  type: synthetic

--- a/deployments/warp_routes/HYPERSTAGE/arbitrum-base-bsc-ethereum-optimism-deploy.yaml
+++ b/deployments/warp_routes/HYPERSTAGE/arbitrum-base-bsc-ethereum-optimism-deploy.yaml
@@ -1,0 +1,36 @@
+arbitrum:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0xC44C6eb6Fe37A6389B6b741A0A17dcB6b1aAbC89"
+  symbol: HYPER
+  type: synthetic
+base:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0xf189b22a6Be9378C5cDa94a6E72C6d18611291cA"
+  symbol: HYPER
+  type: synthetic
+bsc:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0xaE1DA73F3aB27F30b32239114d4d14c789D64176"
+  symbol: HYPER
+  type: synthetic
+ethereum:
+  contractVersion: 7.0.0
+  decimals: 18
+  initialSupply: "1000000000000000000000000000"
+  name: Hyperlane
+  owner: "0xf0b850930ede8807e7F472b610b017c187E0e493"
+  symbol: HYPER
+  type: hyperToken
+optimism:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Hyperlane
+  owner: "0x6Fd6Be005D6e122b51b33044968d6CDB5F7A292c"
+  symbol: HYPER
+  type: synthetic

--- a/deployments/warp_routes/stHYPER/bsc-ethereum-deploy.yaml
+++ b/deployments/warp_routes/stHYPER/bsc-ethereum-deploy.yaml
@@ -1,0 +1,16 @@
+bsc:
+  collateralChainName: ethereum
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Staked HYPER
+  owner: "0x117E878B9f8b1C2B455d3636380C1ED26e5e826e"
+  symbol: stHYPER
+  type: syntheticRebase
+ethereum:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Staked HYPER
+  owner: "0x3D079E977d644c914a344Dcb5Ba54dB243Cc4863"
+  symbol: stHYPER
+  token: "0xa860e01Cc4A889BB2917EC97104510A2e1Ae0e53"
+  type: collateralVaultRebase

--- a/deployments/warp_routes/stHYPERSTAGE/bsc-ethereum-deploy.yaml
+++ b/deployments/warp_routes/stHYPERSTAGE/bsc-ethereum-deploy.yaml
@@ -1,0 +1,16 @@
+bsc:
+  collateralChainName: ethereum
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Staked HYPER
+  owner: "0xaE1DA73F3aB27F30b32239114d4d14c789D64176"
+  symbol: stHYPER
+  type: syntheticRebase
+ethereum:
+  contractVersion: 7.0.0
+  decimals: 18
+  name: Staked HYPER
+  owner: "0xf0b850930ede8807e7F472b610b017c187E0e493"
+  symbol: stHYPER
+  token: "0x9FB258cbd8415C4Fda62092003FCB54F60Af670B"
+  type: collateralVaultRebase


### PR DESCRIPTION
## Summary

- Adds warp deploy configs (`*-deploy.yaml`) for HYPER, stHYPER, HYPERSTAGE, and stHYPERSTAGE warp routes.
- Generated from the monorepo infra config getter (`getHyperWarpConfig`); pairs with [hyperlane-monorepo#6030](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6030).
- Captures `contractVersion: 7.0.0` (the deployed version) and owner ICA addresses across all 5 chains for production and staging.

## Test plan

- [ ] `hyperlane warp check` for each route returns no functional violations (etherscan API noise and `ownerStatus: inactive` for undeployed counterfactual ICAs are expected).