### PR TITLE
fix(warp): A2 — update proxyAdmin owners for MITO/mitosis and LUMIA

### DIFF
--- a/.changeset/fix-a2-proxyadmin-owners.md
+++ b/.changeset/fix-a2-proxyadmin-owners.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The proxyAdmin owner is updated for MITO/mitosis and LUMIA warp routes to match on-chain state after customers took self-custody of their proxyAdmin contracts.

--- a/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-deploy.yaml
+++ b/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-deploy.yaml
@@ -1,39 +1,54 @@
 arbitrum:
   owner: "0xc8A9Dea7359Bd6FDCAD3B8EDE108416C25cF4CE9"
+  proxyAdmin:
+    address: "0xBeD2B2C890cC5387Ed1554DC91279a80abbAc88E"
+    owner: "0xc8A9Dea7359Bd6FDCAD3B8EDE108416C25cF4CE9"
   symbol: LUMIA
   type: synthetic
 avalanche:
   owner: "0x6d5Cd9e6EB9a2E74bF9857c53aA44F659f0Cc332"
+  proxyAdmin:
+    address: "0x5b7a06F8632153C2f5654a0673840CFD7D8Bd8be"
+    owner: "0x6d5Cd9e6EB9a2E74bF9857c53aA44F659f0Cc332"
   symbol: LUMIA
   type: synthetic
 base:
   owner: "0xcEC53d6fF9B4C7b8E77f0C0D3f8828Bb872f2377"
+  proxyAdmin:
+    address: "0xA65B8FD1Bfa8a8e3f290FA8f1a255DC2949887dC"
+    owner: "0xcEC53d6fF9B4C7b8E77f0C0D3f8828Bb872f2377"
   symbol: LUMIA
   type: synthetic
 bsc:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0x54bB5b12c67095eB3dabCD11FA74AAcfE46E7767"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   type: synthetic
 ethereum:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0xdaB976ae358D4D2d25050b5A25f71520983C46c9"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   token: "0xD9343a049D5DBd89CD19DC6BcA8c48fB3a0a42a7"
   type: collateral
 lumiaprism:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0xBC53dACd8c0ac0d2bAC461479EAaf5519eCC8853"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   type: native
 optimism:
   owner: "0x914931eBb5638108651455F50C1F784d3E5fd3EC"
+  proxyAdmin:
+    address: "0x10fA25052B35B5d38d7f894db3490d3C76CD7957"
+    owner: "0x914931eBb5638108651455F50C1F784d3E5fd3EC"
   symbol: LUMIA
   type: synthetic
 polygon:
   owner: "0x7a412dD3812369226cd42023FC9301A66788122e"
+  proxyAdmin:
+    address: "0x615254BD35Af40e66239A51dE9cbbdD67f46477F"
+    owner: "0x7a412dD3812369226cd42023FC9301A66788122e"
   symbol: LUMIA
   type: synthetic

--- a/deployments/warp_routes/MITO/mitosis-deploy.yaml
+++ b/deployments/warp_routes/MITO/mitosis-deploy.yaml
@@ -38,10 +38,10 @@ bsc:
     type: staticAggregationIsm
   owner: "0x1248163214D9A0D6F02932A245370D3fD9613A82"
   ownerOverrides:
-    proxyAdmin: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    proxyAdmin: "0x1248163214D9A0D6F02932A245370D3fD9613A82"
   proxyAdmin:
     address: "0xb80d5c3DDF890C39c84ed487Ed95794560addb66"
-    owner: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    owner: "0x1248163214D9A0D6F02932A245370D3fD9613A82"
   symbol: MITO
   type: synthetic
 mitosis:
@@ -64,8 +64,8 @@ mitosis:
     type: staticAggregationIsm
   owner: "0x1248163200964459971c7cC9631909132AD28C27"
   ownerOverrides:
-    proxyAdmin: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    proxyAdmin: "0x1248163200964459971c7cC9631909132AD28C27"
   proxyAdmin:
     address: "0x8452363d5c78bf95538614441Dc8B465e03A89ca"
-    owner: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    owner: "0x1248163200964459971c7cC9631909132AD28C27"
   type: native


### PR DESCRIPTION
## A2 incident fix — proxyAdmin ownership transferred to customer

This is the **second PR in the A-family incident series**, resolving all **A2 (Owner)** cases.

### Problem
`warp-check` reported `proxyAdmin.owner` mismatches for MITO/mitosis and LUMIA. Customers had taken self-custody of their proxyAdmin contracts but the registry still reflected the original Hyperlane-controlled owner.

### Routes fixed

| Route | Chain(s) | Old (expected) | New (actual) | Notes |
|---|---|---|---|---|
| MITO/mitosis | bsc | `0x8f51e8…` | `0x1248163214…` | Mitosis ICA/Safe-style proxy — self-custody, benign |
| MITO/mitosis | mitosis | `0x8f51e8…` | `0x1248163200…` | Same — vanity `0x12481632` prefix |
| LUMIA | bsc, ethereum, lumiaprism | `0x8bBA07…` | `0xa86C4AF592…` | Single EOA across all chains — benign but flagged to Lumia: should migrate to a Safe |
| LUMIA | arbitrum, avalanche, base, optimism, polygon | _(missing)_ | per-chain from warp read | Added missing proxyAdmin entries surfaced by full warp read |

> ⚠️ **Note for Lumia:** `0xa86C4AF592…` is an EOA, not a contract. Using an EOA as `proxyAdmin` owner is a security risk — a single key compromise would allow a proxy upgrade. Recommend migrating to a Gnosis Safe.

### Method
On-chain state recovered via `hyperlane warp read -r http://localhost:3333`. Registry-only fix — no on-chain changes.

### A-family series
- ✅ [A1 — ClientIsm](https://github.com/hyperlane-xyz/hyperlane-registry/pull/1568): custom ISMs encoded for 6 routes
- ✅ **A2 — Owner** (this PR): proxyAdmin owners bumped for MITO and LUMIA
- 🔜 A3+ (USDC/eclipsemainnet proxyAdmin): needs investigation before fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)