### PR TITLE
fix(MITO): update proxyAdmin owner to customer timelocks

### DIFF
--- a/.changeset/mitosis-proxyadmin-owner.md
+++ b/.changeset/mitosis-proxyadmin-owner.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Updated the MITO/mitosis warp route proxyAdmin owners on bsc and mitosis to the customer governance timelocks, matching the 2025-09-23 on-chain ownership handoff from the Mitosis customer EOA. bsc proxyAdmin.owner and ownerOverrides.proxyAdmin are now 0x1248163214D9A0D6F02932A245370D3fD9613A82; mitosis are now 0x1248163200964459971c7cC9631909132AD28C27.

--- a/deployments/warp_routes/MITO/mitosis-deploy.yaml
+++ b/deployments/warp_routes/MITO/mitosis-deploy.yaml
@@ -38,10 +38,10 @@ bsc:
     type: staticAggregationIsm
   owner: "0x1248163214D9A0D6F02932A245370D3fD9613A82"
   ownerOverrides:
-    proxyAdmin: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    proxyAdmin: "0x1248163214D9A0D6F02932A245370D3fD9613A82"
   proxyAdmin:
     address: "0xb80d5c3DDF890C39c84ed487Ed95794560addb66"
-    owner: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    owner: "0x1248163214D9A0D6F02932A245370D3fD9613A82"
   symbol: MITO
   type: synthetic
 mitosis:
@@ -64,8 +64,8 @@ mitosis:
     type: staticAggregationIsm
   owner: "0x1248163200964459971c7cC9631909132AD28C27"
   ownerOverrides:
-    proxyAdmin: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    proxyAdmin: "0x1248163200964459971c7cC9631909132AD28C27"
   proxyAdmin:
     address: "0x8452363d5c78bf95538614441Dc8B465e03A89ca"
-    owner: "0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612"
+    owner: "0x1248163200964459971c7cC9631909132AD28C27"
   type: native


### PR DESCRIPTION
## Summary

The MITO/mitosis warp route proxyAdmins were transferred from the Mitosis (customer) EOA (`0x8f51e8e0…13612`) to the customer's governance timelocks on **2025-09-23** (self-signed `transferOwnership`):

- **bsc** proxyAdmin `0xb80d5c3D…db66` → `0x1248163214D9A0D6F02932A245370D3fD9613A82`
- **mitosis** proxyAdmin `0x8452…89ca` → `0x1248163200964459971c7cC9631909132AD28C27`

This updates the recorded `proxyAdmin.owner` and `ownerOverrides.proxyAdmin` on both chains to match verified on-chain state (`cast call <proxyAdmin> owner()`), clearing the spurious `proxyAdmin` Owner mismatch reported by the warp config check.

The per-chain timelock is the same address already recorded as the route `owner`. ISM owners are intentionally unchanged (still the Mitosis customer EOA `0x8f51e8e0` on-chain).

Paired with the monorepo config-getter update (hyperlane-xyz/hyperlane-monorepo#8996).