### PR TITLE
fix(warp): key ctUSD/citrea rebalancing bridges by domain id

### DIFF
--- a/.changeset/ctusd-citrea-bridge-domain-keys.md
+++ b/.changeset/ctusd-citrea-bridge-domain-keys.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Re-keyed the ctUSD/citrea route's allowedRebalancingBridges by domain id (ethereum=1, citrea=4114) to match the on-chain state.

--- a/deployments/warp_routes/ctUSD/citrea-deploy.yaml
+++ b/deployments/warp_routes/ctUSD/citrea-deploy.yaml
@@ -2,7 +2,7 @@ citrea:
   allowedRebalancers:
     - "0xDA97A88A777FDC13978f3567bb1A94beec7F229D"
   allowedRebalancingBridges:
-    ethereum:
+    "1":
       - bridge: "0x5b877447F549ef799214dF0e9745a76a7129dA2A"
   # custom ISM deployed by the team
   interchainSecurityModule: "0x7d9a697eFfdEbb16C6A4b7eEedD16ac22227Fd0e"
@@ -13,7 +13,7 @@ ethereum:
   allowedRebalancers:
     - "0xDA97A88A777FDC13978f3567bb1A94beec7F229D"
   allowedRebalancingBridges:
-    citrea:
+    "4114":
       - bridge: "0x926BDd2Ab8DeDa17757be78c8aF55b4fb8e38914"
   # custom ISM deployed by the team
   interchainSecurityModule: "0x02F02A24dd6135d7d4aD15f42B16D7F5f3a16421"


### PR DESCRIPTION
## Summary
- On-chain, the ctUSD/citrea route keys `allowedRebalancingBridges` by domain id (ethereum = `1`, citrea = `4114`); the registry keyed them by chain name (`ethereum`, `citrea`).
- The bridge addresses already match on-chain — only the key representation differed — but check-warp-deploy flags the key mismatch as 4 `ConfigMismatch` violations.
- Re-key the registry entries to domain ids to accept the on-chain state.

## Test plan
- [ ] check-warp-deploy shows ctUSD/citrea clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)