### PR TITLE
test: require collateralAddressOrDenom on non-native collateralized warp tokens

### DIFF
--- a/.changeset/enforce-collateral-address.md
+++ b/.changeset/enforce-collateral-address.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Backfilled the missing collateralAddressOrDenom on every non-native collateralized warp token (USDC/mainnet-cctp-v2-fast, USDC/mainnet-cctp-v2-standard, USDT/oft, USDT/oft-legacy, KYVE/base-kyve, MILK/bsc-milkyway) and added a registry test that enforces the invariant going forward, so dedup and route resolution can match tokens sharing the same underlying asset across routes.

--- a/deployments/warp_routes/KYVE/base-kyve-config.yaml
+++ b/deployments/warp_routes/KYVE/base-kyve-config.yaml
@@ -11,6 +11,7 @@ tokens:
     symbol: KYVE
   - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
     chainName: kyve
+    collateralAddressOrDenom: ukyve
     coinGeckoId: kyve-network
     connections:
       - token: ethereum|base|0xAD13BcE42394Add02e6c215a40e582309B7975C7

--- a/deployments/warp_routes/MILK/bsc-milkyway-config.yaml
+++ b/deployments/warp_routes/MILK/bsc-milkyway-config.yaml
@@ -11,6 +11,7 @@ tokens:
     symbol: MILK
   - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
     chainName: milkyway
+    collateralAddressOrDenom: umilk
     coinGeckoId: milkyway-2
     connections:
       - token: ethereum|bsc|0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml
@@ -1,6 +1,7 @@
 tokens:
   - addressOrDenom: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
     chainName: arbitrum
+    collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
       - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -22,6 +23,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
     chainName: avalanche
+    collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -43,6 +45,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
     chainName: base
+    collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -64,6 +67,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
     chainName: ethereum
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -85,6 +89,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
     chainName: hyperevm
+    collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -106,6 +111,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
     chainName: ink
+    collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -127,6 +133,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
     chainName: linea
+    collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -148,6 +155,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
     chainName: optimism
+    collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -169,6 +177,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x890CB8Dd7b6817b2Ab45b484264386ee48000F21"
     chainName: plume
+    collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -190,6 +199,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
     chainName: polygon
+    collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -211,6 +221,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x3Ce3585d2Fa9AfB4101Fd6007b0839ddCb5b9599"
     chainName: sei
+    collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -232,6 +243,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x45935ea31cF8fd877122DB8D9c47065Bbc095135"
     chainName: sonic
+    collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -253,6 +265,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
     chainName: unichain
+    collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -274,6 +287,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
     chainName: worldchain
+    collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml
@@ -1,6 +1,7 @@
 tokens:
   - addressOrDenom: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
     chainName: arbitrum
+    collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
       - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -22,6 +23,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: avalanche
+    collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -43,6 +45,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: base
+    collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -64,6 +67,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
     chainName: ethereum
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -85,6 +89,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
     chainName: hyperevm
+    collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -106,6 +111,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
     chainName: ink
+    collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -127,6 +133,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: linea
+    collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -148,6 +155,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: optimism
+    collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -169,6 +177,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
     chainName: plume
+    collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -190,6 +199,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: polygon
+    collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -211,6 +221,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x346961e35b9a2ea5511AA5FC44DBF61Ab0f293F6"
     chainName: sei
+    collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -232,6 +243,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: sonic
+    collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -253,6 +265,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: unichain
+    collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -274,6 +287,7 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: worldchain
+    collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a

--- a/deployments/warp_routes/USDT/oft-config.yaml
+++ b/deployments/warp_routes/USDT/oft-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
     chainName: arbitrum
+    collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
     connections:
       - token: ethereum|ethereum|0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6
       - token: ethereum|plasma|0x93bfFA2231fbA5029997603fb68D9aC08024Baa2
@@ -11,6 +12,7 @@ tokens:
     symbol: USDT
   - addressOrDenom: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
     chainName: ethereum
+    collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
     connections:
       - token: ethereum|arbitrum|0xE4c1A1E54C232454311cF68610c3885FdD991c0E
       - token: ethereum|plasma|0x93bfFA2231fbA5029997603fb68D9aC08024Baa2
@@ -20,6 +22,7 @@ tokens:
     symbol: USDT
   - addressOrDenom: "0x93bfFA2231fbA5029997603fb68D9aC08024Baa2"
     chainName: plasma
+    collateralAddressOrDenom: "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb"
     connections:
       - token: ethereum|arbitrum|0xE4c1A1E54C232454311cF68610c3885FdD991c0E
       - token: ethereum|ethereum|0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6

--- a/deployments/warp_routes/USDT/oft-legacy-config.yaml
+++ b/deployments/warp_routes/USDT/oft-legacy-config.yaml
@@ -2,6 +2,7 @@
 tokens:
   - addressOrDenom: "0x9323793FB9a071ce5fE839079925c0e39f37170F"
     chainName: arbitrum
+    collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
     connections:
       - token: ethereum|ethereum|0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B
       - token: tron|tron|0x43Bb7C9C64a05af94d67B52883a60756950058D7
@@ -11,6 +12,7 @@ tokens:
     symbol: USDT
   - addressOrDenom: "0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B"
     chainName: ethereum
+    collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
     connections:
       - token: ethereum|arbitrum|0x9323793FB9a071ce5fE839079925c0e39f37170F
       - token: tron|tron|0x43Bb7C9C64a05af94d67B52883a60756950058D7
@@ -20,6 +22,7 @@ tokens:
     symbol: USDT
   - addressOrDenom: "0x43Bb7C9C64a05af94d67B52883a60756950058D7"
     chainName: tron
+    collateralAddressOrDenom: "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
     connections:
       - token: ethereum|arbitrum|0x9323793FB9a071ce5fE839079925c0e39f37170F
       - token: ethereum|ethereum|0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -4190,6 +4190,7 @@ KYVE/base-kyve:
     - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
       chainName: kyve
       coinGeckoId: kyve-network
+      collateralAddressOrDenom: ukyve
       connections:
         - token: ethereum|base|0xAD13BcE42394Add02e6c215a40e582309B7975C7
       decimals: 6
@@ -4727,6 +4728,7 @@ MILK/bsc-milkyway:
     - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000000"
       chainName: milkyway
       coinGeckoId: milkyway-2
+      collateralAddressOrDenom: umilk
       connections:
         - token: ethereum|bsc|0x7b4Bf9fEcCfF207eF2CB7101Ceb15b8516021AcD
       decimals: 6
@@ -8717,6 +8719,7 @@ USDC/mainnet-cctp-v2-fast:
   tokens:
     - addressOrDenom: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
       chainName: arbitrum
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
       connections:
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
         - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -8738,6 +8741,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
       chainName: avalanche
+      collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -8759,6 +8763,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
       chainName: base
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8780,6 +8785,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
       chainName: ethereum
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8801,6 +8807,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
       chainName: hyperevm
+      collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8822,6 +8829,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
       chainName: ink
+      collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8843,6 +8851,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
       chainName: linea
+      collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8864,6 +8873,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
       chainName: optimism
+      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8885,6 +8895,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x890CB8Dd7b6817b2Ab45b484264386ee48000F21"
       chainName: plume
+      collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8906,6 +8917,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
       chainName: polygon
+      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8927,6 +8939,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x3Ce3585d2Fa9AfB4101Fd6007b0839ddCb5b9599"
       chainName: sei
+      collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8948,6 +8961,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x45935ea31cF8fd877122DB8D9c47065Bbc095135"
       chainName: sonic
+      collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8969,6 +8983,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
       chainName: unichain
+      collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -8990,6 +9005,7 @@ USDC/mainnet-cctp-v2-fast:
       symbol: USDC
     - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
       chainName: worldchain
+      collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9013,6 +9029,7 @@ USDC/mainnet-cctp-v2-standard:
   tokens:
     - addressOrDenom: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       chainName: arbitrum
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
       connections:
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
         - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9034,6 +9051,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: avalanche
+      collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9055,6 +9073,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: base
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9076,6 +9095,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       chainName: ethereum
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9097,6 +9117,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       chainName: hyperevm
+      collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9118,6 +9139,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       chainName: ink
+      collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9139,6 +9161,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: linea
+      collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9160,6 +9183,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: optimism
+      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9181,6 +9205,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       chainName: plume
+      collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9202,6 +9227,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: polygon
+      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9223,6 +9249,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x346961e35b9a2ea5511AA5FC44DBF61Ab0f293F6"
       chainName: sei
+      collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9244,6 +9271,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: sonic
+      collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9265,6 +9293,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: unichain
+      collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9286,6 +9315,7 @@ USDC/mainnet-cctp-v2-standard:
       symbol: USDC
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: worldchain
+      collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -11623,6 +11653,7 @@ USDT/oft:
   tokens:
     - addressOrDenom: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
       chainName: arbitrum
+      collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
       connections:
         - token: ethereum|ethereum|0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6
         - token: ethereum|plasma|0x93bfFA2231fbA5029997603fb68D9aC08024Baa2
@@ -11632,6 +11663,7 @@ USDT/oft:
       symbol: USDT
     - addressOrDenom: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
       chainName: ethereum
+      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
       connections:
         - token: ethereum|arbitrum|0xE4c1A1E54C232454311cF68610c3885FdD991c0E
         - token: ethereum|plasma|0x93bfFA2231fbA5029997603fb68D9aC08024Baa2
@@ -11641,6 +11673,7 @@ USDT/oft:
       symbol: USDT
     - addressOrDenom: "0x93bfFA2231fbA5029997603fb68D9aC08024Baa2"
       chainName: plasma
+      collateralAddressOrDenom: "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb"
       connections:
         - token: ethereum|arbitrum|0xE4c1A1E54C232454311cF68610c3885FdD991c0E
         - token: ethereum|ethereum|0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6
@@ -11652,6 +11685,7 @@ USDT/oft-legacy:
   tokens:
     - addressOrDenom: "0x9323793FB9a071ce5fE839079925c0e39f37170F"
       chainName: arbitrum
+      collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
       connections:
         - token: ethereum|ethereum|0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B
         - token: tron|tron|0x43Bb7C9C64a05af94d67B52883a60756950058D7
@@ -11661,6 +11695,7 @@ USDT/oft-legacy:
       symbol: USDT
     - addressOrDenom: "0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B"
       chainName: ethereum
+      collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
       connections:
         - token: ethereum|arbitrum|0x9323793FB9a071ce5fE839079925c0e39f37170F
         - token: tron|tron|0x43Bb7C9C64a05af94d67B52883a60756950058D7
@@ -11670,6 +11705,7 @@ USDT/oft-legacy:
       symbol: USDT
     - addressOrDenom: "0x43Bb7C9C64a05af94d67B52883a60756950058D7"
       chainName: tron
+      collateralAddressOrDenom: "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
       connections:
         - token: ethereum|arbitrum|0x9323793FB9a071ce5fE839079925c0e39f37170F
         - token: ethereum|ethereum|0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B

--- a/test/unit/warp-routes.test.ts
+++ b/test/unit/warp-routes.test.ts
@@ -98,6 +98,23 @@ describe('Warp Core Configs', () => {
         ).to.be.true;
       }
     });
+
+    it(`WarpCore ${id} non-native collateralized tokens have collateralAddressOrDenom`, () => {
+      const config = routes[id];
+      const warpCore = WarpCore.FromConfig(multiProvider, config);
+      for (const token of warpCore.tokens) {
+        // Only HypNative is legitimately collateralized without an explicit
+        // collateral address; every other collateralized standard must point
+        // at its underlying so dedup and route resolution can match across
+        // routes that share the same underlying asset.
+        if (token.isCollateralized() && !token.isHypNative()) {
+          expect(
+            token.collateralAddressOrDenom,
+            `${token.symbol} on ${token.chainName} (${token.standard}) is collateralized but missing collateralAddressOrDenom`,
+          ).to.be.a('string').and.not.empty;
+        }
+      }
+    });
   }
 });
 


### PR DESCRIPTION
## Summary

- Backfill `collateralAddressOrDenom` on every non-native collateralized warp token currently missing it across `USDC/mainnet-cctp-v2-fast` (14 chains), `USDC/mainnet-cctp-v2-standard` (14 chains), `USDT/oft` (3 chains), `USDT/oft-legacy` (3 chains), `KYVE/base-kyve` (kyve → `ukyve`), and `MILK/bsc-milkyway` (milkyway → `umilk`).
- Add a registry test that asserts every token with `isCollateralized() && !isHypNative()` carries a non-empty `collateralAddressOrDenom`, matching the invariant already documented in the SDK at `typescript/sdk/src/token/TokenMetadata.ts:49-50` ("Only HypNative collateral legitimately lacks collateralAddressOrDenom").

## Why

The `hyperlane-warp-ui-template` (and other consumers) deduplicates and reconciles tokens across warp routes via their collateral key. When a non-native collateralized token is missing `collateralAddressOrDenom`, it falls into a synthetic "hypnative" key that doesn't dedup with other routes sharing the same underlying asset. That fragments dedup and breaks UI route resolution — `findConnectedDestinationToken` can return undefined because the deduped origin and destination tokens come from incompatible routes. Adding the field restores the invariant.

This surfaced during the `hyperlane-warp-ui-template#1081` (SDK 35.0.0 + registry 25.1.0) dep-bump, where the newly added `USDC/moonpay-config.yaml` shifted iteration order such that the picker landed on the `mainnet-cctp-v2-fast` Base USDC token (which has the broken hypnative key), causing `findConnectedDestinationToken` to return undefined and dropping the Remote Token row from the review panel.

## Verification

- **EVM routers (32):** queried `wrappedToken()` on every router across cctp-v2-fast, cctp-v2-standard, USDT/oft, USDT/oft-legacy. Every result matches the corresponding `*-deploy.yaml` `token` field exactly. Polygon RPC was the only chain that needed a retry on a different public endpoint.
- **Tron OFT-legacy:** queried via TronGrid `triggerconstantcontract`. The router returns `0xa614f803b6fd780986a42c78ec9c7f77e6ded13c`, which decodes to `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` — the official Tron USDT (TUSDT).
- **KYVE:** chain metadata `canonicalAsset: ukyve`, live staking module `bond_denom: "ukyve"` via `https://api.kyve.network/cosmos/staking/v1beta1/params`, live `ukyve` supply ≈ 1.28B microKYVE.
- **MILK:** chain metadata `canonicalAsset: umilk`, `gasPrice.denom: umilk`. Chain is marked `availability.status: disabled` and the route is being sunset (`KI-001`), so on-chain live verification isn't possible; the value matches the same pattern every other `CosmosNativeHypCollateral` route follows (e.g. TIA on celestia → `utia`).

## Test plan

- [ ] CI passes `test:unit`, including the new "non-native collateralized tokens have collateralAddressOrDenom" case (locally: 326 cases passing, 2063 in the full warp-routes file).
- [ ] CI runs `test:unit` against all routes and confirms there are no other tokens missing the field.