### PR TITLE
Add Ethereum ↔ TurkChain USDT Warp Route

### DIFF
--- a/deployments/warp_routes/TURK/ethereum-turkchain-config.yaml
+++ b/deployments/warp_routes/TURK/ethereum-turkchain-config.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../schema.json
+
+tokens:
+  - addressOrDenom: "0xbD1C15e8E9F9c73804C3620E7615DD65016c35bF"
+    chainName: turkchain
+    connections:
+      - token: ethereum|ethereum|0x1fEabcA65D66Be8E1f9ef2DDBB1906cd64ca9872
+    decimals: 18
+    name: TC
+    standard: EvmHypNative
+    symbol: TURK
+    tokenType: native
+
+  - addressOrDenom: "0x1fEabcA65D66Be8E1f9ef2DDBB1906cd64ca9872"
+    chainName: ethereum
+    connections:
+      - token: ethereum|turkchain|0xbD1C15e8E9F9c73804C3620E7615DD65016c35bF
+    decimals: 18
+    name: TC
+    standard: EvmHypSynthetic
+    symbol: TURK
+    tokenType: synthetic

--- a/deployments/warp_routes/TURK/ethereum-turkchain-deploy.yaml
+++ b/deployments/warp_routes/TURK/ethereum-turkchain-deploy.yaml
@@ -1,0 +1,35 @@
+ethereum:
+  interchainSecurityModule:
+    modules:
+      - relayer: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+        type: trustedRelayerIsm
+      - domains: {}
+        owner: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+        type: defaultFallbackRoutingIsm
+    threshold: 1
+    type: staticAggregationIsm
+  isNft: false
+  mailbox: "0xeeA9fEf5e41845a12e0C3C929a2203750C301c1e"
+  owner: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+  proxyAdmin:
+    address: "0xa52f464A701B98D6df0947402DEe049c63531fC6"
+    owner: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+  type: synthetic
+
+turkchain:
+  interchainSecurityModule:
+    modules:
+      - relayer: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+        type: trustedRelayerIsm
+      - domains: {}
+        owner: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+        type: defaultFallbackRoutingIsm
+    threshold: 1
+    type: staticAggregationIsm
+  isNft: false
+  mailbox: "0x92421580c1d960c320C0FDE0849D4400B6A78455"
+  owner: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+  proxyAdmin:
+    address: "0xDd58c6410a995857fa10db73792d3AA6b4c44Db6"
+    owner: "0x3F62cE857EDb2E2B2ee80a4FbcE59fE7B943088a"
+  type: native

--- a/deployments/warp_routes/USDT/ethereum-turkchain-config.yaml
+++ b/deployments/warp_routes/USDT/ethereum-turkchain-config.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=../schema.json
+
+tokens:
+  - addressOrDenom: "0x1B87aC71a9078bC58bB6F31466E19809823b09d2"
+    chainName: ethereum
+    collateralAddressOrDenom: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+    coinGeckoId: tether
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: USDT
+    standard: EvmHypCollateral
+    symbol: USDT
+    connections:
+      - token: ethereum|turkchain|0x10bC3c9Af0907b69dc39E7A4fC1819ddD8FEC952
+
+  - addressOrDenom: "0x10bC3c9Af0907b69dc39E7A4fC1819ddD8FEC952"
+    chainName: turkchain
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: USDT
+    standard: EvmHypSynthetic
+    symbol: USDT
+    connections:
+      - token: ethereum|ethereum|0x1B87aC71a9078bC58bB6F31466E19809823b09d2

--- a/deployments/warp_routes/USDT/ethereum-turkchain-deploy.yaml
+++ b/deployments/warp_routes/USDT/ethereum-turkchain-deploy.yaml
@@ -1,0 +1,9 @@
+ethereum:
+  type: collateral
+  token: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+
+turkchain:
+  type: synthetic
+  decimals: 6
+  name: USDT
+  symbol: USDT


### PR DESCRIPTION
## Summary

This PR adds the USDT Warp Route configuration for TurkChain.

### Route

- Asset: USDT
- Origin: Ethereum
- Destination: TurkChain

### Token Standards

- Ethereum: EvmHypCollateral
- TurkChain: EvmHypSynthetic

### Deployment

Ethereum Collateral Router

0x1B87aC71a9078bC58bB6F31466E19809823b09d2

Ethereum USDT

0xdAC17F958D2ee523a2206206994597C13D831ec7

TurkChain Synthetic Router

0x10bC3c9Af0907b69dc39E7A4fC1819ddD8FEC952

### Verification

The Warp Route has been deployed and tested successfully.

Verified transfer:

- Ethereum → TurkChain
- 50,000 units (0.05 USDT)
- Synthetic USDT successfully minted on TurkChain

TurkChain (Domain ID 1919) is already included in the Hyperlane Registry.

This PR adds the missing Warp Route configuration so the route can be discovered by Hyperlane Registry consumers such as the Warp UI and Nexus.