### PR TITLE
feat: add Moonpay staging ALRB deploy config

### DIFF
--- a/.changeset/moonpay-staging-local-rebalancing-bridges.md
+++ b/.changeset/moonpay-staging-local-rebalancing-bridges.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Added the deployment config for Moonpay staging USDT-to-USDC atomic local rebalancing bridges on Arbitrum, Base, BSC, Ethereum, and Polygon. Deployed addresses and source-router wiring will follow after the staging rollout is validated.

--- a/.changeset/moonpay-staging-local-rebalancing-bridges.md
+++ b/.changeset/moonpay-staging-local-rebalancing-bridges.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': minor
 ---
 
-Added the deployment config for Moonpay staging USDT-to-USDC atomic local rebalancing bridges on Arbitrum, Base, BSC, Ethereum, and Polygon. Deployed addresses and source-router wiring will follow after the staging rollout is validated.
+Added the deployment config for Moonpay staging USDT-to-USDC atomic local rebalancing bridges on Arbitrum, Base, BSC, Ethereum, and Polygon, and prepared the staging USDT routers for the v12 upgrade. Deployed bridge addresses and source-router wiring will follow after the staging rollout is validated.

--- a/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-config.yaml
+++ b/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-config.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xbe103Cb39B205d8AcB9E71E29dF3A7FDB87716E2"
+    chainName: arbitrum
+    decimals: 6
+    name: Tether USD
+    standard: EvmAtomicLocalRebalancingBridge
+    symbol: mpALRB-STAGE
+    tokenType: atomicLocalRebalancing
+  - addressOrDenom: "0xFb2727dD89f39D5527d6ff4e05D61b02BF8cd492"
+    chainName: base
+    decimals: 6
+    name: Tether USD
+    standard: EvmAtomicLocalRebalancingBridge
+    symbol: mpALRB-STAGE
+    tokenType: atomicLocalRebalancing
+  - addressOrDenom: "0xb2638bD8B1D06255a9e8dBFdeec9af9Af718e8ac"
+    chainName: bsc
+    decimals: 18
+    name: Tether USD
+    standard: EvmAtomicLocalRebalancingBridge
+    symbol: mpALRB-STAGE
+    tokenType: atomicLocalRebalancing
+  - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
+    chainName: ethereum
+    decimals: 6
+    name: Tether USD
+    standard: EvmAtomicLocalRebalancingBridge
+    symbol: mpALRB-STAGE
+    tokenType: atomicLocalRebalancing
+  - addressOrDenom: "0x72ad40cAc1c1128B04Fea4fb07fd2449ba19Fe3e"
+    chainName: polygon
+    decimals: 6
+    name: USDT0
+    standard: EvmAtomicLocalRebalancingBridge
+    symbol: mpALRB-STAGE
+    tokenType: atomicLocalRebalancing

--- a/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-deploy.yaml
+++ b/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-deploy.yaml
@@ -1,5 +1,6 @@
 arbitrum:
   decimals: 6
+  mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   sourceRouter: "0xACe9bF07AaCfE54a14129561d09394850F3A5dDb"
@@ -7,6 +8,7 @@ arbitrum:
   type: atomicLocalRebalancing
 base:
   decimals: 6
+  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   sourceRouter: "0xF147AAE190F01aaB67152D97Ad3b157c3957BD77"
@@ -14,6 +16,7 @@ base:
   type: atomicLocalRebalancing
 bsc:
   decimals: 18
+  mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   scale:
@@ -24,6 +27,7 @@ bsc:
   type: atomicLocalRebalancing
 ethereum:
   decimals: 6
+  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   sourceRouter: "0x4628D301C4A1A32B4C7E753621b0787C32ee7475"
@@ -31,6 +35,7 @@ ethereum:
   type: atomicLocalRebalancing
 polygon:
   decimals: 6
+  mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   sourceRouter: "0x3382D9253eE54d49A90cBA41Cfc7b2704e713cEf"

--- a/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-deploy.yaml
+++ b/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-deploy.yaml
@@ -1,43 +1,38 @@
 arbitrum:
   decimals: 6
-  mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
-  sourceRouter: "0xACe97be96046876D0975b27E9E1F00e528E93e41"
+  sourceRouter: "0xACe9bF07AaCfE54a14129561d09394850F3A5dDb"
   symbol: mpALRB-STAGE
   type: atomicLocalRebalancing
 base:
   decimals: 6
-  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
-  sourceRouter: "0xF147BE6F30964Adca87D6ceCaC7e711bcd7bAa55"
+  sourceRouter: "0xF147AAE190F01aaB67152D97Ad3b157c3957BD77"
   symbol: mpALRB-STAGE
   type: atomicLocalRebalancing
 bsc:
   decimals: 18
-  mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   scale:
     denominator: 1000000000000
     numerator: 1
-  sourceRouter: "0xaC9e9B1cBc772a92C27086b04e2cF6aF959A3979"
+  sourceRouter: "0xaC9e83a1bDbC86a26aDf331785d3CaCF18963a6C"
   symbol: mpALRB-STAGE
   type: atomicLocalRebalancing
 ethereum:
   decimals: 6
-  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
-  sourceRouter: "0x462878C74432d706256c39D64d09dE9BC832df4B"
+  sourceRouter: "0x4628D301C4A1A32B4C7E753621b0787C32ee7475"
   symbol: mpALRB-STAGE
   type: atomicLocalRebalancing
 polygon:
   decimals: 6
-  mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
   name: Moonpay Staging Local Rebalancing Bridge
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
-  sourceRouter: "0x3382D9253eE54d49a90cBA41cFC7B2704e713cEF"
+  sourceRouter: "0x3382D9253eE54d49A90cBA41Cfc7b2704e713cEf"
   symbol: mpALRB-STAGE
   type: atomicLocalRebalancing

--- a/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-deploy.yaml
+++ b/deployments/warp_routes/CROSS/moonpay-staging-localbridge-usdt-deploy.yaml
@@ -1,0 +1,43 @@
+arbitrum:
+  decimals: 6
+  mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
+  name: Moonpay Staging Local Rebalancing Bridge
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  sourceRouter: "0xACe97be96046876D0975b27E9E1F00e528E93e41"
+  symbol: mpALRB-STAGE
+  type: atomicLocalRebalancing
+base:
+  decimals: 6
+  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+  name: Moonpay Staging Local Rebalancing Bridge
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  sourceRouter: "0xF147BE6F30964Adca87D6ceCaC7e711bcd7bAa55"
+  symbol: mpALRB-STAGE
+  type: atomicLocalRebalancing
+bsc:
+  decimals: 18
+  mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
+  name: Moonpay Staging Local Rebalancing Bridge
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1000000000000
+    numerator: 1
+  sourceRouter: "0xaC9e9B1cBc772a92C27086b04e2cF6aF959A3979"
+  symbol: mpALRB-STAGE
+  type: atomicLocalRebalancing
+ethereum:
+  decimals: 6
+  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
+  name: Moonpay Staging Local Rebalancing Bridge
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  sourceRouter: "0x462878C74432d706256c39D64d09dE9BC832df4B"
+  symbol: mpALRB-STAGE
+  type: atomicLocalRebalancing
+polygon:
+  decimals: 6
+  mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
+  name: Moonpay Staging Local Rebalancing Bridge
+  owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  sourceRouter: "0x3382D9253eE54d49a90cBA41cFC7B2704e713cEF"
+  symbol: mpALRB-STAGE
+  type: atomicLocalRebalancing

--- a/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
+++ b/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
@@ -55,6 +55,11 @@ base:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  rebalanceRecipients:
+    "8453": "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
+  rebalanceTargets:
+    "8453":
+      - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   token: "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2"
   type: crossCollateral
 bsc:
@@ -89,6 +94,90 @@ bsc:
     denominator: 1000000000000
     numerator: 1
   token: "0x55d398326f99059fF775485246999027B3197955"
+  tokenFee:
+    feeContracts:
+      arbitrum:
+        "0x0000000000000000000000009fb176528adf0bb7524ce752b2345c80ed24243f":
+          fallbackCurve:
+            breakpoints:
+              - "250000000000000000"
+              - "750000000000000000"
+            issuedAt: 0
+            marginalBps:
+              - 4
+              - 10
+              - 20
+          maxBands: 4
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedPiecewiseLinearFee
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+      base:
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+      bsc:
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+      citrea:
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+      ethereum:
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+      katana:
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+      polygon:
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+      solanamainnet:
+        "0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47":
+          bps: 3
+          owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+          quoteSigners:
+            - "0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867"
+            - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+          type: OffchainQuotedLinearFee
+    owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+    type: CrossCollateralRoutingFee
   type: crossCollateral
 ethereum:
   allowedRebalancers:

--- a/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
+++ b/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
@@ -2,7 +2,10 @@ arbitrum:
   allowedRebalancers:
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xbe103Cb39B205d8AcB9E71E29dF3A7FDB87716E2"
   allowedRebalancingBridges:
+    arbitrum:
+      - bridge: "0xbe103Cb39B205d8AcB9E71E29dF3A7FDB87716E2"
     bsc:
       - bridge: "0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11"
     ethereum:
@@ -29,13 +32,21 @@ arbitrum:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  rebalanceRecipients:
+    "42161": "0x0000000000000000000000009fb176528adf0bb7524ce752b2345c80ed24243f"
+  rebalanceTargets:
+    "42161":
+      - "0x0000000000000000000000009fb176528adf0bb7524ce752b2345c80ed24243f"
   token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
   type: crossCollateral
 base:
   allowedRebalancers:
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
+    - "0xFb2727dD89f39D5527d6ff4e05D61b02BF8cd492"
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
-  allowedRebalancingBridges: {}
+  allowedRebalancingBridges:
+    base:
+      - bridge: "0xFb2727dD89f39D5527d6ff4e05D61b02BF8cd492"
   contractVersion: 12.0.0
   crossCollateralRouters:
     "1":
@@ -66,9 +77,12 @@ bsc:
   allowedRebalancers:
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xb2638bD8B1D06255a9e8dBFdeec9af9Af718e8ac"
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0xc13d466B9E196AfdE472856923E857cc298EDf1b"
+    bsc:
+      - bridge: "0xb2638bD8B1D06255a9e8dBFdeec9af9Af718e8ac"
     ethereum:
       - bridge: "0xc13d466B9E196AfdE472856923E857cc298EDf1b"
   contractVersion: 12.0.0
@@ -90,6 +104,11 @@ bsc:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  rebalanceRecipients:
+    "56": "0x0000000000000000000000003382d9253ee54d49a90cba41cfc7b2704e713cef"
+  rebalanceTargets:
+    "56":
+      - "0x0000000000000000000000003382d9253ee54d49a90cba41cfc7b2704e713cef"
   scale:
     denominator: 1000000000000
     numerator: 1
@@ -183,12 +202,15 @@ ethereum:
   allowedRebalancers:
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+    - "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
       - bridge: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
     bsc:
       - bridge: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
+    ethereum:
+      - bridge: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
     polygon:
       - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
   contractVersion: 12.0.0
@@ -210,6 +232,11 @@ ethereum:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  rebalanceRecipients:
+    "1": "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
+  rebalanceTargets:
+    "1":
+      - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
   token: "0xdac17f958d2ee523a2206206994597c13d831ec7"
   type: crossCollateral
 katana:
@@ -238,12 +265,15 @@ katana:
 polygon:
   allowedRebalancers:
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
+    - "0x72ad40cAc1c1128B04Fea4fb07fd2449ba19Fe3e"
     - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0x361A7DA84A1f4A0c565772C45Ed838C6a0fAea94"
     ethereum:
       - bridge: "0x361A7DA84A1f4A0c565772C45Ed838C6a0fAea94"
+    polygon:
+      - bridge: "0x72ad40cAc1c1128B04Fea4fb07fd2449ba19Fe3e"
   contractVersion: 12.0.0
   crossCollateralRouters:
     "1":
@@ -263,5 +293,10 @@ polygon:
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  rebalanceRecipients:
+    "137": "0x000000000000000000000000a539ef6ef471c2d00d258540ab0bc38ed0b1f2ab"
+  rebalanceTargets:
+    "137":
+      - "0x000000000000000000000000a539ef6ef471c2d00d258540ab0bc38ed0b1f2ab"
   token: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
   type: crossCollateral

--- a/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
+++ b/deployments/warp_routes/USDT/moonpay-staging-deploy.yaml
@@ -1,15 +1,16 @@
 arbitrum:
   allowedRebalancers:
-    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    "1":
+    bsc:
+      - bridge: "0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11"
+    ethereum:
       - bridge: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
       - bridge: "0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11"
-    "137":
+    polygon:
       - bridge: "0xE4c1A1E54C232454311cF68610c3885FdD991c0E"
-    "56":
-      - bridge: "0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11"
+  contractVersion: 12.0.0
   crossCollateralRouters:
     "1":
       - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
@@ -27,13 +28,15 @@ arbitrum:
       - "0x000000000000000000000000927093cb2328d8632e8e7f63d562ce1f492e4436"
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
-  mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
   type: crossCollateral
 base:
   allowedRebalancers:
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
+  allowedRebalancingBridges: {}
+  contractVersion: 12.0.0
   crossCollateralRouters:
     "1":
       - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
@@ -51,19 +54,19 @@ base:
       - "0x000000000000000000000000927093cb2328d8632e8e7f63d562ce1f492e4436"
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
-  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2"
   type: crossCollateral
 bsc:
   allowedRebalancers:
-    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    "1":
+    arbitrum:
       - bridge: "0xc13d466B9E196AfdE472856923E857cc298EDf1b"
-    "42161":
+    ethereum:
       - bridge: "0xc13d466B9E196AfdE472856923E857cc298EDf1b"
+  contractVersion: 12.0.0
   crossCollateralRouters:
     "1":
       - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
@@ -81,7 +84,6 @@ bsc:
       - "0x000000000000000000000000927093cb2328d8632e8e7f63d562ce1f492e4436"
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
-  mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   scale:
     denominator: 1000000000000
@@ -90,16 +92,17 @@ bsc:
   type: crossCollateral
 ethereum:
   allowedRebalancers:
-    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    "137":
-      - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
-    "42161":
+    arbitrum:
       - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
       - bridge: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
-    "56":
+    bsc:
       - bridge: "0x647C621CEb36853Ef6A907E397Adf18568E70543"
+    polygon:
+      - bridge: "0x7Bb4fe8f406fB7B22487Fa2e3BCbCb6A38cF29E6"
+  contractVersion: 12.0.0
   crossCollateralRouters:
     "1":
       - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
@@ -117,7 +120,6 @@ ethereum:
       - "0x000000000000000000000000927093cb2328d8632e8e7f63d562ce1f492e4436"
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
-  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xdac17f958d2ee523a2206206994597c13d831ec7"
   type: crossCollateral
@@ -141,19 +143,19 @@ katana:
       - "0x000000000000000000000000927093cb2328d8632e8e7f63d562ce1f492e4436"
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
-  mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0x2DCa96907fde857dd3D816880A0df407eeB2D2F2"
   type: crossCollateral
 polygon:
   allowedRebalancers:
-    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
     - "0x2cB236403574301029c7bDDfda133c6e0338a857"
+    - "0xa3948a15e1d0778a7d53268b651B2411AF198FE3"
   allowedRebalancingBridges:
-    "1":
+    arbitrum:
       - bridge: "0x361A7DA84A1f4A0c565772C45Ed838C6a0fAea94"
-    "42161":
+    ethereum:
       - bridge: "0x361A7DA84A1f4A0c565772C45Ed838C6a0fAea94"
+  contractVersion: 12.0.0
   crossCollateralRouters:
     "1":
       - "0x000000000000000000000000b58c85c143f2032a77e2c2b08603453eba6c12af"
@@ -171,7 +173,6 @@ polygon:
       - "0x000000000000000000000000927093cb2328d8632e8e7f63d562ce1f492e4436"
     "8453":
       - "0x000000000000000000000000146fb3fcc2c9f547ee4f85a5b0497274cbd380d0"
-  mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
   token: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
   type: crossCollateral


### PR DESCRIPTION
## Summary

- add the generated five-chain deploy input for `CROSS/moonpay-staging-localbridge-usdt`
- bind Arbitrum, Base, BSC, Ethereum, and Polygon to the source routers in `USDT/moonpay-staging`
- add the generated phase-one `USDT/moonpay-staging` config with audited contract version `12.0.0` on those five chains
- leave Katana unchanged
- keep this PR independent from the production registry rollout

Depends on hyperlane-monorepo#9212 for SDK/CLI ALRB support and hyperlane-monorepo#9230 for the staging getters.

## Current rollout state

This PR contains the pre-deployment state:

- source-router config for the first `warp apply`
- ALRB input for `warp deploy`
- no placeholder ALRB addresses
- no ALRB source-router wiring before deployment

The `check-warp-deploy` job is expected to report `No warp route found` until the staging deployment writes the ALRB core output. Do not add placeholder addresses to satisfy that check.

## Post-deployment update to this PR

1. Run `hyperlane warp deploy --registry <this-worktree> --warp-route-id CROSS/moonpay-staging-localbridge-usdt`.
2. Inspect the five generated addresses and commit the resulting core config to this branch.
3. Regenerate `USDT/moonpay-staging-deploy.yaml` from hyperlane-monorepo#9230 after the output exists.
4. Confirm the regenerated config adds only USDT to USDC ALRB wiring.
5. Run the second `warp apply`, then `warp check` and USDT to USDC canaries.

## Validation

- registry build passed
- registry lint passed
- affected files pass format checking
- registry unit tests: 8,171 passed, 1 pending
- both generated deploy configs pass the support-branch schema
- ALRB deploy config also passes the registry current-dependency compatibility check
- all five source routers match the registered staging route
- no transaction was signed or broadcast

## Production gate

This PR is staging-only. No production registry output or production rollout should be added without explicit operator confirmation.
