### PR TITLE
fix(warp): A1 — encode on-chain custom ISMs for 6 warp routes

### DIFF
--- a/.changeset/fix-custom-ism-warp-routes.md
+++ b/.changeset/fix-custom-ism-warp-routes.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The interchainSecurityModule config is added for WBTC/incentiv, ETH/krown, USDC/krown, USDT/krown, PB/eni, and evENI/bsc warp routes to match their on-chain custom ISM deployments.

--- a/deployments/warp_routes/ETH/krown-deploy.yaml
+++ b/deployments/warp_routes/ETH/krown-deploy.yaml
@@ -1,9 +1,47 @@
 base:
   decimals: 18
+  interchainSecurityModule:
+    owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+    address: "0x9ceFf810Cfc69922F706300bFa888C56B16bA8ad"
+    type: defaultFallbackRoutingIsm
+    domains:
+      krown:
+        address: "0x3B8B75D6cd187F6258aCE17cb34352CD6F61a806"
+        type: staticAggregationIsm
+        modules:
+          - address: "0x8Fe9c48DCE94690a383DbE8311189682B4c87F7a"
+            type: testIsm
+          - address: "0xA63520eE179f07644feB4575B0F7576c3421b59E"
+            relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
+            type: trustedRelayerIsm
+          - owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+            address: "0xB3f8D3251D91FE5b1621e413E9a5160B8C2e9bf1"
+            type: defaultFallbackRoutingIsm
+            domains: {}
+        threshold: 3
   owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
   type: native
 ethereum:
   decimals: 18
+  interchainSecurityModule:
+    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+    address: "0xf2044cF2Cf21cC0213201Bc1E6a031C71c425971"
+    type: defaultFallbackRoutingIsm
+    domains:
+      krown:
+        address: "0x69d01C7F05be9De9f67E20B0A3697DB8F1aA688B"
+        type: staticAggregationIsm
+        modules:
+          - address: "0x5d4C14B895392BD935583ebFfE0f5159540FE8bC"
+            type: testIsm
+          - address: "0xEf52dBb32eaa5307A4802317695ECB77d37077Ec"
+            relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
+            type: trustedRelayerIsm
+          - owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+            address: "0xc304CcEe62944D07fb462BB9690fBAe0D91fA8B6"
+            type: defaultFallbackRoutingIsm
+            domains: {}
+        threshold: 3
   owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
   type: native
 krown:

--- a/deployments/warp_routes/ETH/krown-deploy.yaml
+++ b/deployments/warp_routes/ETH/krown-deploy.yaml
@@ -1,47 +1,47 @@
 base:
   decimals: 18
   interchainSecurityModule:
-    owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
     address: "0x9ceFf810Cfc69922F706300bFa888C56B16bA8ad"
-    type: defaultFallbackRoutingIsm
     domains:
       krown:
         address: "0x3B8B75D6cd187F6258aCE17cb34352CD6F61a806"
-        type: staticAggregationIsm
         modules:
           - address: "0x8Fe9c48DCE94690a383DbE8311189682B4c87F7a"
             type: testIsm
           - address: "0xA63520eE179f07644feB4575B0F7576c3421b59E"
             relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
             type: trustedRelayerIsm
-          - owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
-            address: "0xB3f8D3251D91FE5b1621e413E9a5160B8C2e9bf1"
-            type: defaultFallbackRoutingIsm
+          - address: "0xB3f8D3251D91FE5b1621e413E9a5160B8C2e9bf1"
             domains: {}
+            owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+            type: defaultFallbackRoutingIsm
         threshold: 3
+        type: staticAggregationIsm
+    owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+    type: defaultFallbackRoutingIsm
   owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
   type: native
 ethereum:
   decimals: 18
   interchainSecurityModule:
-    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
     address: "0xf2044cF2Cf21cC0213201Bc1E6a031C71c425971"
-    type: defaultFallbackRoutingIsm
     domains:
       krown:
         address: "0x69d01C7F05be9De9f67E20B0A3697DB8F1aA688B"
-        type: staticAggregationIsm
         modules:
           - address: "0x5d4C14B895392BD935583ebFfE0f5159540FE8bC"
             type: testIsm
           - address: "0xEf52dBb32eaa5307A4802317695ECB77d37077Ec"
             relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
             type: trustedRelayerIsm
-          - owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
-            address: "0xc304CcEe62944D07fb462BB9690fBAe0D91fA8B6"
-            type: defaultFallbackRoutingIsm
+          - address: "0xc304CcEe62944D07fb462BB9690fBAe0D91fA8B6"
             domains: {}
+            owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+            type: defaultFallbackRoutingIsm
         threshold: 3
+        type: staticAggregationIsm
+    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+    type: defaultFallbackRoutingIsm
   owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
   type: native
 krown:

--- a/deployments/warp_routes/PB/eni-deploy.yaml
+++ b/deployments/warp_routes/PB/eni-deploy.yaml
@@ -1,18 +1,22 @@
 bsc:
   decimals: 18
   interchainSecurityModule:
-    modules:
-      - domains: {}
-        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        type: defaultFallbackRoutingIsm
-      - owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        paused: false
-        type: pausableIsm
-      - maxCapacity: "199999999999999999999929600"
-        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        type: rateLimitedIsm
-    threshold: 3
+    address: "0x3C7C56581932AD0D463f97B175E93DFB39118D4F"
     type: staticAggregationIsm
+    modules:
+      - address: "0x54f5Bf8DFF1D0197fBEB6398AfEC759433bBeAef"
+        type: rateLimitedIsm
+        maxCapacity: "999999999999999999999993600"
+        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+      - owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+        address: "0x5d50888811c39e58ca90E91fAbBd348892Bbab18"
+        type: defaultFallbackRoutingIsm
+        domains: {}
+      - address: "0x6b39a2039532Ee1F3B5081E87317C4AFeb3Db175"
+        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+        type: pausableIsm
+        paused: false
+    threshold: 3
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: PB
   owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
@@ -23,18 +27,22 @@ bsc:
 eni:
   decimals: 18
   interchainSecurityModule:
-    modules:
-      - domains: {}
-        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        type: defaultFallbackRoutingIsm
-      - owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        paused: false
-        type: pausableIsm
-      - maxCapacity: "199999999999999999999929600"
-        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        type: rateLimitedIsm
-    threshold: 3
+    address: "0xe39f74604d53408caE95ADf555E869B4EC173E4A"
     type: staticAggregationIsm
+    modules:
+      - address: "0x132916B82A48D383EC70F3347fCD680C67364621"
+        type: rateLimitedIsm
+        maxCapacity: "999999999999999999999993600"
+        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+      - address: "0xB934d19F39Ce0eD9bc3915E7aE0Aa95F6581e79A"
+        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+        type: pausableIsm
+        paused: false
+      - owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+        address: "0xac357910cE7fDD735de1fBE470408D78bdcdba51"
+        type: defaultFallbackRoutingIsm
+        domains: {}
+    threshold: 3
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
   name: PB
   owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"

--- a/deployments/warp_routes/PB/eni-deploy.yaml
+++ b/deployments/warp_routes/PB/eni-deploy.yaml
@@ -2,21 +2,21 @@ bsc:
   decimals: 18
   interchainSecurityModule:
     address: "0x3C7C56581932AD0D463f97B175E93DFB39118D4F"
-    type: staticAggregationIsm
     modules:
       - address: "0x54f5Bf8DFF1D0197fBEB6398AfEC759433bBeAef"
-        type: rateLimitedIsm
         maxCapacity: "999999999999999999999993600"
         owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-      - owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        address: "0x5d50888811c39e58ca90E91fAbBd348892Bbab18"
-        type: defaultFallbackRoutingIsm
+        type: rateLimitedIsm
+      - address: "0x5d50888811c39e58ca90E91fAbBd348892Bbab18"
         domains: {}
+        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+        type: defaultFallbackRoutingIsm
       - address: "0x6b39a2039532Ee1F3B5081E87317C4AFeb3Db175"
         owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        type: pausableIsm
         paused: false
+        type: pausableIsm
     threshold: 3
+    type: staticAggregationIsm
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: PB
   owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
@@ -28,21 +28,21 @@ eni:
   decimals: 18
   interchainSecurityModule:
     address: "0xe39f74604d53408caE95ADf555E869B4EC173E4A"
-    type: staticAggregationIsm
     modules:
       - address: "0x132916B82A48D383EC70F3347fCD680C67364621"
-        type: rateLimitedIsm
         maxCapacity: "999999999999999999999993600"
         owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+        type: rateLimitedIsm
       - address: "0xB934d19F39Ce0eD9bc3915E7aE0Aa95F6581e79A"
         owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        type: pausableIsm
         paused: false
-      - owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        address: "0xac357910cE7fDD735de1fBE470408D78bdcdba51"
-        type: defaultFallbackRoutingIsm
+        type: pausableIsm
+      - address: "0xac357910cE7fDD735de1fBE470408D78bdcdba51"
         domains: {}
+        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+        type: defaultFallbackRoutingIsm
     threshold: 3
+    type: staticAggregationIsm
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
   name: PB
   owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"

--- a/deployments/warp_routes/USDC/krown-deploy.yaml
+++ b/deployments/warp_routes/USDC/krown-deploy.yaml
@@ -1,10 +1,48 @@
 base:
   decimals: 6
+  interchainSecurityModule:
+    owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+    address: "0x8889cA7DA10F30C548ab4Bdaa6df610781BD2bBf"
+    type: defaultFallbackRoutingIsm
+    domains:
+      krown:
+        address: "0xa1D3E750Ca5E0D2C4e0B54bfD6C6715B5343b4d0"
+        type: staticAggregationIsm
+        modules:
+          - address: "0x1fEd3c0640e3791be181183fe008dA759a7Ed11a"
+            type: testIsm
+          - owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+            address: "0x3399F53B18e8c59574dE918eacdC941D9aD8Db57"
+            type: defaultFallbackRoutingIsm
+            domains: {}
+          - address: "0xE228C42F3962ef2603084e282ab38957E56c8ae6"
+            relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
+            type: trustedRelayerIsm
+        threshold: 3
   owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
   token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
   type: collateral
 ethereum:
   decimals: 6
+  interchainSecurityModule:
+    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+    address: "0xa23b481B609CbB4C2589D32C4d3080A90926D95f"
+    type: defaultFallbackRoutingIsm
+    domains:
+      krown:
+        address: "0x14B255dB1Fc61a680ae322097028B2089d14d04A"
+        type: staticAggregationIsm
+        modules:
+          - address: "0x075DA912914E2B60fEc86780f57182132F30FBbc"
+            type: testIsm
+          - owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+            address: "0xaCf1dDaB1a8998438B4bc4F2D16CECe7Bd2B7d3a"
+            type: defaultFallbackRoutingIsm
+            domains: {}
+          - address: "0xeC2cc153f977618dF577BC60cca1b6dD0C7F21a8"
+            relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
+            type: trustedRelayerIsm
+        threshold: 3
   name: USD Coin
   owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
   symbol: USDC

--- a/deployments/warp_routes/USDC/krown-deploy.yaml
+++ b/deployments/warp_routes/USDC/krown-deploy.yaml
@@ -1,48 +1,48 @@
 base:
   decimals: 6
   interchainSecurityModule:
-    owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
     address: "0x8889cA7DA10F30C548ab4Bdaa6df610781BD2bBf"
-    type: defaultFallbackRoutingIsm
     domains:
       krown:
         address: "0xa1D3E750Ca5E0D2C4e0B54bfD6C6715B5343b4d0"
-        type: staticAggregationIsm
         modules:
           - address: "0x1fEd3c0640e3791be181183fe008dA759a7Ed11a"
             type: testIsm
-          - owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
-            address: "0x3399F53B18e8c59574dE918eacdC941D9aD8Db57"
-            type: defaultFallbackRoutingIsm
+          - address: "0x3399F53B18e8c59574dE918eacdC941D9aD8Db57"
             domains: {}
+            owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+            type: defaultFallbackRoutingIsm
           - address: "0xE228C42F3962ef2603084e282ab38957E56c8ae6"
             relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
             type: trustedRelayerIsm
         threshold: 3
+        type: staticAggregationIsm
+    owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
+    type: defaultFallbackRoutingIsm
   owner: "0x349B20024DD7EECc872BA6C203d8A77EAcF043EC"
   token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
   type: collateral
 ethereum:
   decimals: 6
   interchainSecurityModule:
-    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
     address: "0xa23b481B609CbB4C2589D32C4d3080A90926D95f"
-    type: defaultFallbackRoutingIsm
     domains:
       krown:
         address: "0x14B255dB1Fc61a680ae322097028B2089d14d04A"
-        type: staticAggregationIsm
         modules:
           - address: "0x075DA912914E2B60fEc86780f57182132F30FBbc"
             type: testIsm
-          - owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
-            address: "0xaCf1dDaB1a8998438B4bc4F2D16CECe7Bd2B7d3a"
-            type: defaultFallbackRoutingIsm
+          - address: "0xaCf1dDaB1a8998438B4bc4F2D16CECe7Bd2B7d3a"
             domains: {}
+            owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+            type: defaultFallbackRoutingIsm
           - address: "0xeC2cc153f977618dF577BC60cca1b6dD0C7F21a8"
             relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
             type: trustedRelayerIsm
         threshold: 3
+        type: staticAggregationIsm
+    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+    type: defaultFallbackRoutingIsm
   name: USD Coin
   owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
   symbol: USDC

--- a/deployments/warp_routes/USDT/krown-deploy.yaml
+++ b/deployments/warp_routes/USDT/krown-deploy.yaml
@@ -1,24 +1,24 @@
 ethereum:
   decimals: 6
   interchainSecurityModule:
-    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
     address: "0x103f0364B4b397808003EfF122e1003EB850A357"
-    type: defaultFallbackRoutingIsm
     domains:
       krown:
         address: "0xbf91D262FdF612ccDc62F7d557B582cCF0C2C5Cf"
-        type: staticAggregationIsm
         modules:
-          - owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
-            address: "0x0F4457519098a3f16B0b18493c919ae69eb13f78"
-            type: defaultFallbackRoutingIsm
+          - address: "0x0F4457519098a3f16B0b18493c919ae69eb13f78"
             domains: {}
+            owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+            type: defaultFallbackRoutingIsm
           - address: "0x8889cA7DA10F30C548ab4Bdaa6df610781BD2bBf"
             type: testIsm
           - address: "0xD886e5DEa5591791F1bB656058a0378514689c8a"
             relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
             type: trustedRelayerIsm
         threshold: 3
+        type: staticAggregationIsm
+    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+    type: defaultFallbackRoutingIsm
   name: Tether USD
   owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
   symbol: USDT

--- a/deployments/warp_routes/USDT/krown-deploy.yaml
+++ b/deployments/warp_routes/USDT/krown-deploy.yaml
@@ -1,5 +1,24 @@
 ethereum:
   decimals: 6
+  interchainSecurityModule:
+    owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+    address: "0x103f0364B4b397808003EfF122e1003EB850A357"
+    type: defaultFallbackRoutingIsm
+    domains:
+      krown:
+        address: "0xbf91D262FdF612ccDc62F7d557B582cCF0C2C5Cf"
+        type: staticAggregationIsm
+        modules:
+          - owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
+            address: "0x0F4457519098a3f16B0b18493c919ae69eb13f78"
+            type: defaultFallbackRoutingIsm
+            domains: {}
+          - address: "0x8889cA7DA10F30C548ab4Bdaa6df610781BD2bBf"
+            type: testIsm
+          - address: "0xD886e5DEa5591791F1bB656058a0378514689c8a"
+            relayer: "0x74Cae0ECC47B02Ed9B9D32E000Fd70B9417970C5"
+            type: trustedRelayerIsm
+        threshold: 3
   name: Tether USD
   owner: "0x3Ea04C1cDDebf600dA09e6FE0654835F27258f30"
   symbol: USDT

--- a/deployments/warp_routes/WBTC/incentiv-deploy.yaml
+++ b/deployments/warp_routes/WBTC/incentiv-deploy.yaml
@@ -1,8 +1,24 @@
 ethereum:
+  interchainSecurityModule:
+    address: "0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4"
+    type: merkleRootMultisigIsm
+    validators:
+      - "0x7177e97c220DdCfE2DFA73D1aDd1929c4B033832"
+      - "0xB6D0CAA8e08dA05a3543E163c998Ae6E5eF2FfCE"
+      - "0xEFfb8D9B7666Cf85Dd5B45B0cB90Ef76d7CB6128"
+    threshold: 2
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
   type: collateral
 incentiv:
+  interchainSecurityModule:
+    address: "0x9fDe79BD608AfB4B95E271a03019e4A4629dd003"
+    type: merkleRootMultisigIsm
+    validators:
+      - "0x0475e5B9a3769fdBcDa78965c5b50E5B4fcDb204"
+      - "0x614571a2c8E4575da493eBed053fDe32Bf519c32"
+      - "0xC2061992603E9a638Db3A1f070a118a792B77888"
+    threshold: 2
   isNft: false
   owner: "0x4c1B3430ec07F2D58b07a18c53B6f92603C2eF3F"
   type: synthetic

--- a/deployments/warp_routes/WBTC/incentiv-deploy.yaml
+++ b/deployments/warp_routes/WBTC/incentiv-deploy.yaml
@@ -1,24 +1,24 @@
 ethereum:
   interchainSecurityModule:
     address: "0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4"
+    threshold: 2
     type: merkleRootMultisigIsm
     validators:
       - "0x7177e97c220DdCfE2DFA73D1aDd1929c4B033832"
       - "0xB6D0CAA8e08dA05a3543E163c998Ae6E5eF2FfCE"
       - "0xEFfb8D9B7666Cf85Dd5B45B0cB90Ef76d7CB6128"
-    threshold: 2
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
   type: collateral
 incentiv:
   interchainSecurityModule:
     address: "0x9fDe79BD608AfB4B95E271a03019e4A4629dd003"
+    threshold: 2
     type: merkleRootMultisigIsm
     validators:
       - "0x0475e5B9a3769fdBcDa78965c5b50E5B4fcDb204"
       - "0x614571a2c8E4575da493eBed053fDe32Bf519c32"
       - "0xC2061992603E9a638Db3A1f070a118a792B77888"
-    threshold: 2
   isNft: false
   owner: "0x4c1B3430ec07F2D58b07a18c53B6f92603C2eF3F"
   type: synthetic

--- a/deployments/warp_routes/evENI/bsc-deploy.yaml
+++ b/deployments/warp_routes/evENI/bsc-deploy.yaml
@@ -1,18 +1,22 @@
 bsc:
   decimals: 18
   interchainSecurityModule:
-    modules:
-      - domains: {}
-        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        type: defaultFallbackRoutingIsm
-      - owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        paused: false
-        type: pausableIsm
-      - maxCapacity: "4999999999999999999968000"
-        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        type: rateLimitedIsm
-    threshold: 3
+    address: "0xe0c91455e83f5F71ed73D36466C3b7d3FB9a55E5"
     type: staticAggregationIsm
+    modules:
+      - owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+        address: "0x51DE40d57873c4C6aeFD58cC9D782E15426A8CaA"
+        type: defaultFallbackRoutingIsm
+        domains: {}
+      - address: "0x766A80a7a6BBA555731DC1726DB5BFa030631270"
+        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+        type: pausableIsm
+        paused: false
+      - address: "0x972fBEDDF3f6c88B413796090E18EC34fe467901"
+        type: rateLimitedIsm
+        maxCapacity: "20999999999999999999952000"
+        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+    threshold: 3
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: ECO Voucher ENI 1
   owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
@@ -29,18 +33,22 @@ bsc:
 eni:
   decimals: 18
   interchainSecurityModule:
-    modules:
-      - domains: {}
-        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        type: defaultFallbackRoutingIsm
-      - owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        paused: false
-        type: pausableIsm
-      - maxCapacity: "4999999999999999999968000"
-        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        type: rateLimitedIsm
-    threshold: 3
+    address: "0x57078Bc6516A3385b11e883FF13c5E5618290269"
     type: staticAggregationIsm
+    modules:
+      - address: "0x3b9486c24784936cb7b8EfaC0AF14B9AAa0df215"
+        type: rateLimitedIsm
+        maxCapacity: "20999999999999999999952000"
+        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+      - owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+        address: "0x58E16564F60A7C16669B076d239A23d8C5164918"
+        type: defaultFallbackRoutingIsm
+        domains: {}
+      - address: "0x67a1910e73B097E30a678C7616F20e6a4F72CBb6"
+        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+        type: pausableIsm
+        paused: false
+    threshold: 3
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
   name: ECO Voucher ENI 1
   owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"

--- a/deployments/warp_routes/evENI/bsc-deploy.yaml
+++ b/deployments/warp_routes/evENI/bsc-deploy.yaml
@@ -2,21 +2,21 @@ bsc:
   decimals: 18
   interchainSecurityModule:
     address: "0xe0c91455e83f5F71ed73D36466C3b7d3FB9a55E5"
-    type: staticAggregationIsm
     modules:
-      - owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        address: "0x51DE40d57873c4C6aeFD58cC9D782E15426A8CaA"
-        type: defaultFallbackRoutingIsm
+      - address: "0x51DE40d57873c4C6aeFD58cC9D782E15426A8CaA"
         domains: {}
+        owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+        type: defaultFallbackRoutingIsm
       - address: "0x766A80a7a6BBA555731DC1726DB5BFa030631270"
         owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
-        type: pausableIsm
         paused: false
+        type: pausableIsm
       - address: "0x972fBEDDF3f6c88B413796090E18EC34fe467901"
-        type: rateLimitedIsm
         maxCapacity: "20999999999999999999952000"
         owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
+        type: rateLimitedIsm
     threshold: 3
+    type: staticAggregationIsm
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: ECO Voucher ENI 1
   owner: "0xb8d4b6B1f402Cf9C525e6c167B3Efa59BCb718A9"
@@ -34,21 +34,21 @@ eni:
   decimals: 18
   interchainSecurityModule:
     address: "0x57078Bc6516A3385b11e883FF13c5E5618290269"
-    type: staticAggregationIsm
     modules:
       - address: "0x3b9486c24784936cb7b8EfaC0AF14B9AAa0df215"
-        type: rateLimitedIsm
         maxCapacity: "20999999999999999999952000"
         owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-      - owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        address: "0x58E16564F60A7C16669B076d239A23d8C5164918"
-        type: defaultFallbackRoutingIsm
+        type: rateLimitedIsm
+      - address: "0x58E16564F60A7C16669B076d239A23d8C5164918"
         domains: {}
+        owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
+        type: defaultFallbackRoutingIsm
       - address: "0x67a1910e73B097E30a678C7616F20e6a4F72CBb6"
         owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"
-        type: pausableIsm
         paused: false
+        type: pausableIsm
     threshold: 3
+    type: staticAggregationIsm
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
   name: ECO Voucher ENI 1
   owner: "0xf0004476DDC8985C067b6BDf94a1759f7b230809"


### PR DESCRIPTION
## A1 incident fix — ClientIsm registry mismatch

This is the **first PR in the A-family incident series**, resolving all **A1 (ClientIsm)** cases.

### Problem
`warp-check` reported ISM mismatches masked as `[object Object]` for 6 routes. Each customer had deployed a custom `interchainSecurityModule` that the registry still expected to be the mailbox default.

### Routes fixed

| Route | Chain(s) | ISM type | Notes |
|---|---|---|---|
| WBTC/incentiv | eth / incentiv | `MERKLE_ROOT_MULTISIG` | Deprecation event from original #eng thread; new multisig set encoded |
| ETH/krown | base / eth | `ROUTING` (`defaultFallbackRoutingIsm`) | Richer security than default — benign |
| USDC/krown | base / eth | `ROUTING` (`defaultFallbackRoutingIsm`) | Benign |
| USDT/krown | eth | `ROUTING` (`defaultFallbackRoutingIsm`) | Benign |
| PB/eni | eni / bsc | `AGGREGATION` (`staticAggregationIsm`) | Registry had stale ISM object; replaced with on-chain read |
| evENI/bsc | eni / bsc | `AGGREGATION` (`staticAggregationIsm`) | Same as above |

### Method
All ISM configs recovered via `hyperlane warp read -r http://localhost:3333` (TypeScript CLI) and written verbatim into each `*-deploy.yaml`. No on-chain changes — registry-only fix.

### Remaining A-family incidents
A2+ (MITO/mitosis proxyAdmin, LUMIA 8-chain proxyAdmin, USDC/eclipsemainnet) are tracked separately and will be addressed in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)