### PR TITLE
chore: unenroll litchain from LITKEY route

### DIFF
--- a/.changeset/unenroll-litchain.md
+++ b/.changeset/unenroll-litchain.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Unenrolled litchain from the LITKEY warp route ahead of litchain deprecation. Removed the `ethereum|litchain|...` connection from every other spoke's `connections` list.

--- a/deployments/warp_routes/LITKEY/litchain-config.yaml
+++ b/deployments/warp_routes/LITKEY/litchain-config.yaml
@@ -9,7 +9,6 @@ tokens:
       - token: ethereum|bsc|0x0bBeA6812fb3fcBcA126eDb558e551B3f1702026
       - token: ethereum|ethereum|0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD
       - token: ethereum|linea|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|optimism|0x56aE521E18a7de66b2e3AcE3A0b71e716a61D34d
       - token: ethereum|polygon|0x5bEd1A06b26853360D9D1a6a27eaCE1b85206867
     decimals: 18
@@ -25,7 +24,6 @@ tokens:
       - token: ethereum|bsc|0x0bBeA6812fb3fcBcA126eDb558e551B3f1702026
       - token: ethereum|ethereum|0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD
       - token: ethereum|linea|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|optimism|0x56aE521E18a7de66b2e3AcE3A0b71e716a61D34d
       - token: ethereum|polygon|0x5bEd1A06b26853360D9D1a6a27eaCE1b85206867
     decimals: 18
@@ -43,7 +41,6 @@ tokens:
       - token: ethereum|bsc|0x0bBeA6812fb3fcBcA126eDb558e551B3f1702026
       - token: ethereum|ethereum|0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD
       - token: ethereum|linea|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|optimism|0x56aE521E18a7de66b2e3AcE3A0b71e716a61D34d
       - token: ethereum|polygon|0x5bEd1A06b26853360D9D1a6a27eaCE1b85206867
     decimals: 18
@@ -59,7 +56,6 @@ tokens:
       - token: ethereum|base|0x9D132d5678253FD88f7DB51Ac2AC13FC40a63547
       - token: ethereum|ethereum|0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD
       - token: ethereum|linea|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|optimism|0x56aE521E18a7de66b2e3AcE3A0b71e716a61D34d
       - token: ethereum|polygon|0x5bEd1A06b26853360D9D1a6a27eaCE1b85206867
     decimals: 18
@@ -77,7 +73,6 @@ tokens:
       - token: ethereum|base|0x9D132d5678253FD88f7DB51Ac2AC13FC40a63547
       - token: ethereum|bsc|0x0bBeA6812fb3fcBcA126eDb558e551B3f1702026
       - token: ethereum|linea|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|optimism|0x56aE521E18a7de66b2e3AcE3A0b71e716a61D34d
       - token: ethereum|polygon|0x5bEd1A06b26853360D9D1a6a27eaCE1b85206867
     decimals: 18
@@ -93,7 +88,6 @@ tokens:
       - token: ethereum|base|0x9D132d5678253FD88f7DB51Ac2AC13FC40a63547
       - token: ethereum|bsc|0x0bBeA6812fb3fcBcA126eDb558e551B3f1702026
       - token: ethereum|ethereum|0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|optimism|0x56aE521E18a7de66b2e3AcE3A0b71e716a61D34d
       - token: ethereum|polygon|0x5bEd1A06b26853360D9D1a6a27eaCE1b85206867
     decimals: 18
@@ -129,7 +123,6 @@ tokens:
       - token: ethereum|bsc|0x0bBeA6812fb3fcBcA126eDb558e551B3f1702026
       - token: ethereum|ethereum|0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD
       - token: ethereum|linea|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|polygon|0x5bEd1A06b26853360D9D1a6a27eaCE1b85206867
     decimals: 18
     logoURI: /deployments/warp_routes/LITKEY/logo.svg
@@ -145,7 +138,6 @@ tokens:
       - token: ethereum|bsc|0x0bBeA6812fb3fcBcA126eDb558e551B3f1702026
       - token: ethereum|ethereum|0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD
       - token: ethereum|linea|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
-      - token: ethereum|litchain|0x94930Cbfed2483b69DfBed9d96a9CdD7c27D1393
       - token: ethereum|optimism|0x56aE521E18a7de66b2e3AcE3A0b71e716a61D34d
     decimals: 18
     logoURI: /deployments/warp_routes/LITKEY/logo.svg


### PR DESCRIPTION
## Summary
- Remove litchain as a connection from every other LITKEY warp route spoke, ahead of deprecating the litchain chain.
- Changeset included.

## Test plan
- [x] `pnpm run build && pnpm run lint`