### PR TITLE
fix: point igra gasCurrencyCoinGeckoId to wrapped-ikas-zealous-swap

### DIFF
--- a/.changeset/igra-ikas-coingecko-id.md
+++ b/.changeset/igra-ikas-coingecko-id.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+- Fixed igra's gasCurrencyCoinGeckoId, which pointed at the unrelated IGRA governance token instead of the native iKAS gas token. Repointed to wrapped-ikas-zealous-swap so the IGP gas oracle prices iKAS correctly.

--- a/chains/igra/metadata.yaml
+++ b/chains/igra/metadata.yaml
@@ -14,7 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Igra
 domainId: 38833
-gasCurrencyCoinGeckoId: igra
+gasCurrencyCoinGeckoId: wrapped-ikas-zealous-swap
 gnosisSafeTransactionServiceUrl: https://safe.igralabs.com/txs
 name: igra
 nativeToken:


### PR DESCRIPTION
## Summary
- The igra chain's native gas token is **iKAS**, but `gasCurrencyCoinGeckoId` was set to `igra`, which on CoinGecko is the unrelated **IGRA governance token** (~$0.006, mkt-cap rank 416) — not iKAS.
- This mispriced the IGP gas oracle: the Jun 18 oracle batch fetched the wrong token's price, dropping the configured iKAS price from a placeholder to ~$0.006 and spiking outbound iKAS gas fees ~170x.
- Repoint to `wrapped-ikas-zealous-swap` (~$0.0295), which tracks the real iKAS market price (~$0.033). The dedicated iKAS feed `igra-bridged-kaspa` currently returns no `simple/price` data, so `wrapped-ikas-zealous-swap` is the usable feed.

## Follow-up
- After merge, regenerate `mainnet3` token prices + gas-oracle-configs and push via the next multisig batch so the on-chain oracle picks up the corrected price.

## Test plan
- [x] Confirm `https://api.coingecko.com/api/v3/simple/price?ids=wrapped-ikas-zealous-swap&vs_currencies=usd` returns a price near market (~$0.03)
- [x] CI metadata validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)