### PR TITLE
feat: add USDC token fees testnet warp route (arbitrumsepolia-basesepolia)

### DIFF
--- a/.changeset/strong-spiders-call.md
+++ b/.changeset/strong-spiders-call.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Added token fees testnet route

--- a/deployments/warp_routes/USDC/arbitrumsepolia-basesepolia-token-fees-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrumsepolia-basesepolia-token-fees-config.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x2bef59e84615371304bd731601f6344F5F304504"
+    chainName: arbitrumsepolia
+    collateralAddressOrDenom: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"
+    connections:
+      - token: ethereum|basesepolia|0x7e163aE6A31956Cb166B7426d508e1f346465d56
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDC
+    tokenType: collateral
+  - addressOrDenom: "0x7e163aE6A31956Cb166B7426d508e1f346465d56"
+    chainName: basesepolia
+    connections:
+      - token: ethereum|arbitrumsepolia|0x2bef59e84615371304bd731601f6344F5F304504
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC
+    tokenType: synthetic

--- a/deployments/warp_routes/USDC/arbitrumsepolia-basesepolia-token-fees-deploy.yaml
+++ b/deployments/warp_routes/USDC/arbitrumsepolia-basesepolia-token-fees-deploy.yaml
@@ -1,0 +1,11 @@
+arbitrumsepolia:
+  mailbox: "0x598facE78a4302f11E3de0bee1894Da0b2Cb71F8"
+  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  token: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"
+  type: collateral
+  feeHook: "0x473a72465299C757eD0EA81FC829556E344f856F"
+basesepolia:
+  mailbox: "0x6966b0E55883d49BFB24539356a2f8A673E02039"
+  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  type: synthetic
+  feeHook: "0xbF49AbFF53851817ae6cF4797af6e5c153113988"


### PR DESCRIPTION
## Summary

- Adds USDC warp route config between arbitrumsepolia and basesepolia with token fee hooks
- Collateral on arbitrumsepolia (`0x2bef59e84615371304bd731601f6344F5F304504`), synthetic on basesepolia (`0x7e163aE6A31956Cb166B7426d508e1f346465d56`)
- Both sides configured with `feeHook` addresses for testing token fee functionality

## Test plan

- [ ] Verify contract addresses are correct on respective testnets
- [ ] Confirm warp route is discoverable via registry lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)