### PR TITLE
fix: aleo destination gas config drift

### DIFF
--- a/.changeset/aleo-destination-gas.md
+++ b/.changeset/aleo-destination-gas.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added missing destinationGas entries for the Aleo SOL, USDC, and USDT warp routes' solanamainnet leg.

--- a/deployments/warp_routes/SOL/aleo-deploy.yaml
+++ b/deployments/warp_routes/SOL/aleo-deploy.yaml
@@ -14,6 +14,9 @@ hyperevm:
   type: collateral
 solanamainnet:
   decimals: 9
+  destinationGas:
+    "999": "64000"
+    "1634493807": "64000"
   foreignDeployment: 8YGT2pZwyZe94qBpGzWfY2TMEVcwaQ1bXAE7YAgpUaM7
   gas: 300000
   owner: ABJnd4eWexNte9GYy21ud5hvSwFKWedveP6GCFxXKkCw

--- a/deployments/warp_routes/USDC/aleo-deploy.yaml
+++ b/deployments/warp_routes/USDC/aleo-deploy.yaml
@@ -180,6 +180,15 @@ polygon:
   type: collateral
 solanamainnet:
   decimals: 6
+  destinationGas:
+    "1": "68000"
+    "10": "68000"
+    "56": "68000"
+    "137": "68000"
+    "8453": "68000"
+    "42161": "68000"
+    "43114": "68000"
+    "1634493807": "64000"
   foreignDeployment: EiUymjh3vJ2486ozY24s1A1YWXoH6QnSGjWuP95ph35G
   gas: 300000
   mailbox: E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi

--- a/deployments/warp_routes/USDT/aleo-deploy.yaml
+++ b/deployments/warp_routes/USDT/aleo-deploy.yaml
@@ -35,6 +35,11 @@ hyperevm:
   type: collateral
 solanamainnet:
   decimals: 6
+  destinationGas:
+    "1": "68000"
+    "56": "68000"
+    "999": "68000"
+    "1634493807": "64000"
   foreignDeployment: GZ5zWtLNbQ2qJPymkS9My4AYatQx5HV7MQ9f68vG6GNi
   gas: 300000
   name: Tether USD


### PR DESCRIPTION
## Summary

Fixes `destinationGas` config drift on the **solanamainnet** leg of the USDC/aleo, USDT/aleo, and SOL/aleo warp routes.

Added explicit `destinationGas` overrides so the deploy config matches the real on-chain values read from each route's Solana warp router. Previously the config only had partial/no `destinationGas` entries, which caused `hyperlane warp check` to report false-positive diffs — a partial override in `expandWarpDeployConfig` suppresses the auto-computed defaults for the other destinations on that chain.

Files touched:
- `deployments/warp_routes/USDC/aleo-deploy.yaml`
- `deployments/warp_routes/USDT/aleo-deploy.yaml`
- `deployments/warp_routes/SOL/aleo-deploy.yaml`
- `.changeset/aleo-destination-gas.md`

Config-only change, verified by directly querying the on-chain Solana warp router state for each route.