### PR TITLE
fix: raise maxFeeBps for arbitrum, linea, unichain on USDC CCTP v2 fast route

### DIFF
--- a/.changeset/usdc-cctp-v2-fast-maxfeebps.md
+++ b/.changeset/usdc-cctp-v2-fast-maxfeebps.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Raised `maxFeeBps` on the USDC/mainnet-cctp-v2-fast route for arbitrum (1.3→1.4), linea (11→13), and unichain (1.5→2) to match Circle's current live CCTP V2 fast-transfer fee minimums. These three chains' configured caps had fallen below Circle's live fee for their most expensive destination lane (all currently `-> ethereum`), causing `depositForBurn` fast-transfer attestations to fail with `insufficient_fee` and fall back to slow standard-finality attestation instead of fast.

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-deploy.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-deploy.yaml
@@ -1,7 +1,7 @@
 arbitrum:
   cctpVersion: V2
   contractVersion: 11.2.0
-  maxFeeBps: 1.3
+  maxFeeBps: 1.4
   messageTransmitter: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64"
   minFinalityThreshold: 1000
   owner: "0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e"
@@ -73,7 +73,7 @@ ink:
 linea:
   cctpVersion: V2
   contractVersion: 11.2.0
-  maxFeeBps: 11
+  maxFeeBps: 13
   messageTransmitter: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64"
   minFinalityThreshold: 1000
   owner: "0x7b3d694BdeAE8F496Cc5eD0736c5f734cd231079"
@@ -145,7 +145,7 @@ sonic:
 unichain:
   cctpVersion: V2
   contractVersion: 11.2.0
-  maxFeeBps: 1.5
+  maxFeeBps: 2
   messageTransmitter: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64"
   minFinalityThreshold: 1000
   owner: "0x20c2B4B4C7409D08AD70D5F9e317E98cfA9F49f7"


### PR DESCRIPTION
## Summary
- An Arbitrum → Base USDC transfer on `USDC/mainnet-cctp-v2-fast` got stuck: Circle's attestation API returned `status: pending_confirmations`, `delayReason: insufficient_fee` for the `depositForBurn` message, forcing a fall back to slow standard-finality attestation instead of fast.
- Root cause: Circle's live CCTP V2 fast-transfer fee minimum for Arbitrum's most expensive lane (`-> ethereum`, 1.4 bps) now exceeds this route's configured `maxFeeBps: 1.3` for arbitrum in `mainnet-cctp-v2-fast-deploy.yaml`. Verified directly against `https://iris-api.circle.com/v2/burn/USDC/fees/{srcDomain}/{dstDomain}` for every domain pair in the route (CCTP domains confirmed on-chain via each chain's `MessageTransmitter.localDomain()`, not assumed).
- Swept every chain in the route the same way and found two more already past their configured cap: `linea` (11 vs. live 13) and `unichain` (1.5 vs. live 2).
- Bumped exactly to the current live minimum for these three (no added margin) — `arbitrum: 1.3→1.4`, `linea: 11→13`, `unichain: 1.5→2`.

Left unchanged: `base`, `ethereum`, `ink`, `optimism`, `plume`, `worldchain` are currently sitting exactly at their live fee minimum (zero margin, but not yet broken) — flagging in case a follow-up with headroom is wanted separately.

## Test plan
- [x] CI green (changeset + schema validation)
- [x] `hyperlane warp apply` run against this config to push the new `maxFeeBps` on-chain for arbitrum/linea/unichain
- [ ] Confirm a subsequent Arbitrum → Base USDC transfer attests fast (not `insufficient_fee`) post-apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)