### PR TITLE
fix: deprioritize rate-limited bsc.drpc.org in BSC rpcUrls

### DIFF
--- a/.changeset/bsc-rpc-reorder-drpc.md
+++ b/.changeset/bsc-rpc-reorder-drpc.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Reordered BSC rpcUrls to prioritize healthy public endpoints (bsc.blockrazor.xyz, bsc-pokt.nodies.app) over the rate-limited bsc.drpc.org.

--- a/chains/bsc/metadata.yaml
+++ b/chains/bsc/metadata.yaml
@@ -25,9 +25,9 @@ nativeToken:
   symbol: BNB
 protocol: ethereum
 rpcUrls:
+  - http: https://bsc.blockrazor.xyz
+  - http: https://bsc-pokt.nodies.app
   - http: https://bsc.drpc.org
   - http: https://bnb.rpc.subquery.network/public
   - http: https://binance.llamarpc.com
-  - http: https://bsc.blockrazor.xyz
-  - http: https://bsc-pokt.nodies.app
 technicalStack: other


### PR DESCRIPTION
## Summary
- Reorder BSC `rpcUrls` so verified-healthy public endpoints come first and the rate-limited `bsc.drpc.org` is demoted to a lower-priority fallback.

## Why
`bsc.drpc.org` was the **primary** RPC for BSC and intermittently returns `HTTP 429 {"message":"Too many request","code":15}` on the shared public endpoint. The Nexus warp UI reads chain `rpcUrls` from the registry at runtime and hits the primary first, then retries without backoff — re-tripping the rate limit and breaking bridging for BSC routes (reported on `NES/bsc`, origin=bsc). Hyperlane relayer/delivery is unaffected (agents use keyed RPCs).

Direct probes:
- `bsc.blockrazor.xyz` -> 200
- `bsc-pokt.nodies.app` -> 200
- `bsc.drpc.org` -> intermittent 429 (2/4 attempts)
- `bnb.rpc.subquery.network/public`, `binance.llamarpc.com` -> dead (000)

New order: blockrazor, pokt-nodies, drpc, subquery, llamarpc. drpc is retained as a fallback, just not primary.

## Test plan
- [ ] Confirm Nexus (nexus.hyperlane.xyz) NES/bsc bridge no longer 429s once the registry main branch updates (Nexus fetches registry at runtime).