### PR TITLE
feat(ETH/arbitrum): add base hook pause mechanism + reduce base→arbitrum fee to 11 bps [IGNORE]

### DIFF
--- a/deployments/warp_routes/ETH/arbitrum-config.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xA2cB89330E057a2cF76C6945aEAD22631c4df061"
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    chainName: arbitrum
+    connections:
+      - token: ethereum|base|0xfBB4EE517Ed80C027Fd8217Db53ffD8190792522
+    decimals: 18
+    name: Ether
+    standard: EvmHypSynthetic
+    symbol: ETH
+    tokenType: synthetic
+  - addressOrDenom: "0xfBB4EE517Ed80C027Fd8217Db53ffD8190792522"
+    coinGeckoId: ethereum
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    chainName: base
+    connections:
+      - token: ethereum|arbitrum|0xA2cB89330E057a2cF76C6945aEAD22631c4df061
+    decimals: 18
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+    tokenType: native

--- a/deployments/warp_routes/ETH/arbitrum-deploy.yaml
+++ b/deployments/warp_routes/ETH/arbitrum-deploy.yaml
@@ -1,0 +1,83 @@
+arbitrum:
+  contractVersion: 11.3.1
+  decimals: 18
+  destinationGas:
+    "8453": "44000"
+  hook: "0x0000000000000000000000000000000000000000"
+  interchainSecurityModule:
+    address: "0x832B54Be22f94917Becf10486D5F08027fd290bA"
+    modules:
+      - address: "0x3FdE1aC2d31563f93acB9727b0d5b5FdfDfF8bf6"
+        owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+        paused: false
+        type: pausableIsm
+      - address: "0x52102b061da4BF2f27a23403834095fcf9E1a887"
+        domains: {}
+        owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+        type: defaultFallbackRoutingIsm
+    threshold: 2
+    type: staticAggregationIsm
+  isNft: false
+  mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
+  name: Ether
+  owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+  proxyAdmin:
+    address: "0xF50286Fc7487c8945fFc257ca0fb0d299978fFfC"
+    owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+  remoteRouters:
+    "8453":
+      address: "0x000000000000000000000000fbb4ee517ed80c027fd8217db53ffd8190792522"
+  symbol: ETH
+  tokenFee:
+    address: "0xeafb93d921e4557bECdA567927f36ad28854Aae1"
+    feeContracts:
+      base:
+        address: "0x16BF93e259ee7f7074453a2948379C35C6851b71"
+        bps: 15
+        halfAmount: "38597363079105398474523661669562635951089333"
+        maxFee: "115792089237316195423570985008687907853269"
+        owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+        token: "0xA2cB89330E057a2cF76C6945aEAD22631c4df061"
+        type: LinearFee
+    owner: "0xC92c781F59b6452e7879e1e0317444c5B7Bb651c"
+    token: "0xA2cB89330E057a2cF76C6945aEAD22631c4df061"
+    type: RoutingFee
+  type: synthetic
+base:
+  allowedRebalancers: []
+  allowedRebalancingBridges: {}
+  contractVersion: 11.3.1
+  decimals: 18
+  destinationGas:
+    "42161": "64000"
+  hook:
+    hooks:
+      - type: defaultHook
+      - owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+        paused: false
+        type: pausableHook
+    type: aggregationHook
+  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+  isNft: false
+  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+  name: Ether
+  owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+  proxyAdmin:
+    address: "0x6E0C98A9Efd2bDCD5acbc42b2E9de91994b06FE5"
+    owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+  remoteRouters:
+    "42161":
+      address: "0x000000000000000000000000a2cb89330e057a2cf76c6945aead22631c4df061"
+  symbol: ETH
+  tokenFee:
+    address: "0x5A8237b0cf741b4b62fe40ee2711bF158E25750c"
+    feeContracts:
+      arbitrum:
+        bps: 11
+        owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+        token: "0x0000000000000000000000000000000000000000"
+        type: LinearFee
+    owner: "0x645FE06507C8a188494d3E755B248a8dbF3bd875"
+    token: "0x0000000000000000000000000000000000000000"
+    type: RoutingFee
+  type: native


### PR DESCRIPTION
## Summary
- Adds a pause gate to the **base** hook via `aggregationHook[defaultHook, pausableHook]` — keeps the mailbox-default IGP + merkle insertion on the success path (a bare `pausableHook` would swallow gas payment and brick delivery).
- Reduces the **base→arbitrum** `LinearFee` to **11 bps** (was 15 bps on-chain). `LinearFee.bps` is immutable, so this redeploys the fee contract.
- Config reconciled against current on-chain state via `warp read`. **Supersedes the stale PR #1558** (`feat/eth-base-arbitrum`), which had drifted (fee shown as 10, missing arbitrum's custom ISM).

## Notes
- Reflects the **target post-wiring** state. The base owner is an ICA controlled by EOA `0x3f13C135…0913` on ethereum; the `callRemote` that sets the new aggregationHook + LinearFee on-chain is pending broadcast from that controller.
- New contract addresses (aggregationHook, LinearFee@11bps) are intentionally **not** baked in — they resolve on the next `warp read` once the owner ops execute.
- arbitrum side unchanged (custom `staticAggregationIsm`, arbitrum→base fee at 15 bps preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)