### PR TITLE
fix(warp): update USDC CCTP arbitrum/base owners to AW ICAs

### DIFF
--- a/.changeset/cctp-owner-ica-transfer.md
+++ b/.changeset/cctp-owner-ica-transfer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Updated the arbitrum and base owners of the USDC CCTP warp routes (mainnet-cctp, mainnet-cctp-v2-fast, mainnet-cctp-v2-standard) to match the on-chain transfer of ownership from the AW Safes to the AW Interchain Accounts. mainnet-cctp arbitrum owner is now 0xaB547e6cde21a5cC3247b8F80e6CeC3a030FAD4A and base 0xA6D9Aa3878423C266480B5a7cEe74917220a1ad2; mainnet-cctp-v2-fast and mainnet-cctp-v2-standard arbitrum owners are now 0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45 and base 0x61756c4beBC1BaaC09d89729E2cbaD8BD30c62B7.

--- a/deployments/warp_routes/USDC/mainnet-cctp-deploy.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-deploy.yaml
@@ -1,7 +1,7 @@
 arbitrum:
   cctpVersion: V1
   messageTransmitter: "0xC30362313FBBA5cf9163F0bb16a0e01f01A896ca"
-  owner: "0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e"
+  owner: "0xaB547e6cde21a5cC3247b8F80e6CeC3a030FAD4A"
   token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
   tokenMessenger: "0x19330d10D9Cc8751218eaf51E8885D058642E08A"
   type: collateralCctp
@@ -19,7 +19,7 @@ avalanche:
 base:
   cctpVersion: V1
   messageTransmitter: "0xAD09780d193884d503182aD4588450C416D6F9D4"
-  owner: "0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF"
+  owner: "0xA6D9Aa3878423C266480B5a7cEe74917220a1ad2"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   tokenMessenger: "0x1682Ae6375C4E4A97e4B583BC394c861A46D8962"
   type: collateralCctp

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-deploy.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-deploy.yaml
@@ -4,7 +4,7 @@ arbitrum:
   maxFeeBps: 1.3
   messageTransmitter: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64"
   minFinalityThreshold: 1000
-  owner: "0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e"
+  owner: "0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45"
   token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
   tokenMessenger: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d"
   type: collateralCctp
@@ -28,7 +28,7 @@ base:
   maxFeeBps: 1.3
   messageTransmitter: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64"
   minFinalityThreshold: 1000
-  owner: "0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF"
+  owner: "0x61756c4beBC1BaaC09d89729E2cbaD8BD30c62B7"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   tokenMessenger: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d"
   type: collateralCctp

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-deploy.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-deploy.yaml
@@ -4,7 +4,7 @@ arbitrum:
   maxFeeBps: 0
   messageTransmitter: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64"
   minFinalityThreshold: 2000
-  owner: "0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e"
+  owner: "0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45"
   token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
   tokenMessenger: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d"
   type: collateralCctp
@@ -28,7 +28,7 @@ base:
   maxFeeBps: 0
   messageTransmitter: "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64"
   minFinalityThreshold: 2000
-  owner: "0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF"
+  owner: "0x61756c4beBC1BaaC09d89729E2cbaD8BD30c62B7"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   tokenMessenger: "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d"
   type: collateralCctp


### PR DESCRIPTION
## Summary
Resolves the `warp check` diffs on registry `main` for the USDC CCTP routes after the on-chain ownership transfer from the AW Safes to the AW Interchain Accounts (arbitrum + base legs) was executed via Safe.

Updated owners in the deploy configs to match on-chain:

| Route | Chain | Old owner (Safe) | New owner (ICA) |
|-------|-------|------------------|-----------------|
| mainnet-cctp (V1) | arbitrum | `0x03fD5BE9…F25e` | `0xaB547e6cde21a5cC3247b8F80e6CeC3a030FAD4A` |
| mainnet-cctp (V1) | base | `0x3949eD0C…aeBF` | `0xA6D9Aa3878423C266480B5a7cEe74917220a1ad2` |
| mainnet-cctp-v2-fast | arbitrum | `0x03fD5BE9…F25e` | `0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45` |
| mainnet-cctp-v2-fast | base | `0x3949eD0C…aeBF` | `0x61756c4beBC1BaaC09d89729E2cbaD8BD30c62B7` |
| mainnet-cctp-v2-standard | arbitrum | `0x03fD5BE9…F25e` | `0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45` |
| mainnet-cctp-v2-standard | base | `0x3949eD0C…aeBF` | `0x61756c4beBC1BaaC09d89729E2cbaD8BD30c62B7` |

New owners verified via `cast call owner()` on-chain and match the monorepo infra config (`getCCTPConfig.ts` for V1, `governance/ica/aw.ts` for V2). Changeset included.

## Test plan
- [ ] `warp check` on the three CCTP routes shows no owner diffs against on-chain