### PR TITLE
fix: accept on-chain KYVE/base-kyve kyve leg as ukyve collateral

### DIFF
--- a/deployments/warp_routes/KYVE/base-kyve-deploy.yaml
+++ b/deployments/warp_routes/KYVE/base-kyve-deploy.yaml
@@ -10,4 +10,5 @@ kyve:
   foreignDeployment: "0x726f757465725f61707000000000000000000000000000010000000000000000"
   gas: 50000
   owner: kyve1cmgthdy9yhjfken770zqgchrd7flmld4d3d530
-  type: native
+  token: ukyve
+  type: collateral


### PR DESCRIPTION
## Summary
The `kyve` leg of `KYVE/base-kyve` is deployed on-chain as a **cosmos-native collateral** of `ukyve`, but the deploy config declared it as `native`. This trips `check-warp-deploy` with two `ConfigMismatch` violations (`type`: on-chain collateral vs config native; `token`: on-chain ukyve). Updated the config to match the live on-chain state.

- `type`: `native` → `collateral`
- added `token: ukyve`

`config.yaml` already declares `standard: CosmosNativeHypCollateral`, so this aligns deploy.yaml with it.

## Test plan
- [ ] Next `check-warp-deploy` run shows KYVE/base-kyve `type` + `token` series cleared