### PR TITLE
feat: add Dungeon Chain mainnet metadata

### DIFF
--- a/.changeset/add-dungeon-chain.md
+++ b/.changeset/add-dungeon-chain.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Add Dungeon Chain mainnet metadata and branding.

--- a/chains/dungeon/logo.svg
+++ b/chains/dungeon/logo.svg
@@ -1,0 +1,35 @@
+<svg width="57" height="57" viewBox="0 0 57 57" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Dark circle background -->
+  <circle cx="28.5" cy="28.5" r="28.5" fill="#1a0f05"/>
+  <!-- Outer ring -->
+  <circle cx="28.5" cy="28.5" r="26.5" stroke="#C06014" stroke-width="2" fill="none"/>
+  <!-- Inner ring -->
+  <circle cx="28.5" cy="28.5" r="23" stroke="#FFD700" stroke-width="1" fill="none" opacity="0.5"/>
+  <!-- Castle tower left -->
+  <rect x="16" y="18" width="6" height="22" fill="#C06014" rx="1"/>
+  <rect x="15" y="15" width="8" height="5" fill="#C06014" rx="1"/>
+  <!-- Battlements left -->
+  <rect x="15" y="13" width="2.5" height="3" fill="#C06014"/>
+  <rect x="20.5" y="13" width="2.5" height="3" fill="#C06014"/>
+  <!-- Castle tower right -->
+  <rect x="35" y="18" width="6" height="22" fill="#C06014" rx="1"/>
+  <rect x="34" y="15" width="8" height="5" fill="#C06014" rx="1"/>
+  <!-- Battlements right -->
+  <rect x="34" y="13" width="2.5" height="3" fill="#C06014"/>
+  <rect x="39.5" y="13" width="2.5" height="3" fill="#C06014"/>
+  <!-- Gate arch -->
+  <rect x="22" y="24" width="13" height="16" fill="#C06014" rx="1"/>
+  <ellipse cx="28.5" cy="24" rx="6.5" ry="5" fill="#C06014"/>
+  <!-- Gate opening -->
+  <rect x="24.5" y="28" width="8" height="12" fill="#0d0a07" rx="1"/>
+  <ellipse cx="28.5" cy="28" rx="4" ry="3" fill="#0d0a07"/>
+  <!-- Torch flames -->
+  <ellipse cx="19" cy="11" rx="2" ry="3" fill="#FFD700" opacity="0.9"/>
+  <ellipse cx="19" cy="10.5" rx="1.2" ry="2" fill="#FF8C00"/>
+  <ellipse cx="41" cy="11" rx="2" ry="3" fill="#FFD700" opacity="0.9"/>
+  <ellipse cx="41" cy="10.5" rx="1.2" ry="2" fill="#FF8C00"/>
+  <!-- D letter in gate -->
+  <text x="28.5" y="37" text-anchor="middle" font-family="serif" font-weight="bold" font-size="10" fill="#FFD700">D</text>
+  <!-- Base wall -->
+  <rect x="14" y="38" width="29" height="3" fill="#C06014" rx="1"/>
+</svg>

--- a/chains/dungeon/metadata.yaml
+++ b/chains/dungeon/metadata.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=../schema.json
+bech32Prefix: dungeon
+blockExplorers:
+  - apiUrl: https://api.dungeongames.io
+    family: other
+    name: Dungeon Explorer
+    url: https://explorer.dungeongames.io
+blocks:
+  confirmations: 1
+  estimateBlockTime: 6
+  reorgPeriod: 1
+canonicalAsset: udgn
+chainId: dungeon-1
+contractAddressBytes: 32
+deployer:
+  name: Crypto Dungeon LLC
+  url: https://dungeongames.io
+displayName: Dungeon Chain
+# Generated from: console.log(parseInt('0x'+Buffer.from('dung').toString('hex')))
+domainId: 1685417575
+gasCurrencyCoinGeckoId: dragon-coin-2
+gasPrice:
+  amount: "0.07"
+  denom: udgn
+grpcUrls:
+  - http: https://grpc.dungeon.chaintools.tech:443
+index:
+  chunk: 5
+  from: 17100000
+name: dungeon
+nativeToken:
+  decimals: 6
+  denom: udgn
+  name: Dragon Coin
+  symbol: DGN
+protocol: cosmosnative
+restUrls:
+  - http: https://api.dungeongames.io
+  - http: https://api.dungeon.chaintools.tech
+rpcUrls:
+  - http: https://rpc.dungeongames.io
+  - http: https://rpc.dungeon.chaintools.tech
+slip44: 118
+technicalStack: other
+transactionOverrides:
+  gasPrice: "0.07"


### PR DESCRIPTION
## Summary

- add Dungeon Chain (`dungeon-1`) mainnet metadata
- register domain ID `1685417575` using the four-byte `dung` convention
- classify Dungeon as `cosmosnative` because it integrates the Hyperlane Cosmos SDK module directly
- add Dungeon branding and the required registry changeset

## Verification

- `pnpm run build`
- `pnpm run lint`
- `node scripts/validate-file-path.js`
- `node scripts/validate-svg.js`
- `node scripts/validate-file-data.js`
- `pnpm exec changeset status --since origin/main`

This PR intentionally contains chain metadata only. Dungeon's on-chain Hyperlane module is active, but no Mailbox or Warp Route deployment artifacts are being claimed in the registry until those addresses exist and can be verified on-chain.