### PR TITLE
feat: connect moonpay CCR route on bsc/katana/polygon in combined config

### DIFF
--- a/.changeset/moonpay-cross-bsc-katana.md
+++ b/.changeset/moonpay-cross-bsc-katana.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Connected the moonpay combined cross-collateral warp config to the bsc, katana, and polygon USDC/USDT routers so the CCR route is a fully-connected mesh across all 14 tokens.

--- a/deployments/warp_routes/CROSS/moonpay-config.yaml
+++ b/deployments/warp_routes/CROSS/moonpay-config.yaml
@@ -6,12 +6,18 @@ tokens:
     collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
       - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
       - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
       - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
       - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
@@ -23,15 +29,47 @@ tokens:
     collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
       - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
       - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
       - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
       - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
+    standard: EvmHypCrossCollateralRouter
+    symbol: USDC
+  - addressOrDenom: "0x6E66a10Ce72fBdFA45Ab7de3693321246E254123"
+    chainName: bsc
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
+    connections:
+      - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
+      - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
+      - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
+      - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
+      - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
+      - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
+      - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
+    decimals: 18
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    scale:
+      denominator: 1000000000000
+      numerator: 1
     standard: EvmHypCrossCollateralRouter
     symbol: USDC
   - addressOrDenom: "0x2bef59e84615371304bd731601f6344F5F304504"
@@ -41,11 +79,17 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
       - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
       - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
       - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
       - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/ctUSD/logo.svg
     name: Citrea USD
@@ -58,11 +102,63 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
       - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
       - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
       - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
       - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCrossCollateralRouter
+    symbol: USDC
+  - addressOrDenom: "0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6"
+    chainName: katana
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36"
+    connections:
+      - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
+      - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
+      - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
+      - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
+      - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
+      - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
+      - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
+      - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: Vault Bridge USDC
+    standard: EvmHypCrossCollateralRouter
+    symbol: vbUSDC
+  - addressOrDenom: "0x28a96f9928dB06317356caACd5641C4Fde4424C7"
+    chainName: polygon
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
+    connections:
+      - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
+      - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
+      - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
+      - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
+      - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
+      - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
+      - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/USDC/logo.svg
     name: USD Coin
@@ -75,11 +171,17 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
       - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
       - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
       - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
       - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/XO/logo.png
     name: XO Cash
@@ -92,16 +194,22 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
       - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
       - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
       - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
       - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USD₮0
+    name: "USD\u20AE0"
     standard: EvmHypCrossCollateralRouter
-    symbol: USD₮0
+    symbol: "USD\u20AE0"
   - addressOrDenom: "0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96"
     chainName: base
     coinGeckoId: tether
@@ -109,14 +217,46 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
       - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
       - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
       - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
       - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
+    standard: EvmHypCrossCollateralRouter
+    symbol: USDT
+  - addressOrDenom: "0x050dcc964BCA53eF1A98A2347995cabC73cE25b9"
+    chainName: bsc
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
+    connections:
+      - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
+      - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
+      - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
+      - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
+      - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
+      - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
+      - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
+    decimals: 18
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    scale:
+      denominator: 1000000000000
+      numerator: 1
     standard: EvmHypCrossCollateralRouter
     symbol: USDT
   - addressOrDenom: "0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3"
@@ -126,13 +266,65 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
       - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
       - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
       - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
       - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
       - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
       - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
     standard: EvmHypCrossCollateralRouter
     symbol: USDT
+  - addressOrDenom: "0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad"
+    chainName: katana
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0x2DCa96907fde857dd3D816880A0df407eeB2D2F2"
+    connections:
+      - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
+      - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
+      - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
+      - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
+      - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
+      - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
+      - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
+      - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|polygon|0x766A80a7a6BBA555731DC1726DB5BFa030631270
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Vault Bridge USDT
+    standard: EvmHypCrossCollateralRouter
+    symbol: vbUSDT
+  - addressOrDenom: "0x766A80a7a6BBA555731DC1726DB5BFa030631270"
+    chainName: polygon
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
+    connections:
+      - token: ethereum|arbitrum|0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0
+      - token: ethereum|base|0x253821543C24623ecD3ceBCEd704359AF16CF38f
+      - token: ethereum|bsc|0x6E66a10Ce72fBdFA45Ab7de3693321246E254123
+      - token: ethereum|citrea|0x2bef59e84615371304bd731601f6344F5F304504
+      - token: ethereum|ethereum|0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F
+      - token: ethereum|katana|0x936e8A1fBD8317Be59A9B8924a300993c8Bf7ce6
+      - token: ethereum|polygon|0x28a96f9928dB06317356caACd5641C4Fde4424C7
+      - token: sealevel|solanamainnet|HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU
+      - token: ethereum|arbitrum|0x75a9297db5F0349fd1d6f4030953Fe17175e06d4
+      - token: ethereum|base|0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96
+      - token: ethereum|bsc|0x050dcc964BCA53eF1A98A2347995cabC73cE25b9
+      - token: ethereum|ethereum|0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3
+      - token: ethereum|katana|0x0b51aFdd3F43446a621C555B16A1cb781D8443Ad
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: USDT0
+    standard: EvmHypCrossCollateralRouter
+    symbol: USDT0


### PR DESCRIPTION
## Summary

PR #1551 added the bsc, katana, and polygon USDC/USDT routers to the **per-asset** warpcore configs (`USDC/moonpay-config.yaml`, `USDT/moonpay-config.yaml`) but did **not** propagate them to the **combined** cross-collateral config at `CROSS/moonpay-config.yaml` — the config the Nexus UI/SDK consume for cross-asset (CCR) swaps.

As a result the combined route was missing USDC + USDT on bsc, katana, and polygon, so the CCR mesh was under-connected.

This PR regenerates `CROSS/moonpay-config.yaml` (the `warp combine` equivalent) as a fully-connected 14-token cross-collateral mesh.

## What changed

- `CROSS/moonpay-config.yaml`: 8 → 14 tokens, each connected to all 13 others.
  - Added: USDC on bsc/katana/polygon, USDT on bsc/katana/polygon.
- Preserved `scale` on the bsc 18-decimal collateral tokens (`{numerator: 1, denominator: 1000000000000}`), plus all symbols, names, and logos.

## Verification

- 14 tokens, every token has exactly 13 connections (full mesh).
- 0 self-connections, 0 dangling connections, 0 asymmetric connections.
- Token addresses match the per-asset moonpay configs updated by #1551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)