### PR TITLE
feat: add nativeToken.address to tempo metadata

### DIFF
--- a/.changeset/tempo-native-token-address.md
+++ b/.changeset/tempo-native-token-address.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+- Added the `nativeToken.address` field to tempo metadata, pointing at the pathUSD TIP-20 contract (0x20c0000000000000000000000000000000000000). This flags that tempo's gas token is an ERC20 contract rather than a protocol-level native token, so funding/balance tooling should use balanceOf / ERC20 transfers instead of eth_getBalance / native sends.

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -9003,6 +9003,7 @@ tempo:
   gasCurrencyCoinGeckoId: usd-coin
   name: tempo
   nativeToken:
+    address: "0x20c0000000000000000000000000000000000000"
     decimals: 6
     name: pathUSD
     symbol: pathUSD

--- a/chains/tempo/metadata.yaml
+++ b/chains/tempo/metadata.yaml
@@ -17,6 +17,7 @@ domainId: 4217
 gasCurrencyCoinGeckoId: usd-coin
 name: tempo
 nativeToken:
+  address: "0x20c0000000000000000000000000000000000000"
   decimals: 6
   name: pathUSD
   symbol: pathUSD


### PR DESCRIPTION
## Summary
- Adds `nativeToken.address: "0x20c0000000000000000000000000000000000000"` to `chains/tempo/metadata.yaml`.
- Flags tempo's gas token (pathUSD) as an ERC20 contract rather than a protocol-level native token, so funding/balance tooling uses `balanceOf` / ERC20 transfers instead of `eth_getBalance` / native sends.
- Patch changeset added.
- Follow-up to #1583 (pathUSD decimals/name/symbol), now merged.

## Coordination note
- `nativeToken.address` is not yet in the registry's pinned `@hyperlane-xyz/sdk` (35.1.0) `NativeTokenSchema`, so `chains/schema.json` does not list it and SDK consumers strip it on `ChainMetadataSchema.parse` until the SDK adds the field. Raw registry YAML retains it. CI passes (build + `tempo metadata is valid` unit test verified locally). Once the SDK ships `address` and the registry bumps to it, `schema.json` regenerates to include the field.

## Test plan
- [x] `pnpm run build` succeeds; combined `chains/metadata.yaml` retains the field
- [x] `tempo metadata is valid` unit test passes
- [ ] CI validation (schema + changeset check)