### PR TITLE
feat: limit USDT/eni Nexus connections to bsc + tron

### DIFF
--- a/deployments/warp_routes/USDT/eni-config.yaml
+++ b/deployments/warp_routes/USDT/eni-config.yaml
@@ -4,17 +4,9 @@ tokens:
     chainName: arbitrum
     coinGeckoId: tether
     collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
-    connections:
-      - token: ethereum|base|0x3a669c00F7A041330646AC8AE89d74e104bd1363
-      - token: ethereum|bsc|0xC05617bc2490CB57a8db163b5551bb7E532695e3
-      - token: ethereum|eni|0x545E289B88c6d97b74eC0B96e308cae46Bf5f832
-      - token: ethereum|ethereum|0x291A485Fd288786728Ba34052b95DDb60278AB49
-      - token: ethereum|optimism|0x2EbFeC15f3Ff64E52af17c1c9a4aE9B7f6574298
-      - token: ethereum|polygon|0x98e9738DF4A304A97124D3A360A70DeC6efc4f99
-      - token: tron|tron|0x34662Cb75C0aa7e6f76840e552C31E8C1fA5603c
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USD₮0
+    name: Tether USD
     scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDT
@@ -22,14 +14,6 @@ tokens:
     chainName: base
     coinGeckoId: tether
     collateralAddressOrDenom: "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2"
-    connections:
-      - token: ethereum|arbitrum|0x92637DCE7F34b9e9b5741B9203F33EED7f71E5a4
-      - token: ethereum|bsc|0xC05617bc2490CB57a8db163b5551bb7E532695e3
-      - token: ethereum|eni|0x545E289B88c6d97b74eC0B96e308cae46Bf5f832
-      - token: ethereum|ethereum|0x291A485Fd288786728Ba34052b95DDb60278AB49
-      - token: ethereum|optimism|0x2EbFeC15f3Ff64E52af17c1c9a4aE9B7f6574298
-      - token: ethereum|polygon|0x98e9738DF4A304A97124D3A360A70DeC6efc4f99
-      - token: tron|tron|0x34662Cb75C0aa7e6f76840e552C31E8C1fA5603c
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
@@ -41,13 +25,7 @@ tokens:
     coinGeckoId: tether
     collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
     connections:
-      - token: ethereum|arbitrum|0x92637DCE7F34b9e9b5741B9203F33EED7f71E5a4
-      - token: ethereum|base|0x3a669c00F7A041330646AC8AE89d74e104bd1363
       - token: ethereum|eni|0x545E289B88c6d97b74eC0B96e308cae46Bf5f832
-      - token: ethereum|ethereum|0x291A485Fd288786728Ba34052b95DDb60278AB49
-      - token: ethereum|optimism|0x2EbFeC15f3Ff64E52af17c1c9a4aE9B7f6574298
-      - token: ethereum|polygon|0x98e9738DF4A304A97124D3A360A70DeC6efc4f99
-      - token: tron|tron|0x34662Cb75C0aa7e6f76840e552C31E8C1fA5603c
     decimals: 18
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
@@ -56,12 +34,7 @@ tokens:
   - addressOrDenom: "0x545E289B88c6d97b74eC0B96e308cae46Bf5f832"
     chainName: eni
     connections:
-      - token: ethereum|arbitrum|0x92637DCE7F34b9e9b5741B9203F33EED7f71E5a4
-      - token: ethereum|base|0x3a669c00F7A041330646AC8AE89d74e104bd1363
       - token: ethereum|bsc|0xC05617bc2490CB57a8db163b5551bb7E532695e3
-      - token: ethereum|ethereum|0x291A485Fd288786728Ba34052b95DDb60278AB49
-      - token: ethereum|optimism|0x2EbFeC15f3Ff64E52af17c1c9a4aE9B7f6574298
-      - token: ethereum|polygon|0x98e9738DF4A304A97124D3A360A70DeC6efc4f99
       - token: tron|tron|0x34662Cb75C0aa7e6f76840e552C31E8C1fA5603c
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
@@ -73,14 +46,6 @@ tokens:
     chainName: ethereum
     coinGeckoId: tether
     collateralAddressOrDenom: "0xdac17f958d2ee523a2206206994597c13d831ec7"
-    connections:
-      - token: ethereum|arbitrum|0x92637DCE7F34b9e9b5741B9203F33EED7f71E5a4
-      - token: ethereum|base|0x3a669c00F7A041330646AC8AE89d74e104bd1363
-      - token: ethereum|bsc|0xC05617bc2490CB57a8db163b5551bb7E532695e3
-      - token: ethereum|eni|0x545E289B88c6d97b74eC0B96e308cae46Bf5f832
-      - token: ethereum|optimism|0x2EbFeC15f3Ff64E52af17c1c9a4aE9B7f6574298
-      - token: ethereum|polygon|0x98e9738DF4A304A97124D3A360A70DeC6efc4f99
-      - token: tron|tron|0x34662Cb75C0aa7e6f76840e552C31E8C1fA5603c
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
@@ -91,14 +56,6 @@ tokens:
     chainName: optimism
     coinGeckoId: tether
     collateralAddressOrDenom: "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"
-    connections:
-      - token: ethereum|arbitrum|0x92637DCE7F34b9e9b5741B9203F33EED7f71E5a4
-      - token: ethereum|base|0x3a669c00F7A041330646AC8AE89d74e104bd1363
-      - token: ethereum|bsc|0xC05617bc2490CB57a8db163b5551bb7E532695e3
-      - token: ethereum|eni|0x545E289B88c6d97b74eC0B96e308cae46Bf5f832
-      - token: ethereum|ethereum|0x291A485Fd288786728Ba34052b95DDb60278AB49
-      - token: ethereum|polygon|0x98e9738DF4A304A97124D3A360A70DeC6efc4f99
-      - token: tron|tron|0x34662Cb75C0aa7e6f76840e552C31E8C1fA5603c
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: Tether USD
@@ -109,17 +66,9 @@ tokens:
     chainName: polygon
     coinGeckoId: tether
     collateralAddressOrDenom: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
-    connections:
-      - token: ethereum|arbitrum|0x92637DCE7F34b9e9b5741B9203F33EED7f71E5a4
-      - token: ethereum|base|0x3a669c00F7A041330646AC8AE89d74e104bd1363
-      - token: ethereum|bsc|0xC05617bc2490CB57a8db163b5551bb7E532695e3
-      - token: ethereum|eni|0x545E289B88c6d97b74eC0B96e308cae46Bf5f832
-      - token: ethereum|ethereum|0x291A485Fd288786728Ba34052b95DDb60278AB49
-      - token: ethereum|optimism|0x2EbFeC15f3Ff64E52af17c1c9a4aE9B7f6574298
-      - token: tron|tron|0x34662Cb75C0aa7e6f76840e552C31E8C1fA5603c
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USDT0
+    name: Tether USD
     scale: 1000000000000
     standard: EvmHypCollateral
     symbol: USDT
@@ -127,13 +76,7 @@ tokens:
     chainName: tron
     collateralAddressOrDenom: "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
     connections:
-      - token: ethereum|arbitrum|0x92637DCE7F34b9e9b5741B9203F33EED7f71E5a4
-      - token: ethereum|base|0x3a669c00F7A041330646AC8AE89d74e104bd1363
-      - token: ethereum|bsc|0xC05617bc2490CB57a8db163b5551bb7E532695e3
       - token: ethereum|eni|0x545E289B88c6d97b74eC0B96e308cae46Bf5f832
-      - token: ethereum|ethereum|0x291A485Fd288786728Ba34052b95DDb60278AB49
-      - token: ethereum|optimism|0x2EbFeC15f3Ff64E52af17c1c9a4aE9B7f6574298
-      - token: ethereum|polygon|0x98e9738DF4A304A97124D3A360A70DeC6efc4f99
     decimals: 6
     name: Tether USD
     scale: 1000000000000


### PR DESCRIPTION
Stacked on top of #1556 (`feat/eni-tron-extension`) — for @Troy to consider.

## Context
#1556 extends `USDT/eni` with the Tron leg, but it also rewrites the displayed `connections` graph for every leg into a **full 8-leg mesh** and relabels arbitrum/polygon to `USD₮0`/`USDT0`. Per eda ("we should only add Tron thats new addition here") and Nam's review note, the Nexus-visible change should be the Tron addition only.

## What this does
Trims `eni-config.yaml` `connections` back to the curated subset so that, from the eni synthetic, the visible collateral chains go `[bsc]` → `[bsc, tron]` — matching what `main` already does (it intentionally under-declares connections relative to the on-chain mesh).

**Net effect vs `main` is exactly "main + Tron":**
- eni gains a single `tron|tron|0x34662Cb7…` connection (keeps existing bsc).
- New `tron` leg added (`TronHypCollateral`), connected to eni only.
- The other 5 EVM legs (arbitrum/base/ethereum/optimism/polygon) stay non-routable in Nexus, as today.
- Reverts the cosmetic `USD₮0`/`USDT0` relabels.

## What this does NOT touch
- `eni-deploy.yaml` (mailboxes, `RoutingFee`/`OffchainQuotedLinearFee` 5bps blocks) — left as #1556 has it; not consumed by the Nexus UI.
- On-chain enrollments — the route remains a true full mesh on-chain (verified via fork sim). This is a **display-only** curation.

## Decision for the reviewer
- If the goal is *Nexus shows bsc + tron from eni* → merge this on top of #1556.
- If the goal is *Nexus surfaces the real on-chain full mesh* → merge #1556 as-is and close this.

Linear: [AW-675](https://linear.app/hyperlane-xyz/issue/AW-675/eni-usdt-tron-expansion)