### PR TITLE
fix: backfill CCTP/OFT warp route token types

### DIFF
--- a/.changeset/backfill-cctp-oft-token-types.md
+++ b/.changeset/backfill-cctp-oft-token-types.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Backfilled USDC mainnet CCTP v2 and USDT OFT warp route configs with deploy token types.

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml
@@ -19,6 +19,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
     chainName: avalanche
@@ -40,6 +41,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
     chainName: base
@@ -61,6 +63,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
     chainName: ethereum
@@ -82,6 +85,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
     chainName: hyperevm
@@ -103,6 +107,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
     chainName: ink
@@ -124,6 +129,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
     chainName: linea
@@ -145,6 +151,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
     chainName: optimism
@@ -166,6 +173,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x890CB8Dd7b6817b2Ab45b484264386ee48000F21"
     chainName: plume
@@ -187,6 +195,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
     chainName: polygon
@@ -208,6 +217,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x3Ce3585d2Fa9AfB4101Fd6007b0839ddCb5b9599"
     chainName: sei
@@ -229,6 +239,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x45935ea31cF8fd877122DB8D9c47065Bbc095135"
     chainName: sonic
@@ -250,6 +261,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
     chainName: unichain
@@ -271,6 +283,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
     chainName: worldchain
@@ -292,4 +305,5 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml
@@ -19,6 +19,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: avalanche
@@ -40,6 +41,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: base
@@ -61,6 +63,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
     chainName: ethereum
@@ -82,6 +85,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
     chainName: hyperevm
@@ -103,6 +107,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
     chainName: ink
@@ -124,6 +129,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: linea
@@ -145,6 +151,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: optimism
@@ -166,6 +173,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
     chainName: plume
@@ -187,6 +195,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: polygon
@@ -208,6 +217,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x346961e35b9a2ea5511AA5FC44DBF61Ab0f293F6"
     chainName: sei
@@ -229,6 +239,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: sonic
@@ -250,6 +261,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: unichain
@@ -271,6 +283,7 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: worldchain
@@ -292,4 +305,5 @@ tokens:
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USDC
     standard: EvmHypCollateral
+    tokenType: collateralCctp
     symbol: USDC

--- a/deployments/warp_routes/USDT/oft-config.yaml
+++ b/deployments/warp_routes/USDT/oft-config.yaml
@@ -8,6 +8,7 @@ tokens:
     decimals: 6
     name: Tether USD
     standard: EvmHypCollateral
+    tokenType: collateralOft
     symbol: USDT
   - addressOrDenom: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
     chainName: ethereum
@@ -17,6 +18,7 @@ tokens:
     decimals: 6
     name: Tether USD
     standard: EvmHypCollateral
+    tokenType: collateralOft
     symbol: USDT
   - addressOrDenom: "0x93bfFA2231fbA5029997603fb68D9aC08024Baa2"
     chainName: plasma
@@ -26,4 +28,5 @@ tokens:
     decimals: 6
     name: Tether USD
     standard: EvmHypCollateral
+    tokenType: collateralOft
     symbol: USDT

--- a/deployments/warp_routes/USDT/oft-legacy-config.yaml
+++ b/deployments/warp_routes/USDT/oft-legacy-config.yaml
@@ -8,6 +8,7 @@ tokens:
     decimals: 6
     name: Tether USD
     standard: EvmHypCollateral
+    tokenType: collateralOft
     symbol: USDT
   - addressOrDenom: "0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B"
     chainName: ethereum
@@ -17,6 +18,7 @@ tokens:
     decimals: 6
     name: Tether USD
     standard: EvmHypCollateral
+    tokenType: collateralOft
     symbol: USDT
   - addressOrDenom: "0x43Bb7C9C64a05af94d67B52883a60756950058D7"
     chainName: tron
@@ -26,4 +28,5 @@ tokens:
     decimals: 6
     name: Tether USD
     standard: TronHypCollateral
+    tokenType: collateralOft
     symbol: USDT

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -8939,6 +8939,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
       chainName: avalanche
       connections:
@@ -8960,6 +8961,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
       chainName: base
       connections:
@@ -8981,6 +8983,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
       chainName: ethereum
       connections:
@@ -9002,6 +9005,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
       chainName: hyperevm
       connections:
@@ -9023,6 +9027,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
       chainName: ink
       connections:
@@ -9044,6 +9049,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
       chainName: linea
       connections:
@@ -9065,6 +9071,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
       chainName: optimism
       connections:
@@ -9086,6 +9093,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x890CB8Dd7b6817b2Ab45b484264386ee48000F21"
       chainName: plume
       connections:
@@ -9107,6 +9115,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
       chainName: polygon
       connections:
@@ -9128,6 +9137,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x3Ce3585d2Fa9AfB4101Fd6007b0839ddCb5b9599"
       chainName: sei
       connections:
@@ -9149,6 +9159,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x45935ea31cF8fd877122DB8D9c47065Bbc095135"
       chainName: sonic
       connections:
@@ -9170,6 +9181,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
       chainName: unichain
       connections:
@@ -9191,6 +9203,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
       chainName: worldchain
       connections:
@@ -9212,6 +9225,7 @@ USDC/mainnet-cctp-v2-fast:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
 USDC/mainnet-cctp-v2-standard:
   tokens:
     - addressOrDenom: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
@@ -9235,6 +9249,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: avalanche
       connections:
@@ -9256,6 +9271,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: base
       connections:
@@ -9277,6 +9293,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       chainName: ethereum
       connections:
@@ -9298,6 +9315,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       chainName: hyperevm
       connections:
@@ -9319,6 +9337,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       chainName: ink
       connections:
@@ -9340,6 +9359,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: linea
       connections:
@@ -9361,6 +9381,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: optimism
       connections:
@@ -9382,6 +9403,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       chainName: plume
       connections:
@@ -9403,6 +9425,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: polygon
       connections:
@@ -9424,6 +9447,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USD Coin
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x346961e35b9a2ea5511AA5FC44DBF61Ab0f293F6"
       chainName: sei
       connections:
@@ -9445,6 +9469,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: sonic
       connections:
@@ -9466,6 +9491,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: unichain
       connections:
@@ -9487,6 +9513,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: worldchain
       connections:
@@ -9508,6 +9535,7 @@ USDC/mainnet-cctp-v2-standard:
       name: USDC
       standard: EvmHypCollateral
       symbol: USDC
+      tokenType: collateralCctp
 USDC/mantra:
   tokens:
     - addressOrDenom: "0x82B0d43eFE1aa9877b8C35319006Af2916203e52"
@@ -11855,6 +11883,7 @@ USDT/oft:
       name: Tether USD
       standard: EvmHypCollateral
       symbol: USDT
+      tokenType: collateralOft
     - addressOrDenom: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
       chainName: ethereum
       connections:
@@ -11864,6 +11893,7 @@ USDT/oft:
       name: Tether USD
       standard: EvmHypCollateral
       symbol: USDT
+      tokenType: collateralOft
     - addressOrDenom: "0x93bfFA2231fbA5029997603fb68D9aC08024Baa2"
       chainName: plasma
       connections:
@@ -11873,6 +11903,7 @@ USDT/oft:
       name: Tether USD
       standard: EvmHypCollateral
       symbol: USDT
+      tokenType: collateralOft
 USDT/oft-legacy:
   tokens:
     - addressOrDenom: "0x9323793FB9a071ce5fE839079925c0e39f37170F"
@@ -11884,6 +11915,7 @@ USDT/oft-legacy:
       name: Tether USD
       standard: EvmHypCollateral
       symbol: USDT
+      tokenType: collateralOft
     - addressOrDenom: "0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B"
       chainName: ethereum
       connections:
@@ -11893,6 +11925,7 @@ USDT/oft-legacy:
       name: Tether USD
       standard: EvmHypCollateral
       symbol: USDT
+      tokenType: collateralOft
     - addressOrDenom: "0x43Bb7C9C64a05af94d67B52883a60756950058D7"
       chainName: tron
       connections:
@@ -11902,6 +11935,7 @@ USDT/oft-legacy:
       name: Tether USD
       standard: TronHypCollateral
       symbol: USDT
+      tokenType: collateralOft
 USDT/solanamainnet-nara:
   tokens:
     - addressOrDenom: DCTt9H3pwwU89qC3Z4voYNThZypV68AwhYNzMNBxWXoy


### PR DESCRIPTION
## Summary
- Backfilled `tokenType` for `USDC/mainnet-cctp-v2-fast`.
- Backfilled `tokenType` for `USDC/mainnet-cctp-v2-standard`.
- Backfilled `tokenType` for `USDT/oft`.
- Backfilled `tokenType` for `USDT/oft-legacy`.
- Regenerated `warpRouteConfigs.yaml`.

## Context
Supports hyperlane-monorepo PR #8844, which uses `tokenType` to skip destination collateral checks for protocol-backed CCTP/OFT collateral routes. Scope is intentionally limited to the two mainnet CCTP v2 routes and the two USDT OFT routes.

## Backward compatibility
Registry data only. `tokenType` is supported by `@hyperlane-xyz/sdk@35.1.0`; existing consumers that ignore unknown metadata are unaffected.

## Testing
- `pnpm build`
- `pnpm test:unit`
- `pnpm lint`
- `pnpm format`
- `git diff --check`

## check-warp-deploy notes
`check-warp-deploy` selects `USDC/mainnet-cctp-v2-fast`, `USDC/mainnet-cctp-v2-standard`, `USDT/oft`, and `USDT/oft-legacy`. Config Sync is passing for all four routes. On-chain checks still fail due to known live-read issues: Sei RPC rate limits, USDT/OFT on-chain Polygon domain mapping drift, and Tron verifier API returning HTML instead of JSON.