### PR TITLE
fix(warp): pin LUMIA proxyAdmin owner to on-chain value

### DIFF
--- a/.changeset/lumia-proxyadmin-owner-onchain.md
+++ b/.changeset/lumia-proxyadmin-owner-onchain.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The LUMIA warp route config was updated to pin the bsc, ethereum, and lumiaprism proxyAdmin owners to their on-chain values, clearing the check-warp-deploy ownership mismatch.

--- a/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-deploy.yaml
+++ b/deployments/warp_routes/LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon-deploy.yaml
@@ -14,20 +14,20 @@ bsc:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0x54bB5b12c67095eB3dabCD11FA74AAcfE46E7767"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   type: synthetic
 ethereum:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0xdaB976ae358D4D2d25050b5A25f71520983C46c9"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   token: "0xD9343a049D5DBd89CD19DC6BcA8c48fB3a0a42a7"
   type: collateral
 lumiaprism:
   owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   proxyAdmin:
     address: "0xBC53dACd8c0ac0d2bAC461479EAaf5519eCC8853"
-    owner: "0x8bBA07Ddc72455b55530C17e6f6223EF6E156863"
+    owner: "0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39"
   type: native
 optimism:
   owner: "0x914931eBb5638108651455F50C1F784d3E5fd3EC"


### PR DESCRIPTION
## Summary
The `proxyAdmin.owner` for LUMIA on **bsc, ethereum, lumiaprism** was set in the registry to `0x8bBA07Ddc72455b55530C17e6f6223EF6E156863` — an EOA with no code that appears **nowhere else** in the registry.

On-chain, all three proxyAdmins are owned by `0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39` (verified via `owner()`), which is the **same LUMIA-team address that already owns the tokens** on those chains (no token-owner violation exists). Pinned the registry to the real on-chain owner.

Resolves the 3 `check-warp-deploy` `proxyAdmin.owner` ConfigMismatch violations for LUMIA.

| Chain | proxyAdmin | on-chain owner (now expected) |
|-------|-----------|------------------------------|
| bsc | `0x54bB5b12c67095eB3dabCD11FA74AAcfE46E7767` | `0xa86C4AF...Ae6B39` |
| ethereum | `0xdaB976ae358D4D2d25050b5A25f71520983C46c9` | `0xa86C4AF...Ae6B39` |
| lumiaprism | `0xBC53dACd8c0ac0d2bAC461479EAaf5519eCC8853` | `0xa86C4AF...Ae6B39` |

## Test plan
- [ ] check-warp-deploy no longer reports the 3 LUMIA proxyAdmin.owner ConfigMismatch violations