### PR TITLE
fix(warp): pin KYVE kyve leg to on-chain collateral config

### DIFF
--- a/.changeset/kyve-onchain-collateral-pin.md
+++ b/.changeset/kyve-onchain-collateral-pin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Pinned the `kyve` leg of the KYVE/base-kyve warp route to its on-chain collateral configuration (`type: collateral`, `token: ukyve`) to clear the check-warp-deploy ConfigMismatch. The record previously declared `type: native`, but the deployed router is a collateral token backed by the `ukyve` denom.

--- a/deployments/warp_routes/KYVE/base-kyve-deploy.yaml
+++ b/deployments/warp_routes/KYVE/base-kyve-deploy.yaml
@@ -10,4 +10,5 @@ kyve:
   foreignDeployment: "0x726f757465725f61707000000000000000000000000000010000000000000000"
   gas: 50000
   owner: kyve1cmgthdy9yhjfken770zqgchrd7flmld4d3d530
-  type: native
+  token: ukyve
+  type: collateral


### PR DESCRIPTION
## Summary
- The `kyve` leg of the KYVE/base-kyve warp route is a collateral token (denom `ukyve`) on-chain, but the registry deploy config declared it as `type: native`.
- This produced a persistent `hyperlane warp check` drift (type + missing token).
- Per the decision to accept on-chain state as source-of-truth for reconciled drifts, this pins the registry to the on-chain config: `type: collateral` + `token: ukyve`.

## Verification
- `hyperlane warp check --id KYVE/base-kyve` returns "No violations found" with this change applied.

cc @troykessler