### PR TITLE
fix(warp): pin Incentiv/ENI route configs to on-chain

### DIFF
--- a/.changeset/incentiv-eni-warp-reconcile.md
+++ b/.changeset/incentiv-eni-warp-reconcile.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Pinned the Incentiv CENT, SOL, USDT, WBTC, WETH, and USDC warp route deploy configs to their on-chain state. Added the on-chain hook and interchainSecurityModule addresses that were unset in the registry, the second allowedRebalancer and base proxyAdmin owner on the USDC route, so `warp check` reconciles against chain. The ENI PB and evENI routes were verified against chain and required no changes.

--- a/.changeset/incentiv-eni-warp-reconcile.md
+++ b/.changeset/incentiv-eni-warp-reconcile.md
@@ -3,3 +3,5 @@
 ---
 
 Pinned the Incentiv CENT, SOL, USDT, WBTC, WETH, and USDC warp route deploy configs to their on-chain state. Added the on-chain hook and interchainSecurityModule addresses that were unset in the registry, the second allowedRebalancer and base proxyAdmin owner on the USDC route, so `warp check` reconciles against chain. The ENI PB and evENI routes were verified against chain and required no changes.
+
+Why these changed: the Incentiv team now owns these routes and configured hooks/ISMs on-chain that the registry had left unset; on-chain is source of truth, so no security parameters are being changed here — the live config is just being recorded. All pinned collateral/synthetic hooks are AGGREGATION hooks (hookType 2). All multisig ISMs are 2-of-3 merkle-root multisig (moduleType 4); the Incentiv-side CENT and USDC ISMs are per-origin domain-routing ISMs (moduleType 1) that delegate to 2-of-3 merkle-root multisig sub-modules. Full quorum/validator breakdown is in the PR description.

--- a/deployments/warp_routes/CENT/incentiv-deploy.yaml
+++ b/deployments/warp_routes/CENT/incentiv-deploy.yaml
@@ -1,12 +1,17 @@
 bsc:
+  hook: "0xCce52e3264439EDFa3cE1BF4E52a0e30608BfaCc"
+  interchainSecurityModule: "0xEdbF795cC123223442299e5d0e6628E43b18dF76"
   isNft: false
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   type: synthetic
 ethereum:
+  hook: "0xb044808982E45Fb4e6F34225FcdbFCf83875A031"
+  interchainSecurityModule: "0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4"
   isNft: false
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   type: synthetic
 incentiv:
+  interchainSecurityModule: "0xe702EB772C8bCdbd987b7dF8949548f16eEB56Ff"
   isNft: false
   owner: "0x4c1B3430ec07F2D58b07a18c53B6f92603C2eF3F"
   type: native

--- a/deployments/warp_routes/SOL/incentiv-deploy.yaml
+++ b/deployments/warp_routes/SOL/incentiv-deploy.yaml
@@ -1,5 +1,6 @@
 incentiv:
   decimals: 9
+  interchainSecurityModule: "0xDB3b308b62b84Ed65dC702f4041Da6aa6e168af9"
   isNft: false
   name: Solana
   owner: "0x4c1B3430ec07F2D58b07a18c53B6f92603C2eF3F"

--- a/deployments/warp_routes/USDC/incentiv-deploy.yaml
+++ b/deployments/warp_routes/USDC/incentiv-deploy.yaml
@@ -1,6 +1,7 @@
 arbitrum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xe3beaa914C59c982aD8aC1089Ec7c052754FeF18"
   allowedRebalancingBridges:
     base:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
@@ -10,12 +11,15 @@ arbitrum:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
     polygon:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
+  hook: "0x21A3A0eccdeeFf91cFea401B52248BB32653e4D6"
+  interchainSecurityModule: "0x3f9707b144D11AD0eFfB542825a251fcf13CD158"
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
   type: collateral
 base:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xe3beaa914C59c982aD8aC1089Ec7c052754FeF18"
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
@@ -25,12 +29,17 @@ base:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
     polygon:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
+  hook: "0x54BDdDa7de4ca683ebA79C2f7C67F89e3b690390"
+  interchainSecurityModule: "0xc578857D4978fc001C31C3670C961512253d97b7"
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
+  proxyAdmin:
+    owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   type: collateral
 ethereum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xe3beaa914C59c982aD8aC1089Ec7c052754FeF18"
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
@@ -40,15 +49,19 @@ ethereum:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
     polygon:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
+  hook: "0xb044808982E45Fb4e6F34225FcdbFCf83875A031"
+  interchainSecurityModule: "0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4"
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
   type: collateral
 incentiv:
+  interchainSecurityModule: "0x147B4686866e09cEE3CB4260F4585AD6Ed973A42"
   owner: "0x4c1B3430ec07F2D58b07a18c53B6f92603C2eF3F"
   type: synthetic
 optimism:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xe3beaa914C59c982aD8aC1089Ec7c052754FeF18"
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE"
@@ -58,12 +71,15 @@ optimism:
       - bridge: "0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE"
     polygon:
       - bridge: "0xfB7681ECB05F85c383A5ce4439C7dF5ED12c77DE"
+  hook: "0x072204eD1453e80f9D18c9d15b75371ef9A16a3d"
+  interchainSecurityModule: "0x3cc5EeD05081eBd6a25607254d9dDE5E5f507bD3"
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
   type: collateral
 polygon:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xe3beaa914C59c982aD8aC1089Ec7c052754FeF18"
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
@@ -73,6 +89,8 @@ polygon:
       - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
     optimism:
       - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
+  hook: "0xBa6F97DfC53CB6fae7161d37cFC1Dc202e4F1056"
+  interchainSecurityModule: "0xdE46617A91d8ACbde319D43d99CA23615910622F"
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
   type: collateral

--- a/deployments/warp_routes/USDT/incentiv-deploy.yaml
+++ b/deployments/warp_routes/USDT/incentiv-deploy.yaml
@@ -1,8 +1,11 @@
 ethereum:
+  hook: "0xb044808982E45Fb4e6F34225FcdbFCf83875A031"
+  interchainSecurityModule: "0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4"
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0x04DA4b99FFc82f0e44DEd14c3539A6fDaD08E2fE"
   type: collateralVault
 incentiv:
+  interchainSecurityModule: "0x9fDe79BD608AfB4B95E271a03019e4A4629dd003"
   isNft: false
   owner: "0x4c1B3430ec07F2D58b07a18c53B6f92603C2eF3F"
   type: synthetic

--- a/deployments/warp_routes/WBTC/incentiv-deploy.yaml
+++ b/deployments/warp_routes/WBTC/incentiv-deploy.yaml
@@ -1,4 +1,5 @@
 ethereum:
+  hook: "0xb044808982E45Fb4e6F34225FcdbFCf83875A031"
   interchainSecurityModule:
     address: "0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4"
     threshold: 2

--- a/deployments/warp_routes/WETH/incentiv-deploy.yaml
+++ b/deployments/warp_routes/WETH/incentiv-deploy.yaml
@@ -1,9 +1,12 @@
 ethereum:
   # Bump up gas cost due to withdrawing from the Vault
   gas: 100000
+  hook: "0xb044808982E45Fb4e6F34225FcdbFCf83875A031"
+  interchainSecurityModule: "0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4"
   owner: "0x64F6C20eAeaF8418F73E1D399d8b86B9eA26e6F2"
   token: "0xB1ea329f0B79d0b213957569594ca2a9dE637215"
   type: collateralVault
 incentiv:
+  interchainSecurityModule: "0x9fDe79BD608AfB4B95E271a03019e4A4629dd003"
   owner: "0x4c1B3430ec07F2D58b07a18c53B6f92603C2eF3F"
   type: synthetic


### PR DESCRIPTION
## Summary

Reconciles the registry-static Incentiv + ENI warp route deploy configs against fresh on-chain state, treating chain as source of truth (E&I/Incentiv policy — no drift allowlisting). Each drifted field is pinned to its on-chain value so `hyperlane warp check` reconciles against chain.

Scope limited to the 8 registry-static routes. Getter-backed ENI routes (materialized from `warpConfigGetterMap`) and `contractVerificationStatus` were intentionally left untouched.

## Per-route changes

- **CENT/incentiv** — added on-chain `hook`/`interchainSecurityModule` on bsc + ethereum, and ISM on incentiv.
- **SOL/incentiv** — added incentiv `interchainSecurityModule` (verified via `cast`; hook is `0x0`, unchanged; solanamainnet leg untouched).
- **USDT/incentiv** — added ethereum (collateralVault) `hook`/`ISM` + incentiv `ISM`.
- **WBTC/incentiv** — added ethereum `hook` (ISM already present as merkleRootMultisigIsm object, matches chain).
- **WETH/incentiv** — added ethereum (collateralVault) `hook`/`ISM` + incentiv `ISM`.
- **USDC/incentiv** — added the second `allowedRebalancer` per leg, base `proxyAdmin.owner`, and on-chain `hook`/`ISM` across arbitrum/base/ethereum/incentiv/optimism/polygon.
- **PB/eni** — verified against chain, no changes required.
- **evENI/bsc** — verified against chain, no changes required.

All 5 EVM Incentiv routes now pass `warp check` ("No violations found"); SOL verified via `cast` (SVM leg not fully checkable via CLI); PB/evENI verified clean via direct `cast` reads.

Includes a `@hyperlane-xyz/registry` patch changeset.

## Why the hooks/ISMs changed

The Incentiv team took ownership of these routes and deployed/configured hooks and ISMs on-chain that the registry had left unset (or stale). **This PR changes no security parameters** — it only records the live on-chain config so `warp check` reconciles. All addresses below were read directly from chain via `cast` (`hookType()`, `moduleType()`, `validatorsAndThreshold()`, `module(uint32)`).

### Hooks — all AGGREGATION (`hookType 2`)

Each collateral/synthetic leg uses an aggregation hook (fans out to merkle-tree + IGP sub-hooks). The registry simply omitted the field.

| Chain | Route(s) | Hook |
|---|---|---|
| ethereum | CENT, WBTC, WETH, USDT, USDC | `0xb044808982E45Fb4e6F34225FcdbFCf83875A031` |
| bsc | CENT | `0xCce52e3264439EDFa3cE1BF4E52a0e30608BfaCc` |
| arbitrum | USDC | `0x21A3A0eccdeeFf91cFea401B52248BB32653e4D6` |
| base | USDC | `0x54BDdDa7de4ca683ebA79C2f7C67F89e3b690390` |
| optimism | USDC | `0x072204eD1453e80f9D18c9d15b75371ef9A16a3d` |
| polygon | USDC | `0xBa6F97DfC53CB6fae7161d37cFC1Dc202e4F1056` |

### ISMs — collateral/origin legs (validate messages **from** Incentiv)

All are **2-of-3 merkle-root multisig** (`moduleType 4`), carrying the Incentiv validator set.

| Chain | Route(s) | ISM | Quorum |
|---|---|---|---|
| ethereum | CENT, WBTC, WETH, USDT, USDC | `0xEE3a7cBF5a28fAA173d346a4B7DD4904218710d4` | 2/3 |
| bsc | CENT | `0xEdbF795cC123223442299e5d0e6628E43b18dF76` | 2/3 |
| arbitrum | USDC | `0x3f9707b144D11AD0eFfB542825a251fcf13CD158` | 2/3 |
| base | USDC | `0xc578857D4978fc001C31C3670C961512253d97b7` | 2/3 |
| optimism | USDC | `0x3cc5EeD05081eBd6a25607254d9dDE5E5f507bD3` | 2/3 |
| polygon | USDC | `0xdE46617A91d8ACbde319D43d99CA23615910622F` | 2/3 |

Incentiv validator set (2/3): `0x7177e97c220DdCfE2DFA73D1aDd1929c4B033832`, `0xB6D0CAA8e08dA05a3543E163c998Ae6E5eF2FfCE`, `0xEFfb8D9B7666Cf85Dd5B45B0cB90Ef76d7CB6128`.

### ISMs — Incentiv-side legs (validate messages **from** the collateral chains)

Single-origin routes use a plain 2-of-3 merkle-root multisig; multi-origin routes (CENT, USDC) use a **domain-routing ISM** (`moduleType 1`) that delegates per-origin to 2-of-3 merkle-root multisig sub-modules.

- **`0x9fDe79BD608AfB4B95E271a03019e4A4629dd003`** — merkle-root multisig 2/3 — WBTC, WETH, USDT synthetics. Validators (ethereum set): `0x0475e5B9a3769fdBcDa78965c5b50E5B4fcDb204`, `0x614571a2c8E4575da493eBed053fDe32Bf519c32`, `0xC2061992603E9a638Db3A1f070a118a792B77888`.
- **`0xe702EB772C8bCdbd987b7dF8949548f16eEB56Ff`** — CENT native, domain-routing:
  - domain 1 (ethereum) → `0x9fDe79BD608AfB4B95E271a03019e4A4629dd003`, 2/3, ethereum validator set (above).
  - domain 56 (bsc) → `0x17a7c0510a8767aB10586Df696B3c3bE3dB70273`, 2/3, bsc set: `0x28b17Cab3A9C00F3608a8DB9198AC5ad414f386b`, `0x3B3Bc22a9b5F9E90CBf001133c1c149570cB538B`, `0xeE742685133E2eB0D4c66AcC5911e58782FE6585`.
- **`0x147B4686866e09cEE3CB4260F4585AD6Ed973A42`** — USDC synthetic, domain-routing (all sub-modules 2/3 merkle-root multisig):
  - domain 1 (ethereum) → `0x9fDe79BD608AfB4B95E271a03019e4A4629dd003` — ethereum set.
  - domain 10 (optimism) → `0x52De331f1d9b08b886AB3d2629776850960e9c0E` — `0x0D842730A85b7E66daA1e94844C3f18a535BFD28`, `0x3ae45611fDcEA2A932fa5c3297f5ec3f10b0495F`, `0x446324C3e95E6482b7E482aB8b306F8C08E0A91f`.
  - domain 137 (polygon) → `0xb058870b5C47E1c71f6D7BFAFbEBe293927020Df` — `0x09651b2cA1B29Dec8f6F06963f09B978aE270f5d`, `0x49Bbe57A2be2F2200Ec94bC193343A9E95b82E90`, `0xC522de5b88b7ABB774F0E0eAF77baa4284bdE084`.
  - domain 8453 (base) → `0xAfBb5539f2E2946bA810c0786B86074544860d10` — `0x001d555E4de4b035777763a67F374a230427348f`, `0x1AC46f8F900a816B0cCB8824d1a7c8a331e417B1`, `0x1f9b8a7A0A961995646cf288714C08DE435Fb6ce`.
  - domain 42161 (arbitrum) → `0xFD289E8926f7B107B79db336149a848F935677AD` — `0xB7c031D840984deDb1478489eE02eb5C444d88e3`, `0xc2AAB0a173067Bc83b41dA326E4AF0E74AC2E3E3`, `0xd67727F4Bc596694aA3F63b02c2daE98bB35e184`.
- **`0xDB3b308b62b84Ed65dC702f4041Da6aa6e168af9`** — SOL synthetic on incentiv, merkle-root multisig 2/3, solanamainnet set: `0x3a11065537f5A5beD8B02D26EA9A3cA14B628b2f`, `0x6f4B045cEC23FDc7d48C4947D417f8BdaF2fF511`, `0xF26bF3c204c7e688282b0D5f49F9CB9beBc80eED`.

## Test plan

- [ ] `hyperlane warp check` passes for each edited route against chain
- [ ] Registry CI green
