### PR TITLE
fix: moonpay bsc owner

### DIFF
--- a/.changeset/selfish-nails-join.md
+++ b/.changeset/selfish-nails-join.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Fixed moonpay bsc owner by using the bsc ica instead of safe address

--- a/deployments/warp_routes/USDC/moonpay-deploy.yaml
+++ b/deployments/warp_routes/USDC/moonpay-deploy.yaml
@@ -364,20 +364,20 @@ bsc:
             polygon:
               relayer: "0x1e100476e9360b11a592eafe1c90328368e547b6"
               type: trustedRelayerIsm
-          owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+          owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
           type: domainRoutingIsm
         threshold: 1000000000
         type: amountRoutingIsm
         upperIsm:
           domains: {}
-          owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+          owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
           type: defaultFallbackRoutingIsm
       - domains: {}
-        owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+        owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
         type: defaultFallbackRoutingIsm
     threshold: 1
     type: staticAggregationIsm
-  owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+  owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
   scale:
     denominator: 1000000000000
     numerator: 1

--- a/deployments/warp_routes/USDT/moonpay-deploy.yaml
+++ b/deployments/warp_routes/USDT/moonpay-deploy.yaml
@@ -337,7 +337,7 @@ bsc:
     domains: {}
     fallback:
       type: defaultHook
-    owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+    owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
     type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
@@ -361,20 +361,20 @@ bsc:
             polygon:
               relayer: "0x1e100476e9360b11a592eafe1c90328368e547b6"
               type: trustedRelayerIsm
-          owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+          owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
           type: domainRoutingIsm
         threshold: 1000000000
         type: amountRoutingIsm
         upperIsm:
           domains: {}
-          owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+          owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
           type: defaultFallbackRoutingIsm
       - domains: {}
-        owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+        owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
         type: defaultFallbackRoutingIsm
     threshold: 1
     type: staticAggregationIsm
-  owner: "0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170"
+  owner: "0x269Af9E53192AF49a22ff47e30b89dE1375AE1fd"
   scale:
     denominator: 1000000000000
     numerator: 1


### PR DESCRIPTION
### Description

Updates the USDC/moonpay and USDT/moonpay BSC warp route deploy config to reflect the new owner (`awIcas.bsc` ICA) after running `warp apply`.

### Backward compatibility

Yes

### Testing

Generated via `generate-warp-config.ts` and validated with `warp apply`.