### PR TITLE
feat: transfer moonpay-staging route ownership to deployer key

### DIFF
--- a/.changeset/moonpay-staging-ownership-transfer.md
+++ b/.changeset/moonpay-staging-ownership-transfer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Transferred ownership of the USDC/moonpay-staging and USDT/moonpay-staging routes from the personal deployer keys to the standard Hyperlane deployer key. EVM legs are now owned by 0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba and the Solana leg by 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf.

--- a/deployments/warp_routes/USDC/moonpay-staging-deploy.yaml
+++ b/deployments/warp_routes/USDC/moonpay-staging-deploy.yaml
@@ -39,7 +39,7 @@ arbitrum:
     "8453":
       - "0x000000000000000000000000f147aae190f01aab67152d97ad3b157c3957bd77"
   mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
   type: crossCollateral
 base:
@@ -83,7 +83,7 @@ base:
     "8453":
       - "0x000000000000000000000000f147aae190f01aab67152d97ad3b157c3957bd77"
   mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   type: crossCollateral
 bsc:
@@ -112,7 +112,7 @@ bsc:
     "8453":
       - "0x000000000000000000000000f147aae190f01aab67152d97ad3b157c3957bd77"
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   scale:
     denominator: 1000000000000
     numerator: 1
@@ -144,7 +144,7 @@ citrea:
     "8453":
       - "0x000000000000000000000000f147aae190f01aab67152d97ad3b157c3957bd77"
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D"
   type: crossCollateral
 ethereum:
@@ -188,7 +188,7 @@ ethereum:
     "8453":
       - "0x000000000000000000000000f147aae190f01aab67152d97ad3b157c3957bd77"
   mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
   type: crossCollateral
 katana:
@@ -206,7 +206,7 @@ katana:
     "8453":
       - "0x000000000000000000000000f147aae190f01aab67152d97ad3b157c3957bd77"
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36"
   type: crossCollateral
 polygon:
@@ -246,7 +246,7 @@ polygon:
     "8453":
       - "0x000000000000000000000000f147aae190f01aab67152d97ad3b157c3957bd77"
   mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
   type: crossCollateral
 solanamainnet:
@@ -268,7 +268,7 @@ solanamainnet:
   hook: BhNcatUDC2D5JTyeaqrdSukiVFsEHK7e3hVmKMztwefv
   mailbox: E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi
   name: XO Cash
-  owner: D4jZ2sNktKgTrhWVMnjZb5BXP7MMh9N3y5ZLwkyKfozb
+  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
   symbol: XO
   token: xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y
   type: crossCollateral

--- a/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
+++ b/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
@@ -27,7 +27,7 @@ arbitrum:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
   type: crossCollateral
 base:
@@ -49,7 +49,7 @@ base:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2"
   type: crossCollateral
 bsc:
@@ -78,7 +78,7 @@ bsc:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   scale:
     denominator: 1000000000000
     numerator: 1
@@ -113,7 +113,7 @@ ethereum:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xdac17f958d2ee523a2206206994597c13d831ec7"
   type: crossCollateral
 katana:
@@ -135,7 +135,7 @@ katana:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0x2DCa96907fde857dd3D816880A0df407eeB2D2F2"
   type: crossCollateral
 polygon:
@@ -164,6 +164,6 @@ polygon:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
-  owner: "0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E"
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
   type: crossCollateral


### PR DESCRIPTION
## Summary
Regenerated deploy YAMLs for `USDC/moonpay-staging` and `USDT/moonpay-staging` with the standard Hyperlane deployer key as owner on every leg (companion to monorepo #8991).

- EVM legs (13) → `0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba`
- Solana leg → `9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf`

Owner-only diff; includes a changeset.

## Test plan
- [x] Regenerated both deploy YAMLs; diff is owner-only (14 legs)
- [ ] `warp apply` to push on-chain