### PR TITLE
chore: july 2026 chain deprecations

### DIFF
--- a/.changeset/deprecate-h1-2026-ready-chains.md
+++ b/.changeset/deprecate-h1-2026-ready-chains.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': minor
 ---
 
-Deprecated 20 mainnet chains that are ready for removal in H1 2026. Marked the following chains as disabled in their metadata: arcadia, astar, chilizmainnet, coredao, cyber, flare, fusemainnet, gravity, kaia, miraclechain, ontology, opbnb, orderly, rarichain, shibarium, sophon, stride, xai, xrplevm, zetachain.
+Deprecated 21 mainnet chains that are ready for removal in H1 2026. Marked the following chains as disabled in their metadata: ancient8, arcadia, astar, chilizmainnet, coredao, cyber, flare, fusemainnet, gravity, kaia, miraclechain, ontology, opbnb, orderly, rarichain, shibarium, sophon, stride, xai, xrplevm, zetachain.

--- a/.changeset/deprecate-h1-2026-ready-chains.md
+++ b/.changeset/deprecate-h1-2026-ready-chains.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Deprecated 20 mainnet chains that are ready for removal in H1 2026. Marked the following chains as disabled in their metadata: arcadia, astar, chilizmainnet, coredao, cyber, flare, fusemainnet, gravity, kaia, miraclechain, ontology, opbnb, orderly, rarichain, shibarium, sophon, stride, xai, xrplevm, zetachain.

--- a/chains/ancient8/metadata.yaml
+++ b/chains/ancient8/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://scan.ancient8.gg/api
     family: blockscout

--- a/chains/arcadia/metadata.yaml
+++ b/chains/arcadia/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.arcadia.khalani.network/api
     family: blockscout

--- a/chains/astar/metadata.yaml
+++ b/chains/astar/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://astar.blockscout.com/api
     family: blockscout

--- a/chains/chilizmainnet/metadata.yaml
+++ b/chains/chilizmainnet/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/88888/etherscan/api
     family: routescan

--- a/chains/coredao/metadata.yaml
+++ b/chains/coredao/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://scan.coredao.org/api
     family: other

--- a/chains/cyber/metadata.yaml
+++ b/chains/cyber/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api.socialscan.io/cyber
     family: other

--- a/chains/flare/metadata.yaml
+++ b/chains/flare/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://flare-explorer.flare.network/api
     family: blockscout

--- a/chains/fusemainnet/metadata.yaml
+++ b/chains/fusemainnet/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.fuse.io/api
     family: etherscan

--- a/chains/gravity/metadata.yaml
+++ b/chains/gravity/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.gravity.xyz/api
     family: blockscout

--- a/chains/kaia/metadata.yaml
+++ b/chains/kaia/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api-cypress.klaytnscope.com/api
     family: etherscan

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -445,6 +445,10 @@ arbitrumsepolia:
     - http: https://sepolia-rollup.arbitrum.io/rpc
   technicalStack: arbitrumnitro
 arcadia:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.arcadia.khalani.network/api
       family: blockscout
@@ -638,6 +642,10 @@ artheratestnet:
       pagination:
         maxBlockRange: 10000
 astar:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://astar.blockscout.com/api
       family: blockscout
@@ -1646,6 +1654,10 @@ cheesechain:
     - http: https://cheesechain.calderachain.xyz/http
   technicalStack: arbitrumnitro
 chilizmainnet:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/88888/etherscan/api
       family: routescan
@@ -1876,6 +1888,10 @@ conwai:
     - http: https://conwai.calderachain.xyz/http
   technicalStack: arbitrumnitro
 coredao:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://scan.coredao.org/api
       family: other
@@ -2067,6 +2083,10 @@ cronoszkevm:
   rpcUrls:
     - http: https://mainnet.zkevm.cronos.org
 cyber:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api.socialscan.io/cyber
       family: other
@@ -3114,6 +3134,10 @@ flametestnet:
     - http: https://rpc.flame.dawn-1.astria.org
   technicalStack: other
 flare:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://flare-explorer.flare.network/api
       family: blockscout
@@ -3451,6 +3475,10 @@ funki:
   rpcUrls:
     - http: https://rpc-mainnet.funkichain.com
 fusemainnet:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.fuse.io/api
       family: etherscan
@@ -3678,6 +3706,10 @@ gnosischiadotestnet:
     - http: https://gnosis-chiado-rpc.publicnode.com
   technicalStack: other
 gravity:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.gravity.xyz/api
       family: blockscout
@@ -4358,6 +4390,10 @@ inksepolia:
     - http: https://rpc-qnd-sepolia.inkonchain.com
   technicalStack: opstack
 kaia:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api-cypress.klaytnscope.com/api
       family: etherscan
@@ -5462,6 +5498,10 @@ mintsepoliatest:
   rpcUrls:
     - http: https://sepolia-testnet-rpc.mintchain.io
 miraclechain:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.miracleplay.io/api
       family: blockscout
@@ -6207,6 +6247,10 @@ odysseytestnet:
   rpcUrls:
     - http: https://odyssey.ithaca.xyz
 ontology:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.ont.io/api
       family: other
@@ -6259,6 +6303,10 @@ oortmainnet:
     - http: https://mainnet-rpc.oortech.com
   technicalStack: other
 opbnb:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
       apiUrl: https://api.etherscan.io/v2/api?chainid=204
@@ -6403,6 +6451,10 @@ optimismsepolia:
   rpcUrls:
     - http: https://sepolia.optimism.io
 orderly:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.orderly.network/api
       family: blockscout
@@ -6971,6 +7023,10 @@ radixtestnet:
   rpcUrls:
     - http: https://stokenet.radixdlt.com
 rarichain:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://mainnet.explorer.rarichain.org/api
       family: blockscout
@@ -7560,6 +7616,10 @@ sepolia:
     - http: https://sepolia.drpc.org
     - http: https://1rpc.io/sepolia
 shibarium:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://shibariumscan.io/api
       family: blockscout
@@ -8081,6 +8141,10 @@ soon:
     - http: https://rpc.mainnet.soo.network/rpc
   technicalStack: other
 sophon:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://verification-explorer.sophon.xyz/contract_verification
       family: etherscan
@@ -8356,6 +8420,10 @@ storytestnet:
   transactionOverrides:
     gasPrice: 16000000000
 stride:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   bech32Prefix: stride
   blockExplorers:
     - apiUrl: https://apis.mintscan.io/v1/stride
@@ -9464,6 +9532,10 @@ worldchain:
     - http: https://worldchain-mainnet.g.alchemy.com/public
   technicalStack: opstack
 xai:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.xai-chain.net/api
       family: blockscout
@@ -9548,6 +9620,10 @@ xpla:
     - http: https://dimension-evm-rpc.xpla.dev
   technicalStack: other
 xrplevm:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.xrplevm.org/api
       family: blockscout
@@ -9632,6 +9708,10 @@ zeronetwork:
     - http: https://zero.drpc.org
   technicalStack: zksync
 zetachain:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.zetachain.com
       family: other

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -260,6 +260,10 @@ alfajores:
   rpcUrls:
     - http: https://alfajores-forno.celo-testnet.org
 ancient8:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://scan.ancient8.gg/api
       family: blockscout

--- a/chains/miraclechain/metadata.yaml
+++ b/chains/miraclechain/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.miracleplay.io/api
     family: blockscout

--- a/chains/ontology/metadata.yaml
+++ b/chains/ontology/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.ont.io/api
     family: other

--- a/chains/opbnb/metadata.yaml
+++ b/chains/opbnb/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
     apiUrl: https://api.etherscan.io/v2/api?chainid=204

--- a/chains/orderly/metadata.yaml
+++ b/chains/orderly/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.orderly.network/api
     family: blockscout

--- a/chains/rarichain/metadata.yaml
+++ b/chains/rarichain/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://mainnet.explorer.rarichain.org/api
     family: blockscout

--- a/chains/shibarium/metadata.yaml
+++ b/chains/shibarium/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://shibariumscan.io/api
     family: blockscout

--- a/chains/sophon/metadata.yaml
+++ b/chains/sophon/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://verification-explorer.sophon.xyz/contract_verification
     family: etherscan

--- a/chains/stride/metadata.yaml
+++ b/chains/stride/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 bech32Prefix: stride
 blockExplorers:
   - apiUrl: https://apis.mintscan.io/v1/stride

--- a/chains/xai/metadata.yaml
+++ b/chains/xai/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.xai-chain.net/api
     family: blockscout

--- a/chains/xrplevm/metadata.yaml
+++ b/chains/xrplevm/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.xrplevm.org/api
     family: blockscout

--- a/chains/zetachain/metadata.yaml
+++ b/chains/zetachain/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.zetachain.com
     family: other


### PR DESCRIPTION
Marks 20 mainnet chains as deprecated/disabled in registry metadata, per the [H1 2026 Chain Removals - Mainnet](https://linear.app/hyperlane-xyz/project/h1-2026-chain-removals-mainnet-efbcb9189820/issues) project (Linear status: Ready to start).

### Chains deprecated
- ancient8
- arcadia
- astar
- chilizmainnet
- coredao
- cyber
- flare
- fusemainnet
- gravity
- kaia
- miraclechain
- ontology
- opbnb
- orderly
- rarichain
- shibarium
- sophon
- stride
- xai
- xrplevm
- zetachain

### Changes
- Added `availability: { status: disabled, reasons: [deprecated] }` to each chain's `chains/{chain}/metadata.yaml`.
- Regenerated combined `chains/metadata.yaml` via build.
- Added a changeset for the registry minor bump.

### Verification
- `pnpm run format` applied.
- `pnpm run lint` passes.
- `pnpm run build` passes.
