### PR TITLE
feat: add Taifoon chain

### DIFF
--- a/chains/taifoon/addresses.yaml
+++ b/chains/taifoon/addresses.yaml
@@ -1,0 +1,6 @@
+# Hyperlane core contracts on Taifoon — populated by `hyperlane core deploy` (permissionless).
+# Placeholders until the deploy runs on the live Taifoon parachain RPC.
+mailbox: "0x0000000000000000000000000000000000000000"
+interchainGasPaymaster: "0x0000000000000000000000000000000000000000"
+validatorAnnounce: "0x0000000000000000000000000000000000000000"
+proxyAdmin: "0x0000000000000000000000000000000000000000"

--- a/chains/taifoon/metadata.yaml
+++ b/chains/taifoon/metadata.yaml
@@ -16,5 +16,7 @@ nativeToken:
   symbol: FOON
 protocol: ethereum
 rpcUrls:
-  - http: https://rpc.taifoon.dev
+  # TODO(taifoon): the Taifoon PARACHAIN Frontier-EVM RPC, set once the collator is live.
+  # This is NOT rpc.taifoon.dev — that is the separate standalone EVM devnet (a different chain).
+  - http: https://<taifoon-parachain-evm-rpc>
 technicalStack: polkadotsubstrate

--- a/chains/taifoon/metadata.yaml
+++ b/chains/taifoon/metadata.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=../schema.json
+blocks:
+  confirmations: 2
+  estimateBlockTime: 12
+  reorgPeriod: finalized
+chainId: 36927
+deployer:
+  name: Taifoon
+  url: https://www.taifoon.io
+displayName: Taifoon
+domainId: 36927
+name: taifoon
+nativeToken:
+  decimals: 18
+  name: Taifoon
+  symbol: FOON
+protocol: ethereum
+rpcUrls:
+  - http: https://rpc.taifoon.dev
+technicalStack: polkadotsubstrate


### PR DESCRIPTION
Adds Taifoon (a Moonbeam-fork Polkadot parachain, EVM chainId 36927, native FOON) to the registry, copying the Moonbeam chain entry structure (technicalStack polkadotsubstrate, domainId 36927). Hyperlane is permissionless — core contracts (mailbox/IGP/ISM/validatorAnnounce) are deployed via `hyperlane core deploy` on the live Taifoon RPC; addresses are placeholders (0x0) until that deploy runs.

🤖 Prepared as a Moonbeam-inheritance re-wiring.