### PR TITLE
fix(tempo): correct native token to pathUSD with 6 decimals

### DIFF
--- a/.changeset/fix-tempo-native-token.md
+++ b/.changeset/fix-tempo-native-token.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Fixed the tempo native token metadata: decimals corrected from 18 to 6, and name/symbol updated to pathUSD.

--- a/chains/tempo/metadata.yaml
+++ b/chains/tempo/metadata.yaml
@@ -17,9 +17,9 @@ domainId: 4217
 gasCurrencyCoinGeckoId: usd-coin
 name: tempo
 nativeToken:
-  decimals: 18
-  name: USD
-  symbol: USD
+  decimals: 6
+  name: pathUSD
+  symbol: pathUSD
 protocol: ethereum
 rpcUrls:
   - http: https://rpc.tempo.xyz


### PR DESCRIPTION
## Summary
- Tempo's native gas coin is pathUSD, a 6-decimal USD stablecoin, not an 18-decimal generic USD.
- Fixed `chains/tempo/metadata.yaml` `nativeToken`: `decimals` 18 → 6, `name`/`symbol` USD → pathUSD.
- Added a patch changeset.

## Notes
- Left `gasCurrencyCoinGeckoId: usd-coin` unchanged — a USD-stablecoin price proxy is still appropriate for gas cost estimation. Flag if pathUSD has its own CoinGecko id to use instead.

## Test plan
- [ ] CI validation passes (schema + changeset check)