### PR TITLE
fix: add direct Celestia->Forma Hyperlane leg to TIA/forma-stride

### DIFF
--- a/.changeset/tia-forma-stride-direct-celestia-leg.md
+++ b/.changeset/tia-forma-stride-direct-celestia-leg.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added the direct Celestia to Forma Hyperlane leg to the TIA/forma-stride warp route config, mirroring the existing two-hop IBC path so direct Celestia to Forma transfers resolve to a known token.

--- a/deployments/warp_routes/TIA/forma-stride-config.yaml
+++ b/deployments/warp_routes/TIA/forma-stride-config.yaml
@@ -39,11 +39,23 @@ tokens:
     name: TIA
     standard: CosmosIbc
     symbol: TIA
+  # TIA Celestia to Forma (direct Hyperlane)
+  - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000008"
+    chainName: celestia
+    collateralAddressOrDenom: utia
+    connections:
+      - token: ethereum|forma|0x832d26B6904BA7539248Db4D58614251FD63dC05
+    decimals: 6
+    logoURI: /deployments/warp_routes/TIA/logo.svg
+    name: TIA
+    standard: CosmosNativeHypCollateral
+    symbol: TIA
   # TIA on Forma from Stride
   - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
     chainName: forma
     connections:
       - token: cosmos|stride|stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
+      - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000010000000000000008
     decimals: 18
     logoURI: /deployments/warp_routes/TIA/logo.svg
     name: TIA

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -6610,10 +6610,21 @@ TIA/forma-stride:
       name: TIA
       standard: CosmosIbc
       symbol: TIA
+    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000010000000000000008"
+      chainName: celestia
+      collateralAddressOrDenom: utia
+      connections:
+        - token: ethereum|forma|0x832d26B6904BA7539248Db4D58614251FD63dC05
+      decimals: 6
+      logoURI: /deployments/warp_routes/TIA/logo.svg
+      name: TIA
+      standard: CosmosNativeHypCollateral
+      symbol: TIA
     - addressOrDenom: "0x832d26B6904BA7539248Db4D58614251FD63dC05"
       chainName: forma
       connections:
         - token: cosmos|stride|stride1h4rhlwcmdwnnd99agxm3gp7uqkr4vcjd73m4586hcuklh3vdtldqgqmjxc
+        - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000010000000000000008
       decimals: 18
       logoURI: /deployments/warp_routes/TIA/logo.svg
       name: TIA


### PR DESCRIPTION
## Incident

Direct Celestia -> Forma TIA transfers show a blank "Warped Token" column in the Hyperlane Explorer. The explorer matches a message to a warp token by looking up the on-chain `sender` (origin) and `recipient` (destination) against the registry warp config (keyed per chain by `addressOrDenom`). For these transfers the on-chain Celestia sender is the Celestia Hyperlane warp router `0x726f...0008`, but the `TIA/forma-stride` config only described the Celestia leg as an IBC denom token (`addressOrDenom: utia`, `standard: CosmosIbc`) plus a two-hop `ibc-hyperlane` path through Stride. The direct Celestia<->Forma Hyperlane router pair was missing from the config, so the origin lookup failed and the cell stayed blank.

## Change

Added the missing **direct** Celestia -> Forma Hyperlane leg to `deployments/warp_routes/TIA/forma-stride-config.yaml`, mirroring the existing `celestia-ethereum-config.yaml` pattern:

- New Celestia token: `standard: CosmosNativeHypCollateral`, `addressOrDenom: 0x726f757465725f61707000000000000000000000000000010000000000000008`, `collateralAddressOrDenom: utia`, connected to the Forma token.
- Added the reciprocal connection on the existing Forma `0x832d...dC05` token (`cosmosnative|celestia|0x726f...0008`).

The existing IBC and two-hop `ibc-hyperlane` Stride legs are left untouched — the two-hop path remains a separate, valid route. The combined generated `warpRouteConfigs.yaml` was regenerated via `pnpm run build`.

## Verification

All confirmed live on-chain (no owner sign-off needed for the data itself):

**Forma side** (`0x832d26B6904BA7539248Db4D58614251FD63dC05`, RPC https://rpc.forma.art, `localDomain` 984122):
- `domains()` -> `[1128614981]` (celestia)
- `routers(1128614981)` -> `0x726f757465725f61707000000000000000000000000000010000000000000008` (exact match)
- No `wrappedToken()` and `decimals()` reverts -> native router (consistent with `EvmNative`).

**Celestia side** (`hyperlane.warp.v1.Query` via gRPC `celestia-grpc.publicnode.com:443`):
- `Token(0x726f...0008)` -> `tokenType: HYP_TOKEN_TYPE_COLLATERAL`, `originDenom: utia` (matches `CosmosNativeHypCollateral` + `collateralAddressOrDenom: utia`).
- `RemoteRouters(0x726f...0008)` -> `receiverDomain: 984122` (forma), `receiverContract: 0x000...832d26B6904BA7539248Db4D58614251FD63dC05` (exact match).

Bidirectional enrollment is verified: Forma enrolls Celestia `...0008`, and Celestia `...0008` enrolls Forma `0x832d...dC05`.

**Validation run locally:**
- `pnpm run build` — succeeds (parses + zod/schema-validates all warp configs).
- `pnpm exec mocha ... warp-routes.test.ts --grep "TIA/forma-stride"` — 4 passing (`WarpCore.FromConfig` accepts the config; logoURI checks pass).

**Still needs owner sign-off:** none required for correctness of this data, but a route owner should confirm this direct leg is intended to be surfaced alongside the existing two-hop Stride path (both now coexist in the same warp route id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)