### PR TITLE
feat: add ETH/arbitrum warp route [ignore]

### DIFF
--- a/.changeset/add-eth-base-arbitrum.md
+++ b/.changeset/add-eth-base-arbitrum.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+added ETH warp route on base and arbitrum

--- a/deployments/warp_routes/ETH/arbitrum-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xA2cB89330E057a2cF76C6945aEAD22631c4df061"
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    chainName: arbitrum
+    connections:
+      - token: ethereum|base|0xfBB4EE517Ed80C027Fd8217Db53ffD8190792522
+    decimals: 18
+    name: Ether
+    standard: EvmHypSynthetic
+    symbol: ETH
+    tokenType: synthetic
+  - addressOrDenom: "0xfBB4EE517Ed80C027Fd8217Db53ffD8190792522"
+    coinGeckoId: ethereum
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    chainName: base
+    connections:
+      - token: ethereum|arbitrum|0xA2cB89330E057a2cF76C6945aEAD22631c4df061
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+    tokenType: native

--- a/deployments/warp_routes/ETH/arbitrum-deploy.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-deploy.yaml
@@ -1,0 +1,28 @@
+arbitrum:
+  decimals: 18
+  mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
+  name: Ether
+  owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+  symbol: ETH
+  tokenFee:
+    feeContracts:
+      base:
+        bps: 10
+        owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+        type: LinearFee
+    owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+    type: RoutingFee
+  type: synthetic
+base:
+  decimals: 18
+  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+  owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+  tokenFee:
+    feeContracts:
+      arbitrum:
+        bps: 10
+        owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+        type: LinearFee
+    owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+    type: RoutingFee
+  type: native


### PR DESCRIPTION
## Summary

Adds the `ETH/arbitrum` warp route (base ↔ arbitrum).

| Field | Value |
| ----- | ----- |
| **Linear** | https://linear.app/hyperlane/issue/AW-680 |
| **Token** | Ether (ETH) |
| **Route type** | base (native) ↔ arbitrum (synthetic) |
| **Chains** | base (native), arbitrum (synthetic) |
| **Decimals** | 18 |
| **Warp fee** | 10 bps (RoutingFee → LinearFee on both chains) |
| **Owners** | base: `0x645FE06507C8a188494d3E755B248a8dbF3bd875`, arbitrum: `0xC92c781F59b6452e7879e1e0317444c5B7Bb651c` |

### Contracts deployed

| Chain | Contract | Address |
| ----- | -------- | ------- |
| base | HypNative | `0xfBB4EE517Ed80C027Fd8217Db53ffD8190792522` |
| arbitrum | HypSynthetic | `0xA2cB89330E057a2cF76C6945aEAD22631c4df061` |

### Owners (ICAs)

All contracts (router, RoutingFee, LinearFee, proxyAdmin) transferred from the temporary deployer to per-chain ICAs controlled by the Ethereum Safe `0x3f13C1351AC66ca0f4827c607a94c93c82AD0913`:

| Chain | ICA Owner | Controlling Safe |
| ----- | --------- | ---------------- |
| base | `0x645FE06507C8a188494d3E755B248a8dbF3bd875` | `0x3f13C1351AC66ca0f4827c607a94c93c82AD0913` |
| arbitrum | `0xC92c781F59b6452e7879e1e0317444c5B7Bb651c` | `0x3f13C1351AC66ca0f4827c607a94c93c82AD0913` |

### Verification

`warp check` (comprehensive) and `warp check --ica` both reported **no violations**. Bidirectional test transfers (base → arbitrum and arbitrum → base) were delivered successfully through the fee-on-both-sides route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)