### PR TITLE
feat: add hyperevmscan.io (Etherscan V2) as canonical hyperevm explorer

### DIFF
--- a/.changeset/hyperevm-etherscan-explorer.md
+++ b/.changeset/hyperevm-etherscan-explorer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Made hyperevmscan.io (Etherscan V2) the canonical hyperevm block explorer, ahead of the Blockscout-based hyperscan.com fallback, so warp route contract verification checks run against an Etherscan-compatible explorer.

--- a/chains/hyperevm/metadata.yaml
+++ b/chains/hyperevm/metadata.yaml
@@ -1,5 +1,10 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
+  - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
+    apiUrl: https://api.etherscan.io/v2/api?chainid=999
+    family: etherscan
+    name: HyperEVM Scan
+    url: https://hyperevmscan.io
   - apiUrl: https://www.hyperscan.com/api
     family: blockscout
     name: HyperEVM Explorer


### PR DESCRIPTION
## Summary
- Adds **hyperevmscan.io** as the primary block explorer for `hyperevm`, using the Etherscan V2 unified API (`https://api.etherscan.io/v2/api?chainid=999`).
- Retains the existing hyperscan Blockscout explorer as a fallback.

## Why
The hyperscan Blockscout indexer has been unreliable for hyperevm (contracts intermittently report `is_contract=false`), which blocked warp route contract verification. The Etherscan V2 endpoint for chainid 999 supports both verification submission and `getcontractcreation`, and has been proven to work end-to-end — the full hyperevm warp cluster (SOL, ETH, WBTC, USDT, enzoBTC, stBTC — impls + proxies + ProxyAdmins) was verified through it.

Making it the canonical explorer means `check-warp-deploy` and other SDK verification tooling will use the working endpoint.

## Test plan
- [x] YAML validates against schema
- [ ] Confirm SDK explorer resolution picks up the etherscan-family entry for hyperevm