### PR TITLE
feat(warp): add mantle to KII/kiichain warp route

### DIFF
--- a/.changeset/kii-mantle-route.md
+++ b/.changeset/kii-mantle-route.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added mantle to the KII/kiichain warp route.

--- a/deployments/warp_routes/KII/kiichain-config.yaml
+++ b/deployments/warp_routes/KII/kiichain-config.yaml
@@ -7,6 +7,7 @@ tokens:
       - token: ethereum|polygon|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
       - token: ethereum|base|0x3EBA6644819546C44Eb3e7c3A92f034f921dcA80
       - token: ethereum|ethereum|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: ethereum|mantle|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
     decimals: 18
     logoURI: /deployments/warp_routes/KII/logo.png
     name: Kiichain
@@ -19,6 +20,7 @@ tokens:
       - token: ethereum|polygon|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
       - token: ethereum|base|0x3EBA6644819546C44Eb3e7c3A92f034f921dcA80
       - token: ethereum|ethereum|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: ethereum|mantle|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
     decimals: 18
     logoURI: /deployments/warp_routes/KII/logo.png
     name: Kiichain
@@ -31,6 +33,7 @@ tokens:
       - token: ethereum|bsc|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
       - token: ethereum|base|0x3EBA6644819546C44Eb3e7c3A92f034f921dcA80
       - token: ethereum|ethereum|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: ethereum|mantle|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
     decimals: 18
     logoURI: /deployments/warp_routes/KII/logo.png
     name: Kiichain
@@ -43,6 +46,7 @@ tokens:
       - token: ethereum|bsc|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
       - token: ethereum|polygon|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
       - token: ethereum|ethereum|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: ethereum|mantle|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
     decimals: 18
     logoURI: /deployments/warp_routes/KII/logo.png
     name: Kiichain
@@ -55,6 +59,20 @@ tokens:
       - token: ethereum|bsc|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
       - token: ethereum|polygon|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
       - token: ethereum|base|0x3EBA6644819546C44Eb3e7c3A92f034f921dcA80
+      - token: ethereum|mantle|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+    decimals: 18
+    logoURI: /deployments/warp_routes/KII/logo.png
+    name: Kiichain
+    standard: EvmHypSynthetic
+    symbol: KII
+  - addressOrDenom: "0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886"
+    chainName: mantle
+    connections:
+      - token: ethereum|kiichain|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: ethereum|bsc|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: ethereum|polygon|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: ethereum|base|0x3EBA6644819546C44Eb3e7c3A92f034f921dcA80
+      - token: ethereum|ethereum|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
     decimals: 18
     logoURI: /deployments/warp_routes/KII/logo.png
     name: Kiichain

--- a/deployments/warp_routes/KII/kiichain-deploy.yaml
+++ b/deployments/warp_routes/KII/kiichain-deploy.yaml
@@ -52,6 +52,22 @@ kiichain:
   owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
   type: native
 
+mantle:
+  decimals: 18
+  mailbox: "0x398633D19f4371e1DB5a8EFE90468eB70B1176AA"
+  name: Kiichain
+  owner: "0xcBDbef893cadc6B44E89f18b5fb45EA5554DC389"
+  symbol: KII
+  tokenFee:
+    feeContracts:
+      kiichain:
+        bps: 10
+        owner: "0x58c320539EfA1c81d93DD01156481FC58eb4457F"
+        type: LinearFee
+    owner: "0x58c320539EfA1c81d93DD01156481FC58eb4457F"
+    type: RoutingFee
+  type: synthetic
+
 polygon:
   decimals: 18
   mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"


### PR DESCRIPTION
## Summary
- Adds mantle as a new spoke on the KII/kiichain warp route (synthetic KII on mantle, connected to kiichain, bsc, polygon, base, ethereum)
- Updates all existing legs' connections to include mantle
- Adds changeset

Linear: AW-716 (https://linear.app/hyperlane-xyz/issue/AW-716/kiichain-kii-mantle-extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)