### PR TITLE
fix: deprioritize rate-limited base.drpc.org in Base rpcUrls

### DIFF
--- a/.changeset/base-rpc-reorder-drpc.md
+++ b/.changeset/base-rpc-reorder-drpc.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Reordered Base rpcUrls to prioritize healthy public endpoints (mainnet.base.org, base-pokt.nodies.app, base.public.blockpi.network) over the rate-limited base.drpc.org, mirroring the earlier BSC reorder.

--- a/chains/base/metadata.yaml
+++ b/chains/base/metadata.yaml
@@ -32,10 +32,10 @@ nativeToken:
   symbol: ETH
 protocol: ethereum
 rpcUrls:
-  - http: https://base.drpc.org
   - http: https://mainnet.base.org
-  - http: https://base.public.blockpi.network/v1/rpc/public
-  - http: https://base.llamarpc.com
-  - http: https://1rpc.io/base
   - http: https://base-pokt.nodies.app
+  - http: https://base.public.blockpi.network/v1/rpc/public
+  - http: https://base.drpc.org
+  - http: https://1rpc.io/base
+  - http: https://base.llamarpc.com
 technicalStack: opstack

--- a/chains/base/metadata.yaml
+++ b/chains/base/metadata.yaml
@@ -32,9 +32,9 @@ nativeToken:
   symbol: ETH
 protocol: ethereum
 rpcUrls:
-  - http: https://mainnet.base.org
   - http: https://base-pokt.nodies.app
   - http: https://base.public.blockpi.network/v1/rpc/public
+  - http: https://mainnet.base.org
   - http: https://base.drpc.org
   - http: https://1rpc.io/base
   - http: https://base.llamarpc.com


### PR DESCRIPTION
## Summary
- Base was the only remaining chain in the NES warp route with `base.drpc.org` as its primary RPC after #1609 fixed BSC.
- Nexus's viem `fallback()` transport uses `rank=false`, so it re-selects the rate-limited primary on every request instead of demoting it — causing recurring HTTP 429 errors on the base leg of NES transfers (NESA still reporting the same error post-BSC-fix).
- Reordered `chains/base/metadata.yaml` to promote healthy public endpoints (`mainnet.base.org`, `base-pokt.nodies.app`, `base.public.blockpi.network`) above `base.drpc.org`; kept the currently-down `base.llamarpc.com` last.

All three promoted endpoints verified 200 and in sync (block 0x2e847d8) at time of writing.

## Test plan
- [ ] CI green (changeset + schema validation)
- [ ] NESA confirms Nexus NES transfers succeed once merged and propagated (~5min GitHub CDN cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)