### PR TITLE
fix(warp): add subtensor/solanamainnet rebalancing bridges to USDC/subtensor

### DIFF
--- a/.changeset/usdc-subtensor-rebalancing-bridges.md
+++ b/.changeset/usdc-subtensor-rebalancing-bridges.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The USDC/subtensor warp route config was updated to record the subtensor and solanamainnet rebalancing bridges on the arbitrum, base, ethereum, polygon, and unichain collateral routers, matching on-chain state.

--- a/deployments/warp_routes/USDC/subtensor-deploy.yaml
+++ b/deployments/warp_routes/USDC/subtensor-deploy.yaml
@@ -8,6 +8,10 @@ arbitrum:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
     polygon:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
+    solanamainnet:
+      - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
+    subtensor:
+      - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
     unichain:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
   contractVersion: 8.1.1
@@ -23,6 +27,10 @@ base:
     ethereum:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
     polygon:
+      - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
+    solanamainnet:
+      - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
+    subtensor:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
     unichain:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
@@ -40,6 +48,10 @@ ethereum:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
     polygon:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
+    solanamainnet:
+      - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
+    subtensor:
+      - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
     unichain:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
   contractVersion: 8.1.1
@@ -55,6 +67,10 @@ polygon:
     base:
       - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
     ethereum:
+      - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
+    solanamainnet:
+      - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
+    subtensor:
       - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
     unichain:
       - bridge: "0xa62F45662809f5F6535b58bae9A572a2EC4A1f84"
@@ -82,6 +98,10 @@ unichain:
     ethereum:
       - bridge: "0x296aF86bff91b23cF980f6a443bc15A3A5d30682"
     polygon:
+      - bridge: "0x296aF86bff91b23cF980f6a443bc15A3A5d30682"
+    solanamainnet:
+      - bridge: "0x296aF86bff91b23cF980f6a443bc15A3A5d30682"
+    subtensor:
       - bridge: "0x296aF86bff91b23cF980f6a443bc15A3A5d30682"
   contractVersion: 8.1.1
   owner: "0x29dfa34765e29ea353FC8aB70A19e32a5578E603"


### PR DESCRIPTION
## Summary
Adds the missing `allowedRebalancingBridges` entries for `subtensor` (domain 964) and `solanamainnet` (domain 1399811149) to each of the 5 EVM chains in the USDC/subtensor deploy config.

These 10 entries (5 chains × 2 destinations) exist on-chain but were absent from the registry, producing 10 `check-warp-deploy` ConfigMismatch violations. Each added bridge address mirrors the chain's existing per-source rebalancer bridge and was verified on-chain via `allowedBridges(uint32)`:

| Chain | Bridge |
|-------|--------|
| arbitrum | `0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2` |
| base | `0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975` |
| ethereum | `0xedCBAa585FD0F80f20073F9958246476466205b8` |
| polygon | `0xa62F45662809f5F6535b58bae9A572a2EC4A1f84` |
| unichain | `0x296aF86bff91b23cF980f6a443bc15A3A5d30682` |

## Test plan
- [ ] check-warp-deploy no longer reports the 10 USDC/subtensor ConfigMismatch violations