### PR TITLE
chore: deprecate 11 mainnet chains (aug 13 batch)

### DIFF
--- a/.changeset/deprecate-aug-13-2026-chains.md
+++ b/.changeset/deprecate-aug-13-2026-chains.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Deprecated 11 mainnet chains that are ready for removal in H1 2026. Marked the following chains as disabled in their metadata: boba, botanix, hemi, morph, nibiru, noble, peaq, plume, prom, reactive, vana.

--- a/chains/boba/metadata.yaml
+++ b/chains/boba/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/288/etherscan/api
     family: routescan

--- a/chains/botanix/metadata.yaml
+++ b/chains/botanix/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan/api
     family: routescan

--- a/chains/hemi/metadata.yaml
+++ b/chains/hemi/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.hemi.xyz/api
     family: blockscout

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -1098,6 +1098,10 @@ bob:
     - http: https://rpc.gobob.xyz
   technicalStack: opstack
 boba:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/288/etherscan/api
       family: routescan
@@ -1168,6 +1172,10 @@ bobabnbtestnet:
   rpcUrls:
     - http: https://testnet.bnb.boba.network
 botanix:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/3637/etherscan/api
       family: routescan
@@ -3876,6 +3884,10 @@ hashkey:
     - http: https://mainnet.hsk.xyz
   technicalStack: other
 hemi:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.hemi.xyz/api
       family: blockscout
@@ -5849,6 +5861,10 @@ moonriver:
     - http: https://rpc.api.moonriver.moonbeam.network
     - http: https://moonriver.drpc.org
 morph:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer-api.morphl2.io/api
       family: blockscout
@@ -6112,6 +6128,10 @@ nexus:
     - http: https://mainnet.rpc.nexus.xyz
   technicalStack: other
 nibiru:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/6900/etherscan/api
       family: routescan
@@ -6138,6 +6158,10 @@ nibiru:
     - http: https://evm-rpc.nibiru.fi
   technicalStack: other
 noble:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   bech32Prefix: noble
   blockExplorers:
     - apiUrl: https://www.mintscan.io/noble
@@ -6595,6 +6619,10 @@ paradexsepolia:
   rpcUrls:
     - http: https://pathfinder.api.testnet.paradex.trade/rpc/v0_8
 peaq:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://peaq.subscan.io/api
       family: other
@@ -6674,6 +6702,10 @@ plasma:
     - http: https://rpc.plasma.to
   technicalStack: other
 plume:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.plume.org/api
       family: blockscout
@@ -6884,6 +6916,10 @@ poseidontestnet:
     - http: https://poseidon-testnet.rpc.caldera.xyz/http
   technicalStack: opstack
 prom:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://prom-blockscout.eu-north-2.gateway.fm/api/eth-rpc
       family: blockscout
@@ -7069,6 +7105,10 @@ rarichain:
     - http: https://mainnet.rpc.rarichain.org/http
   technicalStack: arbitrumnitro
 reactive:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://reactscan.net/api
       family: other
@@ -9403,6 +9443,10 @@ unitzero:
     - http: https://rpc.unit0.dev
   technicalStack: other
 vana:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://vanascan.io/api/eth-rpc
       family: blockscout

--- a/chains/morph/metadata.yaml
+++ b/chains/morph/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer-api.morphl2.io/api
     family: blockscout

--- a/chains/nibiru/metadata.yaml
+++ b/chains/nibiru/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/6900/etherscan/api
     family: routescan

--- a/chains/noble/metadata.yaml
+++ b/chains/noble/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 bech32Prefix: noble
 blockExplorers:
   - apiUrl: https://www.mintscan.io/noble

--- a/chains/peaq/metadata.yaml
+++ b/chains/peaq/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://peaq.subscan.io/api
     family: other

--- a/chains/plume/metadata.yaml
+++ b/chains/plume/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.plume.org/api
     family: blockscout

--- a/chains/prom/metadata.yaml
+++ b/chains/prom/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://prom-blockscout.eu-north-2.gateway.fm/api/eth-rpc
     family: blockscout

--- a/chains/reactive/metadata.yaml
+++ b/chains/reactive/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://reactscan.net/api
     family: other

--- a/chains/vana/metadata.yaml
+++ b/chains/vana/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://vanascan.io/api/eth-rpc
     family: blockscout


### PR DESCRIPTION
Marks the following chains as disabled (reason: deprecated) in chain metadata:

boba, botanix, hemi, morph, nibiru, noble, peaq, plume, prom, reactive, vana

bsquared was already marked disabled on main.

Tracker: **H1 2026 Chain Removals - Mainnet** (Linear) — these chains are in `Removal Planned` with past-due removal dates.

Supersedes #1642 (vana-only PR).

Companion monorepo PR disables agents/keyfunding and removes config references for the full set (incl. bsquared).