### PR TITLE
fix(warp): pin HOLO scale + direction-sensitive owner drifts to on-chain

### DIFF
--- a/.changeset/warp-holo-scale-pin.md
+++ b/.changeset/warp-holo-scale-pin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Pinned the HOLO/bsc-solanamainnet SVM synthetic `scale` field to its on-chain value (10^9) to clear check-warp-deploy scale drift. The Solana leg has 9 decimals against the 18-decimal BSC counterpart, so the previously missing scale was being treated as identity.

--- a/.changeset/warp-onchain-owner-type-pin.md
+++ b/.changeset/warp-onchain-owner-type-pin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Pinned direction-sensitive warp route drifts to their on-chain values to clear check-warp-deploy ConfigMismatch alerts: Bonk/JUP/TRUMP starknet routes (starknet + solanamainnet owners), Fartcoin/PENGU/UFD apechain-solanamainnet routes (solanamainnet owner), and the ETH/paradex synthetic `type` (collateralDex to collateral, matching the on-chain contract and the existing config.yaml standard). These records were ratified against the deployed contracts rather than the previously-assumed canonical owners.

--- a/.changeset/warp-onchain-owner-type-pin.md
+++ b/.changeset/warp-onchain-owner-type-pin.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': patch
 ---
 
-Pinned direction-sensitive warp route drifts to their on-chain values to clear check-warp-deploy ConfigMismatch alerts: Bonk/JUP/TRUMP starknet routes (starknet + solanamainnet owners), Fartcoin/PENGU/UFD apechain-solanamainnet routes (solanamainnet owner), and the ETH/paradex synthetic `type` (collateralDex to collateral, matching the on-chain contract and the existing config.yaml standard). These records were ratified against the deployed contracts rather than the previously-assumed canonical owners.
+Pinned direction-sensitive warp route owner drifts to their on-chain values to clear check-warp-deploy ConfigMismatch alerts: Bonk/JUP/TRUMP starknet routes (starknet + solanamainnet owners) and Fartcoin/PENGU/UFD apechain-solanamainnet routes (solanamainnet owner). These records were ratified against the deployed contracts rather than the previously-assumed canonical owners.

--- a/deployments/warp_routes/Bonk/starknet-deploy.yaml
+++ b/deployments/warp_routes/Bonk/starknet-deploy.yaml
@@ -2,7 +2,7 @@ solanamainnet:
   decimals: 5
   foreignDeployment: CWSVXTp2LadAE77Lk511ntA5jZNVgqiUXkWzUxjHtmeh
   name: Bonk
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: 71S39xUrJCKmZEG5xugLLVTtp37Jy1F8oyrv1fQ4PYJK
   symbol: Bonk
   token: DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263
   type: collateral
@@ -11,6 +11,6 @@ starknet:
   foreignDeployment: "0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736"
   isNft: false
   name: Bonk
-  owner: "0x06ae465e0c05735820a75500c40cb4dabbe46ebf1f1665f9ba3f9a7dcc78a6d1"
+  owner: "0x04ddb8856c625235247708e945179085506bff53eae7ff04319cd1cbb5b635e7"
   symbol: Bonk
   type: synthetic

--- a/deployments/warp_routes/ETH/paradex-deploy.yaml
+++ b/deployments/warp_routes/ETH/paradex-deploy.yaml
@@ -17,4 +17,4 @@ paradex:
   owner: "0x00395a1eebf43d06be83684da623c4c2ab8e1ea4a89dfa71ee04677b6e19a428"
   symbol: ETH
   token: "0x753b4f4e127a2c2d969a3e4c09e5b0371b78040f7ad433ddc69de4dae90f407"
-  type: collateral
+  type: collateralDex

--- a/deployments/warp_routes/ETH/paradex-deploy.yaml
+++ b/deployments/warp_routes/ETH/paradex-deploy.yaml
@@ -17,4 +17,4 @@ paradex:
   owner: "0x00395a1eebf43d06be83684da623c4c2ab8e1ea4a89dfa71ee04677b6e19a428"
   symbol: ETH
   token: "0x753b4f4e127a2c2d969a3e4c09e5b0371b78040f7ad433ddc69de4dae90f407"
-  type: collateralDex
+  type: collateral

--- a/deployments/warp_routes/Fartcoin/apechain-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/Fartcoin/apechain-solanamainnet-deploy.yaml
@@ -10,6 +10,6 @@ solanamainnet:
   foreignDeployment: 4YGKdefcJMUVnzZFu124t7epCNWnAjmXbKXyC13HiAFR
   gas: 300000
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: B1q2dsjCE4F6wi5ktn4anmFq9572JpziBUg2TqCS2dFn
   token: 9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump
   type: collateral

--- a/deployments/warp_routes/HOLO/bsc-solanamainnet-config.yaml
+++ b/deployments/warp_routes/HOLO/bsc-solanamainnet-config.yaml
@@ -19,5 +19,6 @@ tokens:
     decimals: 9
     logoURI: /deployments/warp_routes/HOLO/logo.svg
     name: Holoworld AI
+    scale: 1000000000
     standard: SealevelHypSynthetic
     symbol: HOLO

--- a/deployments/warp_routes/HOLO/bsc-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/HOLO/bsc-solanamainnet-deploy.yaml
@@ -7,4 +7,5 @@ bsc:
 solanamainnet:
   foreignDeployment: CJVjRp7ndm14RhwGoLFMBWMS2EZ6vCsGhB3YMXaPcPHb
   owner: 6d3vKAcmi7XRtG8jWAKJj8VPDaiprT56bVSkVW2eCxCp
+  scale: 1000000000
   type: synthetic

--- a/deployments/warp_routes/JUP/starknet-deploy.yaml
+++ b/deployments/warp_routes/JUP/starknet-deploy.yaml
@@ -2,7 +2,7 @@ solanamainnet:
   decimals: 6
   foreignDeployment: 7heDuWfoApUWd8Y9rezYnNCVDbj8XB5fkLiTH4uxbocW
   name: Jupiter
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: 71S39xUrJCKmZEG5xugLLVTtp37Jy1F8oyrv1fQ4PYJK
   symbol: JUP
   token: JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN
   type: collateral
@@ -11,6 +11,6 @@ starknet:
   foreignDeployment: "0x03a292bd498266ac4b05d93cc2df5cd7883c0684faabff182ab568d566a3c151"
   isNft: false
   name: Jupiter
-  owner: "0x06ae465e0c05735820a75500c40cb4dabbe46ebf1f1665f9ba3f9a7dcc78a6d1"
+  owner: "0x04ddb8856c625235247708e945179085506bff53eae7ff04319cd1cbb5b635e7"
   symbol: JUP
   type: synthetic

--- a/deployments/warp_routes/PENGU/apechain-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/PENGU/apechain-solanamainnet-deploy.yaml
@@ -10,6 +10,6 @@ solanamainnet:
   foreignDeployment: C7a43nYF9atxgJhfqoP2vc95exJcEQhvJqYbtCNkDf8f
   gas: 300000
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: B1q2dsjCE4F6wi5ktn4anmFq9572JpziBUg2TqCS2dFn
   token: 2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv
   type: collateral

--- a/deployments/warp_routes/TRUMP/starknet-deploy.yaml
+++ b/deployments/warp_routes/TRUMP/starknet-deploy.yaml
@@ -2,7 +2,7 @@ solanamainnet:
   decimals: 6
   foreignDeployment: G13ocbVp6aCUdz8kHPpv2p82cPNXGTAUfnJRuTmscaCQ
   name: OFFICIAL TRUMP
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: 71S39xUrJCKmZEG5xugLLVTtp37Jy1F8oyrv1fQ4PYJK
   symbol: TRUMP
   token: 6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN
   type: collateral
@@ -11,6 +11,6 @@ starknet:
   foreignDeployment: "0x07380caa64fdf27501afad0bd93c89d1e83a081a553af89bbeffb28dae8d8916"
   isNft: false
   name: OFFICIAL TRUMP
-  owner: "0x06ae465e0c05735820a75500c40cb4dabbe46ebf1f1665f9ba3f9a7dcc78a6d1"
+  owner: "0x04ddb8856c625235247708e945179085506bff53eae7ff04319cd1cbb5b635e7"
   symbol: TRUMP
   type: synthetic

--- a/deployments/warp_routes/UFD/apechain-solanamainnet-deploy.yaml
+++ b/deployments/warp_routes/UFD/apechain-solanamainnet-deploy.yaml
@@ -10,6 +10,6 @@ solanamainnet:
   foreignDeployment: DTNQ9T9KYbB2rpnJxdwcZbnxB17G9jAiiSqU8fAf6uSS
   gas: 300000
   interchainSecurityModule: "0x0000000000000000000000000000000000000000"
-  owner: 9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf
+  owner: B1q2dsjCE4F6wi5ktn4anmFq9572JpziBUg2TqCS2dFn
   token: eL5fUxj2J4CiQsmW85k5FG9DvuQjjUoBHoQBi2Kpump
   type: collateral

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -4291,6 +4291,7 @@ HOLO/bsc-solanamainnet:
       decimals: 9
       logoURI: /deployments/warp_routes/HOLO/logo.svg
       name: Holoworld AI
+      scale: 1000000000
       standard: SealevelHypSynthetic
       symbol: HOLO
 HYPE/mantra:


### PR DESCRIPTION
## Summary

Pins the remaining **registry-fixable** check-warp-deploy drifts to their on-chain values. Opened for review (not auto-merge) — the owner pins are **direction-sensitive**: pinning ratifies whatever is deployed on-chain, so please eyeball each before merging.

`actual` = on-chain value (what we're pinning TO). `expected` = current registry value (what we're pinning FROM).

### 1. HOLO/bsc-solanamainnet — SVM synthetic `scale` (metadata only, safe)
- solanamainnet `scale`: (missing → treated as identity) → `1000000000`
- Route always worked; on-chain scale is 10^9 (9-decimal Solana leg vs 18-decimal BSC). Registry just omitted the field. Formatting/metadata fix, not a behavior change.

### 2. Owner pins — ratify on-chain owner (please verify each is intended)
On-chain owner diverged from the canonical AW owner in the registry. Pinning records reality. **Verify these on-chain owners are legitimate (partner-owned / intentional transfer) and not unauthorized.**

| Route | Leg | expected (registry) | actual (on-chain, pinned) |
|---|---|---|---|
| Bonk/starknet | starknet | 0x06ae…a6d1 | 0x04ddb8…635e7 |
| Bonk/starknet | solanamainnet | 9bRSUP…HoWnf | 71S39x…4PYJK |
| JUP/starknet | starknet | 0x06ae…a6d1 | 0x04ddb8…635e7 |
| JUP/starknet | solanamainnet | 9bRSUP…HoWnf | 71S39x…4PYJK |
| TRUMP/starknet | starknet | 0x06ae…a6d1 | 0x04ddb8…635e7 |
| TRUMP/starknet | solanamainnet | 9bRSUP…HoWnf | 71S39x…4PYJK |
| Fartcoin/apechain-solanamainnet | solanamainnet | 9bRSUP…HoWnf | B1q2ds…S2dFn |
| PENGU/apechain-solanamainnet | solanamainnet | 9bRSUP…HoWnf | B1q2ds…S2dFn |
| UFD/apechain-solanamainnet | solanamainnet | 9bRSUP…HoWnf | B1q2ds…S2dFn |

Provenance of the apechain-solana owner `B1q2ds…S2dFn`: Christopher Brumm's May 2025 SOL/apechain-solanamainnet deployment (registry #859, monorepo #6249). Same address across all three apechain-solana routes and their sealevel token-config.json files. The registry's `9bRSUP…` was the stale/assumed owner, never the deployed one.

## Excluded (and why) — NOT in this diff

- **ETH/paradex paradex `type`** — the on-chain contract reads as plain `collateral`, but the registry intentionally uses `collateralDex`, a paradex-specific DEX-conversion type that only lives in the registry. The SDK `TokenType` enum has no such member, so warp check downcasts it and false-flags a ConfigMismatch. This is a **checker/tooling gap**, not a real drift — left as `collateralDex`. Fix belongs in the checker (teach it the type or suppress), not the registry.
- **WBTC/eclipsemainnet-ethereum proxyAdmin.owner** — registry `proxyAdmin.owner` **already equals** on-chain (`0x562Dfa…0DA7`). The drift comes from `ownerOverrides.proxyAdmin` = the Safe `0x3965AC…C5b6`. "Pinning to on-chain" would rewrite the stated intent (Safe owns proxyAdmin) to match reality. This looks like **on-chain is the bug** — the proxyAdmin was likely never transferred to the Safe. Recommend an on-chain owner transfer, not a registry edit.
- **USDC/aleo owner** — already fixed on `main` (#1598); deploy.yaml already = on-chain (`aleo1mx0…`). Alert clears on next registry release.
- **All `destinationGas.*` drifts** (Bonk/JUP/TRUMP/PUMP starknet, pumpBTCstk, ETH/paradex, etc.) — `destinationGas` is **not** present in any registry source file; it's SDK-derived. Not registry-fixable, and several read `actual=0` (would delete gas config). Needs a separate look.
- **KYVE/base-kyve type** (native → collateral) — needs a full reconcile (collateral requires a `ukyve` denom), not a one-field pin.
- **SMOL/arbitrum-abstract-ethereum-solanamainnet-base** — multi-field (route extended on-chain: token/remoteRouters/destinationGas on abstract/treasure). Needs a proper reconcile.
- **ctUSD/citrea allowedRebalancingBridges** — same bridge, only domain-id-vs-chain-name representation differs (checker quirk).
- **contractVerificationStatus / ownerStatus / SVM token-mint drifts** — not registry-fixable.
- **USDC/mainnet-cctp-v2-fast maxFeeBps** — owned by branch `fix/usdc-cctp-v2-fast-maxfeebps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)