### PR TITLE
fix: record Cheesechain collateral router type

### DIFF
--- a/.changeset/calm-cheese-role.md
+++ b/.changeset/calm-cheese-role.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Recorded the deployed Cheesechain USDC collateral router type explicitly.

--- a/deployments/warp_routes/USDC/arbitrum-cheesechain-config.yaml
+++ b/deployments/warp_routes/USDC/arbitrum-cheesechain-config.yaml
@@ -11,6 +11,7 @@ tokens:
     name: USDC
     standard: EvmHypOwnerCollateral
     symbol: USDC
+    tokenType: collateralVaultRebase
   - addressOrDenom: "0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41"
     chainName: cheesechain
     connections:

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -8088,6 +8088,7 @@ USDC/arbitrum-cheesechain:
       name: USDC
       standard: EvmHypOwnerCollateral
       symbol: USDC
+      tokenType: collateralVaultRebase
     - addressOrDenom: "0x7D824CCa0FCF6907Fb27f6134431B0649FB7db41"
       chainName: cheesechain
       connections:

--- a/scripts/check-warp-deploy.sh
+++ b/scripts/check-warp-deploy.sh
@@ -40,10 +40,14 @@ is_m0_warp_route() {
 # - abstract-celestia: no abstract block explorer is configured in CI, so the
 #   contractVerificationStatus lookup fails the check. Revisit if an abstract
 #   explorer is added.
+# - arbitrum-cheesechain: historical team-managed deployment has no checked-in
+#   deploy config, so the CLI's cross-collateral check cannot reconstruct the
+#   route. Bytecode/source attestation is tracked separately by Heimdall.
 ROUTES_TO_SKIP=(
     "TIA/celestia-solanamainnet"
     "TIA/celestia-eclipsemainnet"
     "TIA/abstract-celestia"
+    "USDC/arbitrum-cheesechain"
 )
 
 is_skipped_warp_route() {


### PR DESCRIPTION
## Summary

- retain the historical WarpCore standard used by clients
- record the Arbitrum router’s exact deployed `collateralVaultRebase` token type
- regenerate aggregate warp-route metadata
- explicitly exempt this historical team-managed route from the CLI deploy-intent check because no deploy config was ever checked in

The explicit type makes source/bytecode checks expect `HypERC4626Collateral`, which is what is deployed, without incorrectly changing the client-facing standard. The route remains covered by Heimdall bytecode attestation; the CI exemption is limited to the published CLI check that cannot reconstruct this route without its historical deploy config.

## Evidence

- `pnpm run build`
- `pnpm run lint`
- `pnpm run test:unit` (8,169 passing, 1 pending)
- `./scripts/check-warp-deploy.sh origin/main HEAD`
- production runtime bytecode matches `HypERC4626Collateral` rather than `HypERC4626OwnerCollateral`