### PR TITLE
chore: mark vana deprecated (ENG-4333)

### DIFF
--- a/.changeset/deprecate-vana.md
+++ b/.changeset/deprecate-vana.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Marked the vana chain as deprecated (availability status disabled) as part of the Vana paid-chain deprecation (ENG-4333).

--- a/chains/vana/metadata.yaml
+++ b/chains/vana/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://vanascan.io/api/eth-rpc
     family: blockscout


### PR DESCRIPTION
## Summary
- Mark the `vana` chain as deprecated: set `availability.status: disabled` with reason `deprecated`.
- Part of the Vana **paid-chain deprecation** (ENG-4333), contract-end date 2026-08-06.

## Context
- The two Vana warp routers (VANA native `0x96b5…6652`, ETH synthetic `0x3e6D…89aE`) are **already owned** by the customer multisig `0xDDF71a6ddf3FCABBbA4D607b57f0f6Fc0265bb84` (verified Gnosis Safe v1.4.1, 3/7).
- On-chain value negligible: VANA route empty both sides; ETH route has ~0.01001 ETH outstanding, fully backed on Ethereum.

Companion agent spin-down PR in hyperlane-monorepo.

Linear: https://linear.app/hyperlane-xyz/issue/ENG-4333/vana