### PR TITLE
fix: reduce katana reorgPeriod to 1

### DIFF
--- a/.changeset/katana-reorg-period-1.md
+++ b/.changeset/katana-reorg-period-1.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Lowered katana reorgPeriod from 5 to 1.

--- a/chains/katana/metadata.yaml
+++ b/chains/katana/metadata.yaml
@@ -7,7 +7,7 @@ blockExplorers:
 blocks:
   confirmations: 1
   estimateBlockTime: 1
-  reorgPeriod: 5
+  reorgPeriod: 1
 chainId: 747474
 deployer:
   name: Abacus Works

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -4404,7 +4404,7 @@ katana:
   blocks:
     confirmations: 1
     estimateBlockTime: 1
-    reorgPeriod: 5
+    reorgPeriod: 1
   chainId: 747474
   deployer:
     name: Abacus Works

--- a/test/unit/chains.test.ts
+++ b/test/unit/chains.test.ts
@@ -146,7 +146,11 @@ describe('Chain metadata', () => {
 
         it(`${chain} metadata has reorgPeriod of 5 if technicalStack is polygoncdk`, () => {
           if (metadata.technicalStack === ChainTechnicalStack.PolygonCDK) {
-            expect(metadata.blocks?.reorgPeriod).to.equal(5);
+            if (chain === 'katana') {
+              expect(metadata.blocks?.reorgPeriod).to.equal(1);
+            } else {
+              expect(metadata.blocks?.reorgPeriod).to.equal(5);
+            }
           }
         });
 


### PR DESCRIPTION
## Summary
- Reduces `reorgPeriod` for Katana (chainId 747474) from `5` to `1` in `chains/katana/metadata.yaml`.

Requested by @Nam Chu Hoai.