### PR TITLE
chore: lower monad reorgPeriod from 5 to 1

### DIFF
--- a/.changeset/lower-monad-reorg-period.md
+++ b/.changeset/lower-monad-reorg-period.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Lowered monad reorgPeriod from 5 to 1 to better reflect MonadBFT's deterministic finality.

--- a/chains/monad/metadata.yaml
+++ b/chains/monad/metadata.yaml
@@ -12,7 +12,7 @@ blockExplorers:
 blocks:
   confirmations: 1
   estimateBlockTime: 1
-  reorgPeriod: 5
+  reorgPeriod: 1
 chainId: 143
 deployer:
   name: Abacus Works


### PR DESCRIPTION
### Description

Monad uses MonadBFT with ~1s block times and deterministic single-slot finality (a block is locked once the next block's QC commits). The current `reorgPeriod: 5` was a conservative default carried over from the Sep 29 chain-deploys batch (#1168) and was not based on Monad-specific analysis — confirmed with @paulbalaji in Slack.

Lowering to `1` matches `monadtestnet` and the chain's deterministic finality guarantees, which should reduce Hyperlane delivery latency on Monad without meaningful reorg risk.

### Backward compatibility

Yes — `reorgPeriod` is consumed by agents/SDK at config-load time; lowering it shortens the confirmation window but doesn't break interfaces or storage.

### Testing

Manual: validated the YAML diff against `chains/monadtestnet/metadata.yaml` (also `reorgPeriod: 1`). No other agent config changes required.