### PR TITLE
feat: add extra rebalancer to CROSS/moonpay staging routes

### DIFF
--- a/.changeset/moonpay-staging-extra-rebalancer.md
+++ b/.changeset/moonpay-staging-extra-rebalancer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added 0x2cB236403574301029c7bDDfda133c6e0338a857 as an allowedRebalancer on every EVM leg of the USDC/moonpay-staging and USDT/moonpay-staging routes, alongside the existing MCR signer. The Solana leg is unchanged.

--- a/deployments/warp_routes/USDC/moonpay-staging-deploy.yaml
+++ b/deployments/warp_routes/USDC/moonpay-staging-deploy.yaml
@@ -1,6 +1,7 @@
 arbitrum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
@@ -45,6 +46,7 @@ arbitrum:
 base:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
@@ -89,6 +91,7 @@ base:
 bsc:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0x1eebF9d94a5E707E30f18b9aB3295D963C111fb7"
@@ -121,6 +124,7 @@ bsc:
 citrea:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0x5eF92fe56Db2d7c6934fD160a88099fF91F93907"
@@ -150,6 +154,7 @@ citrea:
 ethereum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "137":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
@@ -192,6 +197,8 @@ ethereum:
   token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
   type: crossCollateral
 katana:
+  allowedRebalancers:
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   crossCollateralRouters:
     "1":
       - "0x0000000000000000000000004628d301c4a1a32b4c7e753621b0787c32ee7475"
@@ -212,6 +219,7 @@ katana:
 polygon:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"

--- a/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
+++ b/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
@@ -1,6 +1,7 @@
 arbitrum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
@@ -31,6 +32,8 @@ arbitrum:
   token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
   type: crossCollateral
 base:
+  allowedRebalancers:
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   crossCollateralRouters:
     "1":
       - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
@@ -55,6 +58,7 @@ base:
 bsc:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0xc13d466B9E196AfdE472856923E857cc298EDf1b"
@@ -87,6 +91,7 @@ bsc:
 ethereum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "137":
       - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
@@ -117,6 +122,8 @@ ethereum:
   token: "0xdac17f958d2ee523a2206206994597c13d831ec7"
   type: crossCollateral
 katana:
+  allowedRebalancers:
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   crossCollateralRouters:
     "1":
       - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
@@ -141,6 +148,7 @@ katana:
 polygon:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0x2cB236403574301029c7bDDfda133c6e0338a857"
   allowedRebalancingBridges:
     "1":
       - bridge: "0x361A7DA84A1f4A0c565772C45Ed838C6a0fAea94"


### PR DESCRIPTION
## Summary
Regenerated deploy YAMLs for `USDC/moonpay-staging` and `USDT/moonpay-staging` adding `0x2cB236403574301029c7bDDfda133c6e0338a857` as an `allowedRebalancer` on every EVM leg, alongside the existing MCR signer. Solana leg unchanged. Includes a changeset.

Companion to monorepo #8990. The ownership transfer is split into a separate PR (#1590).

## Test plan
- [x] Regenerated both deploy YAMLs; diff is rebalancer-additive only
- [ ] `warp apply` to push on-chain