### PR TITLE
fix: upgrade aleotestnet RPC endpoint to v2

### DIFF
--- a/.changeset/aleotestnet-rpc-v2.md
+++ b/.changeset/aleotestnet-rpc-v2.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Upgrade aleotestnet RPC endpoint from https://api.explorer.provable.com/v1 to https://api.explorer.provable.com/v2.

--- a/chains/aleotestnet/metadata.yaml
+++ b/chains/aleotestnet/metadata.yaml
@@ -24,4 +24,4 @@ nativeToken:
   symbol: ALEO
 protocol: aleo
 rpcUrls:
-  - http: https://api.explorer.provable.com/v1
+  - http: https://api.explorer.provable.com/v2

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -162,7 +162,7 @@ aleotestnet:
     symbol: ALEO
   protocol: aleo
   rpcUrls:
-    - http: https://api.explorer.provable.com/v1
+    - http: https://api.explorer.provable.com/v2
 alephzeroevmmainnet:
   availability:
     reasons:


### PR DESCRIPTION
## Summary
- Bumps the `aleotestnet` RPC URL in the registry from `https://api.explorer.provable.com/v1` to `https://api.explorer.provable.com/v2`.
- Updates both the per-chain `chains/aleotestnet/metadata.yaml` and the aggregated `chains/metadata.yaml`.
- Matches the `aleo` mainnet entry, which is already on `/v2`.

Requested by @troywiipongwii in the on-call thread.

## Test plan
- [x] Registry CI passes
- [x] Spot-check that the new endpoint responds: `curl -s https://api.explorer.provable.com/v2/testnet/latest/height`