### PR TITLE
chore: migrate aleo warp route owners to v2 admin programs

### DIFF
--- a/.changeset/aleo-v2-owner-upgrade.md
+++ b/.changeset/aleo-v2-owner-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Updated the aleo owner for the ETH, SOL, USDC, USDT, and WBTC warp routes to the newly deployed v2 admin programs (hyp*warp_token*{eth,sol,wbtc,usdc,usdt}\_v2.aleo).

--- a/deployments/warp_routes/ETH/aleo-deploy.yaml
+++ b/deployments/warp_routes/ETH/aleo-deploy.yaml
@@ -3,7 +3,7 @@ aleo:
   decimals: 18
   gas: 60000
   name: Ether
-  owner: aleo1mx0tldt5qsqymn5a3whnmf9rx2whp837jjn0tvqgxqf86zg6dvyqnc8spm
+  owner: aleo1wq6f6qdqya44avznygz5hae40u3mjg64w0r93a4qfu4utpf8cg9q566f4r
   symbol: ETH
   type: synthetic
 ethereum:

--- a/deployments/warp_routes/SOL/aleo-deploy.yaml
+++ b/deployments/warp_routes/SOL/aleo-deploy.yaml
@@ -3,7 +3,7 @@ aleo:
   decimals: 9
   gas: 60000
   name: Solana
-  owner: aleo1mx0tldt5qsqymn5a3whnmf9rx2whp837jjn0tvqgxqf86zg6dvyqnc8spm
+  owner: aleo1wr8rfr4ggedjxtg5e23s38zqkgy2j05uc9l8t4akjp5zcw3levpswkwk45
   symbol: SOL
   type: synthetic
 hyperevm:

--- a/deployments/warp_routes/USDC/aleo-deploy.yaml
+++ b/deployments/warp_routes/USDC/aleo-deploy.yaml
@@ -3,7 +3,7 @@ aleo:
   gas: 60000
   mailbox: hyp_mailbox.aleo/aleo1u9rclq7at704j7xth037apm056t36qnyam9r3v6sewvqlvnew58qph0gk7
   name: USD Coin
-  owner: aleo1mx0tldt5qsqymn5a3whnmf9rx2whp837jjn0tvqgxqf86zg6dvyqnc8spm
+  owner: aleo1xvxtrlg5a4kze76xejvmremj8qnkkquqtfpece47csw64pegeyqq36xvtr
   scale: 1000000000000
   symbol: USDC
   type: synthetic

--- a/deployments/warp_routes/USDT/aleo-deploy.yaml
+++ b/deployments/warp_routes/USDT/aleo-deploy.yaml
@@ -2,7 +2,7 @@ aleo:
   decimals: 6
   gas: 60000
   name: Tether USD
-  owner: aleo1mx0tldt5qsqymn5a3whnmf9rx2whp837jjn0tvqgxqf86zg6dvyqnc8spm
+  owner: aleo1l3gwacmjruxryy9c7c4fn0acyzprf29hucrvthw7f63lpyhd5y9srydq8z
   scale: 1000000000000
   symbol: USDT
   type: synthetic

--- a/deployments/warp_routes/WBTC/aleo-deploy.yaml
+++ b/deployments/warp_routes/WBTC/aleo-deploy.yaml
@@ -3,7 +3,7 @@ aleo:
   decimals: 8
   gas: 60000
   name: Wrapped BTC
-  owner: aleo1mx0tldt5qsqymn5a3whnmf9rx2whp837jjn0tvqgxqf86zg6dvyqnc8spm
+  owner: aleo14jauje2a5sncm9u5t3mt6qqv3eq2hatkddskccs0dvsy35a0x58q0d6f95
   symbol: WBTC
   type: synthetic
 ethereum:


### PR DESCRIPTION
## Summary

Migrates the aleo owner address for 5 warp routes to their newly deployed v2 admin programs (`hyp_warp_token_{eth,sol,wbtc,usdc,usdt}_v2.aleo`).

Old owner (all 5): `aleo1mx0tldt5qsqymn5a3whnmf9rx2whp837jjn0tvqgxqf86zg6dvyqnc8spm`

| Route | New aleo owner |
|-------|----------------|
| ETH | `aleo1wq6f6qdqya44avznygz5hae40u3mjg64w0r93a4qfu4utpf8cg9q566f4r` |
| SOL | `aleo1wr8rfr4ggedjxtg5e23s38zqkgy2j05uc9l8t4akjp5zcw3levpswkwk45` |
| USDC | `aleo1xvxtrlg5a4kze76xejvmremj8qnkkquqtfpece47csw64pegeyqq36xvtr` |
| USDT | `aleo1l3gwacmjruxryy9c7c4fn0acyzprf29hucrvthw7f63lpyhd5y9srydq8z` |
| WBTC | `aleo14jauje2a5sncm9u5t3mt6qqv3eq2hatkddskccs0dvsy35a0x58q0d6f95` |

Only the `aleo` leg's `owner` field changes in each `aleo-deploy.yaml`; all other legs untouched.

## Changeset

Adds `.changeset/aleo-v2-owner-upgrade.md` (`@hyperlane-xyz/registry` patch).

## Test plan

- [ ] CI passes (schema validation / changeset check)