### PR TITLE
chore: add Kiichain warp timelocks

### DIFF
--- a/.changeset/big-stamps-cheat.md
+++ b/.changeset/big-stamps-cheat.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added kiichain timelocks

--- a/.changeset/update-kii-timelocks.md
+++ b/.changeset/update-kii-timelocks.md
@@ -1,5 +1,0 @@
----
-'@hyperlane-xyz/registry': patch
----
-
-kii warp route deploy config was updated with timelocks for synthetic chains

--- a/.changeset/update-kii-timelocks.md
+++ b/.changeset/update-kii-timelocks.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+kii warp route deploy config was updated with timelocks for synthetic chains

--- a/deployments/warp_routes/KII/kiichain-deploy.yaml
+++ b/deployments/warp_routes/KII/kiichain-deploy.yaml
@@ -4,6 +4,11 @@ base:
   name: Kiichain
   owner: "0xaDa314c0177aD3BbBEff0D34707A15Ea0830dc14"
   symbol: KII
+  timelock:
+    delay: 259200
+    roles:
+      executor: "0xaDa314c0177aD3BbBEff0D34707A15Ea0830dc14"
+      proposer: "0xaDa314c0177aD3BbBEff0D34707A15Ea0830dc14"
   tokenFee:
     feeContracts:
       kiichain:
@@ -20,6 +25,11 @@ bsc:
   name: Kiichain
   owner: "0xB0C2698721Fa5F605a80E45beE81C33FE1a988b0"
   symbol: KII
+  timelock:
+    delay: 259200
+    roles:
+      executor: "0xB0C2698721Fa5F605a80E45beE81C33FE1a988b0"
+      proposer: "0xB0C2698721Fa5F605a80E45beE81C33FE1a988b0"
   tokenFee:
     feeContracts:
       kiichain:
@@ -36,6 +46,11 @@ ethereum:
   name: Kiichain
   owner: "0xB8e88116dAd2fE06045cC59bca7b63fFdbda2A52"
   symbol: KII
+  timelock:
+    delay: 259200
+    roles:
+      executor: "0xB8e88116dAd2fE06045cC59bca7b63fFdbda2A52"
+      proposer: "0xB8e88116dAd2fE06045cC59bca7b63fFdbda2A52"
   tokenFee:
     feeContracts:
       kiichain:
@@ -58,6 +73,11 @@ mantle:
   name: Kiichain
   owner: "0xcBDbef893cadc6B44E89f18b5fb45EA5554DC389"
   symbol: KII
+  timelock:
+    delay: 259200
+    roles:
+      executor: "0xcBDbef893cadc6B44E89f18b5fb45EA5554DC389"
+      proposer: "0xcBDbef893cadc6B44E89f18b5fb45EA5554DC389"
   tokenFee:
     feeContracts:
       kiichain:
@@ -74,6 +94,11 @@ polygon:
   name: Kiichain
   owner: "0xDAfE64C14D71c7b9E1CED61658d77903C02C52De"
   symbol: KII
+  timelock:
+    delay: 259200
+    roles:
+      executor: "0xDAfE64C14D71c7b9E1CED61658d77903C02C52De"
+      proposer: "0xDAfE64C14D71c7b9E1CED61658d77903C02C52De"
   tokenFee:
     feeContracts:
       kiichain:


### PR DESCRIPTION
## Summary
- add 3-day timelocks to KII synthetic warp route legs
- keep native kiichain leg unchanged
- include registry patch changeset

## Tests / checks
- `git diff --check`
- decoded generated tx payload and verified each tx only transfers ProxyAdmin ownership to the new timelock
- verified each timelock on-chain: code exists, delay is 259200, proposer/executor/canceller roles are set, admin is self-held

Related monorepo PR: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9244