### PR TITLE
fix(warp): resolve solanamainnet->starknet destinationGas drifts

### DIFF
--- a/.changeset/starknet-destgas-pin.md
+++ b/.changeset/starknet-destgas-pin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Pinned the Bonk/JUP/TRUMP starknet routes' `starknet` leg `gas` to the on-chain value (5000000) to clear the check-warp-deploy destinationGas ConfigMismatch. The solanamainnet routers deliberately forward 5000000 gas to the Starknet destination, but the registry never declared an explicit `gas`, so the checker derived the EVM default `gasOverhead(synthetic)` = 64000 and flagged every solanamainnet→starknet leg.

--- a/deployments/warp_routes/Bonk/starknet-deploy.yaml
+++ b/deployments/warp_routes/Bonk/starknet-deploy.yaml
@@ -9,6 +9,7 @@ solanamainnet:
 starknet:
   decimals: 5
   foreignDeployment: "0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736"
+  gas: 5000000
   isNft: false
   name: Bonk
   owner: "0x06ae465e0c05735820a75500c40cb4dabbe46ebf1f1665f9ba3f9a7dcc78a6d1"

--- a/deployments/warp_routes/JUP/starknet-deploy.yaml
+++ b/deployments/warp_routes/JUP/starknet-deploy.yaml
@@ -9,6 +9,7 @@ solanamainnet:
 starknet:
   decimals: 6
   foreignDeployment: "0x03a292bd498266ac4b05d93cc2df5cd7883c0684faabff182ab568d566a3c151"
+  gas: 5000000
   isNft: false
   name: Jupiter
   owner: "0x06ae465e0c05735820a75500c40cb4dabbe46ebf1f1665f9ba3f9a7dcc78a6d1"

--- a/deployments/warp_routes/TRUMP/starknet-deploy.yaml
+++ b/deployments/warp_routes/TRUMP/starknet-deploy.yaml
@@ -9,6 +9,7 @@ solanamainnet:
 starknet:
   decimals: 6
   foreignDeployment: "0x07380caa64fdf27501afad0bd93c89d1e83a081a553af89bbeffb28dae8d8916"
+  gas: 5000000
   isNft: false
   name: OFFICIAL TRUMP
   owner: "0x06ae465e0c05735820a75500c40cb4dabbe46ebf1f1665f9ba3f9a7dcc78a6d1"


### PR DESCRIPTION
## Summary

Best-effort resolution of the `destinationGas` ConfigMismatch drifts surfaced by `check-warp-deploy` (verified against live Prometheus, `grafanacloud-prom`).

**Fixed here (registry-fixable):** Bonk/JUP/TRUMP starknet routes, `solanamainnet -> starknet` legs — on-chain `actual=5000000`, checker `expected=64000`.

- The `destinationGas[dest]` expected value derives from the **destination** leg's registry `gas`, else `gasOverhead(destType)` (`configUtils.ts` getGasConfig).
- The starknet legs declared no explicit `gas`, so the checker fell back to the EVM default `gasOverhead(synthetic)` = 64000.
- On-chain, the solanamainnet routers deliberately forward `5000000` gas to Starknet (Starknet execution needs far more than the EVM default). On-chain is correct; the registry simply never declared it.
- Fix: add `gas: 5000000` to the `starknet` leg of each route. Direction-safe — only the `solanamainnet -> starknet` leg consumes it, and the starknet leg's own outbound gas is unaffected.

## NOT fixed here (not registry-fixable)

**Category A — `actual=0`, origin `starknet`/`paradex`** (Bonk/JUP/PUMP/TRUMP starknet->solanamainnet=68000; pumpBTCstk starknet->ethereum=68000; ETH/paradex paradex->ethereum=44000 & ->mode=64000). The Starknet/paradex on-chain reader returns `0` for destinationGas. Pinning the registry to `0` would delete needed gas config and cause relayer underpayment. This is a checker/reader limitation, not a registry drift.

**Category C — SMOL/arbitrum-abstract-ethereum-solanamainnet-base, origin `solanamainnet`.** The on-chain solana router is itself misconfigured:
- `destinationGas.ethereum` actual=64000 vs expected=70000 — every other origin->ethereum is at 70000 on-chain (not flagged), so the registry's 70000 is correct and solana's 64000 is the outlier. Lowering the registry would break the other legs.
- `destinationGas.treasure` actual=64000 — `treasure` is not a leg in this route; stale on-chain enrollment.
- `destinationGas.abstract` missing on-chain, expected=70000 — solana never enrolled abstract's gas.

SMOL needs an on-chain solanamainnet destinationGas reconcile (correct ethereum to 70000, add abstract, drop the stray treasure enrollment), not a registry edit.

## Test plan

- [ ] check-warp-deploy no longer reports destinationGas ConfigMismatch for Bonk/JUP/TRUMP solanamainnet->starknet