### PR TITLE
fix(warp): pin SVM synthetic scale to on-chain values

### DIFF
--- a/.changeset/warp-svm-scale-pin.md
+++ b/.changeset/warp-svm-scale-pin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Pinned the SVM synthetic `scale` field to on-chain values (10^9) to clear check-warp-deploy scale drift for the APXETH, CDX, ETN, GNET, SMOL, TONY, and weETHs warp routes. Each route's Solana/Eclipse leg has 9 decimals against an 18-decimal EVM counterpart, so the previously missing scale was being treated as identity.

--- a/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-config.yaml
@@ -8,6 +8,7 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/APXETH/logo.svg
     name: Autocompounding Pirex Ether
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: apxETH
   - addressOrDenom: "0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c"

--- a/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-deploy.yaml
+++ b/deployments/warp_routes/APXETH/eclipsemainnet-ethereum-deploy.yaml
@@ -5,6 +5,7 @@ eclipsemainnet:
   owner: BwYL3jLky8oHLeQp1S48cVRfZPmcXtg1V33UPmnZK3Jk
   ownerOverrides:
     proxyAdmin: BwYL3jLky8oHLeQp1S48cVRfZPmcXtg1V33UPmnZK3Jk
+  scale: 1000000000
   type: synthetic
 ethereum:
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"

--- a/deployments/warp_routes/CDX/base-solanamainnet-sophon-config.yaml
+++ b/deployments/warp_routes/CDX/base-solanamainnet-sophon-config.yaml
@@ -21,6 +21,7 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/CDX/logo.svg
     name: Cod3x Token
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: CDX
   - addressOrDenom: "0x6ce50f6536fe864952d5aB9abAA3A52E4a7A125F"

--- a/deployments/warp_routes/CDX/base-solanamainnet-sophon-deploy.yaml
+++ b/deployments/warp_routes/CDX/base-solanamainnet-sophon-deploy.yaml
@@ -8,6 +8,7 @@ solanamainnet:
   gas: 300000
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   owner: 7dRAVvdmV3dy4JieuRAirBQ9oSpYaHgmYwupoK5YZcFR
+  scale: 1000000000
   type: synthetic
 sophon:
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"

--- a/deployments/warp_routes/ETN/electroneum-config.yaml
+++ b/deployments/warp_routes/ETN/electroneum-config.yaml
@@ -44,5 +44,6 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/ETN/logo.svg
     name: ETN
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: ETN

--- a/deployments/warp_routes/ETN/electroneum-deploy.yaml
+++ b/deployments/warp_routes/ETN/electroneum-deploy.yaml
@@ -10,4 +10,5 @@ ethereum:
 solanamainnet:
   foreignDeployment: D8pSXG5rgcoCeeu2KQ6VUJ43MeDFJxYYyYggjbVuMxK5
   owner: BTG551UkyMSTe7d574Br2DWzn4fGquZLLXjk1Fc1CYYn
+  scale: 1000000000
   type: synthetic

--- a/deployments/warp_routes/GNET/galactica-config.yaml
+++ b/deployments/warp_routes/GNET/galactica-config.yaml
@@ -17,5 +17,6 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/GNET/logo.svg
     name: GNET
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: GNET

--- a/deployments/warp_routes/GNET/galactica-deploy.yaml
+++ b/deployments/warp_routes/GNET/galactica-deploy.yaml
@@ -5,4 +5,5 @@ solanamainnet:
   foreignDeployment: 9C11B1uMoQrAL7VAiNQMDCXejCwYFF5Je8ucBM5wwuZd
   gas: 300000
   owner: E7LDS4HUbz3gcANoav2YMvU4UARDy6pA7YztPsUp7K7U
+  scale: 1000000000
   type: synthetic

--- a/deployments/warp_routes/SMOL/arbitrum-abstract-ethereum-solanamainnet-base-config.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-abstract-ethereum-solanamainnet-base-config.yaml
@@ -57,5 +57,6 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/SMOL/logo.svg
     name: SMOL
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: SMOL

--- a/deployments/warp_routes/SMOL/arbitrum-abstract-ethereum-solanamainnet-base-deploy.yaml
+++ b/deployments/warp_routes/SMOL/arbitrum-abstract-ethereum-solanamainnet-base-deploy.yaml
@@ -31,4 +31,5 @@ solanamainnet:
       address: "0x53ccE6d10e43d1B3D11872Ad22eC2aCd8d2537B8"
     "2741":
       address: "0xcbfb6dBeb6C06DdCd345781a0ADc711A86a77f7c"
+  scale: 1000000000
   type: synthetic

--- a/deployments/warp_routes/TONY/base-solanamainnet-config.yaml
+++ b/deployments/warp_routes/TONY/base-solanamainnet-config.yaml
@@ -22,5 +22,6 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/TONY/logo.png
     name: Big Tony
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: TONY

--- a/deployments/warp_routes/TONY/base-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/TONY/base-solanamainnet-deploy.yaml
@@ -8,4 +8,5 @@ solanamainnet:
   gas: 300000
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
   owner: 7dRAVvdmV3dy4JieuRAirBQ9oSpYaHgmYwupoK5YZcFR
+  scale: 1000000000
   type: synthetic

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -170,6 +170,7 @@ APXETH/eclipsemainnet-ethereum:
       decimals: 9
       logoURI: /deployments/warp_routes/APXETH/logo.svg
       name: Autocompounding Pirex Ether
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: apxETH
     - addressOrDenom: "0xd34FE1685c28A68Bb4B8fAaadCb2769962AE737c"
@@ -650,6 +651,7 @@ CDX/base-solanamainnet-sophon:
       decimals: 9
       logoURI: /deployments/warp_routes/CDX/logo.svg
       name: Cod3x Token
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: CDX
     - addressOrDenom: "0x6ce50f6536fe864952d5aB9abAA3A52E4a7A125F"
@@ -2734,6 +2736,7 @@ ETN/electroneum:
       decimals: 9
       logoURI: /deployments/warp_routes/ETN/logo.svg
       name: ETN
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: ETN
 EURC/matchain:
@@ -4198,6 +4201,7 @@ GNET/galactica:
       decimals: 9
       logoURI: /deployments/warp_routes/GNET/logo.svg
       name: GNET
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: GNET
 GOAT/solanamainnet-soon:
@@ -6346,6 +6350,7 @@ SMOL/arbitrum-abstract-ethereum-solanamainnet-base:
       decimals: 9
       logoURI: /deployments/warp_routes/SMOL/logo.svg
       name: SMOL
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: SMOL
 SOL/aleo:
@@ -7281,6 +7286,7 @@ TONY/base-solanamainnet:
       decimals: 9
       logoURI: /deployments/warp_routes/TONY/logo.png
       name: Big Tony
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: TONY
 TORUS/torus:
@@ -15966,6 +15972,7 @@ weETHs/eclipsemainnet-ethereum:
       decimals: 9
       logoURI: /deployments/warp_routes/weETHs/logo.svg
       name: Super Symbiotic LRT
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: weETHs
     - addressOrDenom: "0xef899e92DA472E014bE795Ecce948308958E25A2"

--- a/deployments/warp_routes/weETHs/eclipsemainnet-ethereum-config.yaml
+++ b/deployments/warp_routes/weETHs/eclipsemainnet-ethereum-config.yaml
@@ -8,6 +8,7 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/weETHs/logo.svg
     name: Super Symbiotic LRT
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: weETHs
   - addressOrDenom: "0xef899e92DA472E014bE795Ecce948308958E25A2"

--- a/deployments/warp_routes/weETHs/eclipsemainnet-ethereum-deploy.yaml
+++ b/deployments/warp_routes/weETHs/eclipsemainnet-ethereum-deploy.yaml
@@ -5,6 +5,7 @@ eclipsemainnet:
   owner: 4Cj1s2ipALjJk9foQV4oDaZYCZwSsVkAShQL1KFVJG9b
   ownerOverrides:
     proxyAdmin: 4Cj1s2ipALjJk9foQV4oDaZYCZwSsVkAShQL1KFVJG9b
+  scale: 1000000000
   type: synthetic
 ethereum:
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
## Summary
Adds the missing `scale` field (`1000000000` = 10^9) to the Solana/Eclipse legs of 7 warp routes so `check-warp-deploy` no longer reports scale drift.

Each of these routes has an SVM synthetic leg with **9 decimals** bridged against an **18-decimal EVM** counterpart. Without an explicit `scale`, the checker treats it as identity (`1`) while on-chain reports `10^9`, producing a `ConfigMismatch` + derived `ScaleMismatch`. Ground truth taken from a full read-only `warp check` run against registry `main`.

Routes fixed:
| Route | SVM leg | scale |
|-|-|-|
| APXETH/eclipsemainnet-ethereum | eclipsemainnet | 1000000000 |
| CDX/base-solanamainnet-sophon | solanamainnet | 1000000000 |
| ETN/electroneum | solanamainnet | 1000000000 |
| GNET/galactica | solanamainnet | 1000000000 |
| SMOL/arbitrum-abstract-ethereum-solanamainnet-base | solanamainnet | 1000000000 |
| TONY/base-solanamainnet | solanamainnet | 1000000000 |
| weETHs/eclipsemainnet-ethereum | eclipsemainnet | 1000000000 |

`scale` is added to both `-deploy.yaml` and `-config.yaml` (per the deploy/config scale-consistency test from #1484) and `warpRouteConfigs.yaml` was regenerated via `pnpm build`.

## Test plan
- [x] `pnpm build` regenerates `warpRouteConfigs.yaml` with the 7 scale entries
- [x] `pnpm lint` clean
- [x] `pnpm format` clean
- [x] Warp scale-consistency unit tests pass (1809 passing)
- [ ] CI `check-warp-deploy` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)