### PR TITLE
feat: mark torus availability as disabled

### DIFF
--- a/.changeset/deprecate-torus.md
+++ b/.changeset/deprecate-torus.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Mark torus availability as disabled (deprecated).

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -9010,6 +9010,10 @@ tenet:
     - http: https://rpc.tenet.org
     - http: https://tenet-evm.publicnode.com
 torus:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://blockscout.torus.network/api
       family: blockscout

--- a/chains/torus/metadata.yaml
+++ b/chains/torus/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://blockscout.torus.network/api
     family: blockscout


### PR DESCRIPTION
## Summary
Mark **torus** availability as `disabled` (reason: `deprecated`) in the registry. Torus was removed from the hyperlane-monorepo `mainnet3` supported chains list, so the registry should reflect that.

## Cross-check with monorepo (hm1)
Compared the monorepo `mainnet3SupportedChainNames` list against 3 months ago and cross-referenced every removed chain with the registry:

| Removed from monorepo | Registry status |
| --- | --- |
| arbitrumnova, aurora, b3, degenchain, dogechain, everclear, fantom, fluence, harmony, merlin, milkyway, moonbeam, polygonzkevm, polynomialfi, redstone, scroll, story, superpositionmainnet, tangle, zoramainnet | already `disabled` ✅ |
| **torus** | was still active → **disabled in this PR** |

Every chain removed from the monorepo in the last 3 months was already disabled in the registry — torus was the only gap.

## Deprecated-chains doc candidates
Per the docs `deprecated-chains.mdx` table, the remaining candidates are **future-dated** (today is 2026-06-17) and intentionally left active:
- Manta Pacific — June 30, 2026
- Swellchain — June 30, 2026
- Zircuit — August 20, 2026

These will be marked disabled once their deprecation dates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)