### PR TITLE
feat: switch eclipse USDC/USDT EVM fee legs to OffchainQuotedLinearFee

### DIFF
--- a/deployments/warp_routes/USDC/eclipsemainnet-deploy.yaml
+++ b/deployments/warp_routes/USDC/eclipsemainnet-deploy.yaml
@@ -2,34 +2,34 @@ arbitrum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    avalanche:
+    "1":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    base:
+    "10":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    ethereum:
+    "130":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    hyperevm:
+    "137":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    ink:
+    "43114":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    linea:
+    "480":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    optimism:
+    "57073":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    polygon:
+    "59144":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    unichain:
+    "8453":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
-    worldchain:
+    "999":
       - bridge: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       - bridge: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
   contractVersion: 10.1.3
@@ -48,55 +48,81 @@ arbitrum:
       avalanche:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
     type: RoutingFee
   type: collateral
@@ -104,34 +130,34 @@ avalanche:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    base:
+    "10":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    ethereum:
+    "130":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    hyperevm:
+    "137":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    ink:
+    "42161":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    linea:
+    "480":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    optimism:
+    "57073":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    polygon:
+    "59144":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    unichain:
+    "8453":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    worldchain:
+    "999":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
   contractVersion: 10.1.5
@@ -150,55 +176,81 @@ avalanche:
       arbitrum:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
     type: RoutingFee
   type: collateral
@@ -206,34 +258,34 @@ base:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    avalanche:
+    "10":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    ethereum:
+    "130":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    hyperevm:
+    "137":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    ink:
+    "42161":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    linea:
+    "43114":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    optimism:
+    "480":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    polygon:
+    "57073":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    unichain:
+    "59144":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
-    worldchain:
+    "999":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
   contractVersion: 10.1.3
@@ -252,55 +304,81 @@ base:
       arbitrum:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
     type: RoutingFee
   type: collateral
@@ -321,55 +399,81 @@ bsc:
       arbitrum:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
     type: RoutingFee
   type: collateral
@@ -383,34 +487,34 @@ ethereum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "10":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    avalanche:
+    "130":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    base:
+    "137":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    hyperevm:
+    "42161":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    ink:
+    "43114":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    linea:
+    "480":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    optimism:
+    "57073":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    polygon:
+    "59144":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    unichain:
+    "8453":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
-    worldchain:
+    "999":
       - bridge: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       - bridge: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
   contractVersion: 10.1.3
@@ -429,55 +533,81 @@ ethereum:
       arbitrum:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
     type: RoutingFee
   type: collateral
@@ -485,34 +615,34 @@ hyperevm:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    avalanche:
+    "10":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    base:
+    "130":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    ethereum:
+    "137":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    ink:
+    "42161":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    linea:
+    "43114":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    optimism:
+    "480":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    polygon:
+    "57073":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    unichain:
+    "59144":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
-    worldchain:
+    "8453":
       - bridge: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       - bridge: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
   contractVersion: 10.1.5
@@ -531,55 +661,81 @@ hyperevm:
       arbitrum:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
     type: RoutingFee
   type: collateral
@@ -587,34 +743,34 @@ ink:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    avalanche:
+    "10":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    base:
+    "130":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    ethereum:
+    "137":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    hyperevm:
+    "42161":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    linea:
+    "43114":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    optimism:
+    "480":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    polygon:
+    "59144":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    unichain:
+    "8453":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
-    worldchain:
+    "999":
       - bridge: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       - bridge: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
   contractVersion: 10.1.5
@@ -633,55 +789,81 @@ ink:
       arbitrum:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
     type: RoutingFee
   type: collateral
@@ -702,55 +884,81 @@ katana:
       arbitrum:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
     type: RoutingFee
   type: collateral
@@ -758,34 +966,34 @@ linea:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    avalanche:
+    "10":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    base:
+    "130":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    ethereum:
+    "137":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    hyperevm:
+    "42161":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    ink:
+    "43114":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    optimism:
+    "480":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    polygon:
+    "57073":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    unichain:
+    "8453":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    worldchain:
+    "999":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
   contractVersion: 10.1.5
@@ -804,55 +1012,81 @@ linea:
       arbitrum:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
     type: RoutingFee
   type: collateral
@@ -873,55 +1107,81 @@ monad:
       arbitrum:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
     type: RoutingFee
   type: collateral
@@ -929,34 +1189,34 @@ optimism:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    avalanche:
+    "130":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    base:
+    "137":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    ethereum:
+    "42161":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    hyperevm:
+    "43114":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    ink:
+    "480":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    linea:
+    "57073":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    polygon:
+    "59144":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    unichain:
+    "8453":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
-    worldchain:
+    "999":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
   contractVersion: 10.1.3
@@ -975,55 +1235,81 @@ optimism:
       arbitrum:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
     type: RoutingFee
   type: collateral
@@ -1031,34 +1317,34 @@ polygon:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    avalanche:
+    "10":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    base:
+    "130":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    ethereum:
+    "42161":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    hyperevm:
+    "43114":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    ink:
+    "480":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    linea:
+    "57073":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    optimism:
+    "59144":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    unichain:
+    "8453":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
-    worldchain:
+    "999":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
   contractVersion: 10.1.3
@@ -1077,55 +1363,81 @@ polygon:
       arbitrum:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
     type: RoutingFee
   type: collateral
@@ -1140,34 +1452,34 @@ unichain:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    avalanche:
+    "10":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    base:
+    "137":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    ethereum:
+    "42161":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    hyperevm:
+    "43114":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    ink:
+    "480":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    linea:
+    "57073":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    optimism:
+    "59144":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    polygon:
+    "8453":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
-    worldchain:
+    "999":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
   contractVersion: 10.1.3
@@ -1186,55 +1498,81 @@ unichain:
       arbitrum:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
         bps: 1.5
         owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
     type: RoutingFee
   type: collateral
@@ -1242,34 +1580,34 @@ worldchain:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    avalanche:
+    "10":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    base:
+    "130":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    ethereum:
+    "137":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    hyperevm:
+    "42161":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    ink:
+    "43114":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    linea:
+    "57073":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    optimism:
+    "59144":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    polygon:
+    "8453":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
-    unichain:
+    "999":
       - bridge: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       - bridge: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
   contractVersion: 10.1.5
@@ -1288,55 +1626,81 @@ worldchain:
       arbitrum:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
         bps: 1.5
         owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
     type: RoutingFee
   type: collateral

--- a/deployments/warp_routes/USDT/eclipsemainnet-deploy.yaml
+++ b/deployments/warp_routes/USDT/eclipsemainnet-deploy.yaml
@@ -2,13 +2,13 @@ arbitrum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    ethereum:
+    "1":
       - bridge: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
       - bridge: "0x9323793FB9a071ce5fE839079925c0e39f37170F"
-    plasma:
-      - bridge: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
-    tron:
+    "728126428":
       - bridge: "0x9323793FB9a071ce5fE839079925c0e39f37170F"
+    "9745":
+      - bridge: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
   decimals: 6
   name: USD₮0
   owner: "0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45"
@@ -25,19 +25,27 @@ arbitrum:
       bsc:
         bps: 15
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 6.4
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       plasma:
         bps: 10
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
         bps: 15
         owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
     type: RoutingFee
   type: collateral
@@ -58,19 +66,27 @@ bsc:
       arbitrum:
         bps: 15
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 15
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       plasma:
         bps: 15
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
         bps: 15
         owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
     type: RoutingFee
   type: collateral
@@ -87,13 +103,13 @@ ethereum:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "42161":
       - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
       - bridge: "0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B"
-    plasma:
-      - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
-    tron:
+    "728126428":
       - bridge: "0xC0dA8EF1225145E0b720d8A33471fa6360b7e73B"
+    "9745":
+      - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
   contractVersion: 11.1.0
   decimals: 6
   name: Tether USD
@@ -111,19 +127,27 @@ ethereum:
       arbitrum:
         bps: 3.1
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 15
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       plasma:
         bps: 10
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
         bps: 15
         owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
     type: RoutingFee
   type: collateral
@@ -131,9 +155,9 @@ plasma:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x93bfFA2231fbA5029997603fb68D9aC08024Baa2"
-    ethereum:
+    "42161":
       - bridge: "0x93bfFA2231fbA5029997603fb68D9aC08024Baa2"
   decimals: 6
   name: USDT0
@@ -151,19 +175,27 @@ plasma:
       arbitrum:
         bps: 10
         owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
         bps: 15
         owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
         bps: 10
         owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
         bps: 15
         owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
     type: RoutingFee
   type: collateral
@@ -181,9 +213,9 @@ tron:
   allowedRebalancers:
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    arbitrum:
+    "1":
       - bridge: "0x43Bb7C9C64a05af94d67B52883a60756950058D7"
-    ethereum:
+    "42161":
       - bridge: "0x43Bb7C9C64a05af94d67B52883a60756950058D7"
   decimals: 6
   name: Tether USD


### PR DESCRIPTION
## Summary

Exported deploy configs from the mainnet3 warp config getters after the getter changes in hyperlane-xyz/hyperlane-monorepo#9143.

Two categories of change in each file:

1. **Fee migration (the intended change).** Every EVM→EVM fee leg on `USDC/eclipsemainnet` and `USDT/eclipsemainnet` flips from `LinearFee` to `OffchainQuotedLinearFee`, adding `quoteSigners: [0xEd1829805De615eEFC7303766D395Ea0a1B2b04d]` (the Hyperlane quote signer). bps and owners are unchanged.
   - USDC: 182 legs flipped (route has no tron leg).
   - USDT: arbitrum/bsc/ethereum/plasma source legs flipped; the **tron source block stays on `LinearFee` on all 4 destinations, by design** (separate governance domain + flat-bps/reimburse model, per USDT/eni AW-675).

2. **`allowedRebalancingBridges` key re-sync (benign).** Keys change from chain names to domain IDs (e.g. `ethereum`→`1`, `arbitrum`→`42161`, `tron`→`728126428`, `plasma`→`9745`). This is pre-existing drift: the getter has emitted domain IDs since before this branch, and the eclipse files simply hadn't been re-exported. Same bridge addresses, same chains — matches the current convention already used by moonpay/citrea/igra exports.

Generated via `export-warp-configs.ts --environment mainnet3 --warpRouteIds USDC/eclipsemainnet USDT/eclipsemainnet`.

Draft — pairs with monorepo PR #9143; merge after that lands.

## Test plan
- [ ] Confirm the fee-leg flips match the intended OQLF migration
- [ ] Confirm tron USDT legs remain LinearFee
- [ ] warp apply fork simulation of generated txs (in progress)