### PR TITLE
fix: pin LUMIA proxyAdmin owner to on-chain value

### DIFF
--- a/.changeset/lumia-proxyadmin-owner.md
+++ b/.changeset/lumia-proxyadmin-owner.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Pinned the LUMIA warp route proxyAdmin owner on bsc, ethereum, and lumiaprism to the on-chain value (0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39), matching the getter source of truth.

--- a/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-deploy.yaml
+++ b/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-deploy.yaml
@@ -14,20 +14,20 @@ bsc:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0x54bB5b12c67095eB3dabCD11FA74AAcfE46E7767"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   type: synthetic
 ethereum:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0xdaB976ae358D4D2d25050b5A25f71520983C46c9"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   token: "0xD9343a049D5DBd89CD19DC6BcA8c48fB3a0a42a7"
   type: collateral
 lumiaprism:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0xBC53dACd8c0ac0d2bAC461479EAaf5519eCC8853"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   type: native
 optimism:
   owner: "0x914931eBb5638108651455F50C1F784d3E5fd3EC"


### PR DESCRIPTION
Syncs the materialized LUMIA deploy config with monorepo getter #9054. proxyAdmin.owner on bsc/ethereum/lumiaprism moved on-chain to the Lumia team address 0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39 (token owner), replacing stale 0x8bBA07Dd... Fresh scoped warp check on main confirms on-chain match (no violation).