### PR TITLE
docs: Add USDC to Eden and Celestia

### DIFF
--- a/.changeset/usdc-celestia-eden-ethereum.md
+++ b/.changeset/usdc-celestia-eden-ethereum.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Add USDC/celestia-eden-ethereum warp route deployment artifacts (Ethereum collateral, Celestia and Eden synthetics, routed through Celestia)

--- a/chains/eden/metadata.yaml
+++ b/chains/eden/metadata.yaml
@@ -1,4 +1,9 @@
 # yaml-language-server: $schema=../schema.json
+blockExplorers:
+  - apiUrl: https://eden.blockscout.com/api
+    family: blockscout
+    name: Eden Explorer
+    url: https://eden.blockscout.com
 blocks:
   confirmations: 1
   estimateBlockTime: 1

--- a/deployments/warp_routes/USDC/celestia-eden-ethereum-config.yaml
+++ b/deployments/warp_routes/USDC/celestia-eden-ethereum-config.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0x726f757465725f61707000000000000000000000000000020000000000000015"
+    chainName: celestia
+    connections:
+      - token: ethereum|eden|0x67266e82cbc6185d555D0842eD81dF4026E7F66f
+      - token: ethereum|ethereum|0x6CF5640464BE070157D3173C69ca8F294c7595dF
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: CosmosNativeHypSynthetic
+    symbol: USDC
+  - addressOrDenom: "0x67266e82cbc6185d555D0842eD81dF4026E7F66f"
+    chainName: eden
+    connections:
+      - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000020000000000000015
+      - token: ethereum|ethereum|0x6CF5640464BE070157D3173C69ca8F294c7595dF
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC
+  - addressOrDenom: "0x6CF5640464BE070157D3173C69ca8F294c7595dF"
+    chainName: ethereum
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+    connections:
+      - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000020000000000000015
+      - token: ethereum|eden|0x67266e82cbc6185d555D0842eD81dF4026E7F66f
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    name: USD Coin
+    standard: EvmHypCollateral
+    symbol: USDC

--- a/deployments/warp_routes/USDC/celestia-eden-ethereum-deploy.yaml
+++ b/deployments/warp_routes/USDC/celestia-eden-ethereum-deploy.yaml
@@ -1,0 +1,21 @@
+celestia:
+  decimals: 6
+  isNft: false
+  name: USD Coin
+  owner: celestia15w6h52xwtvzxlnegghlly9mdq7mzyma7j6evja
+  symbol: USDC
+  type: synthetic
+eden:
+  decimals: 6
+  isNft: false
+  name: USD Coin
+  owner: "0x3F34D6f5BFb23ed318FAd34ddBf5a8e0c6096174"
+  symbol: USDC
+  type: synthetic
+ethereum:
+  decimals: 6
+  name: USD Coin
+  owner: "0x3F34D6f5BFb23ed318FAd34ddBf5a8e0c6096174"
+  symbol: USDC
+  token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+  type: collateral

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -8302,6 +8302,40 @@ USDC/carrchain:
       scale: 1000000000000
       standard: EvmHypCollateral
       symbol: USDC
+USDC/celestia-eden-ethereum:
+  tokens:
+    - addressOrDenom: "0x726f757465725f61707000000000000000000000000000020000000000000015"
+      chainName: celestia
+      connections:
+        - token: ethereum|eden|0x67266e82cbc6185d555D0842eD81dF4026E7F66f
+        - token: ethereum|ethereum|0x6CF5640464BE070157D3173C69ca8F294c7595dF
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: CosmosNativeHypSynthetic
+      symbol: USDC
+    - addressOrDenom: "0x67266e82cbc6185d555D0842eD81dF4026E7F66f"
+      chainName: eden
+      connections:
+        - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000020000000000000015
+        - token: ethereum|ethereum|0x6CF5640464BE070157D3173C69ca8F294c7595dF
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypSynthetic
+      symbol: USDC
+    - addressOrDenom: "0x6CF5640464BE070157D3173C69ca8F294c7595dF"
+      chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      connections:
+        - token: cosmosnative|celestia|0x726f757465725f61707000000000000000000000000000020000000000000015
+        - token: ethereum|eden|0x67266e82cbc6185d555D0842eD81dF4026E7F66f
+      decimals: 6
+      logoURI: /deployments/warp_routes/USDC/logo.svg
+      name: USD Coin
+      standard: EvmHypCollateral
+      symbol: USDC
 USDC/coti-ethereum:
   tokens:
     - addressOrDenom: "0xEE2e85Df244e32d95d9f327D7a35Ba3d2d412225"


### PR DESCRIPTION
This PR introduces the USDC warp route for the token deployments on Celestia and Eden.