### PR TITLE
fix: add resilient Sei RPC fallbacks

### DIFF
--- a/.changeset/bright-seals-smile.md
+++ b/.changeset/bright-seals-smile.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added resilient public RPC fallbacks for Sei.

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -7613,6 +7613,8 @@ sei:
   protocol: ethereum
   rpcUrls:
     - http: https://evm-rpc.sei-apis.com
+    - http: https://evm-rpc-sei.stingray.plus
+    - http: https://sei-evm-rpc.publicnode.com
   technicalStack: other
 seismictestnet:
   blockExplorers:

--- a/chains/sei/metadata.yaml
+++ b/chains/sei/metadata.yaml
@@ -25,4 +25,6 @@ nativeToken:
 protocol: ethereum
 rpcUrls:
   - http: https://evm-rpc.sei-apis.com
+  - http: https://evm-rpc-sei.stingray.plus
+  - http: https://sei-evm-rpc.publicnode.com
 technicalStack: other


### PR DESCRIPTION
## Summary

- add Stingray and PublicNode public EVM RPC fallbacks for Sei
- regenerate the combined chain metadata
- include a patch changeset

The existing Foundation endpoint remains first for downstream consumers that use registry fallback order. Heimdall production will separately move its single explicit override away from that unhealthy endpoint.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test:unit` (8,169 passed, 1 pending)
- `pnpm exec changeset status`
- `pnpm exec oxfmt --check chains/sei/metadata.yaml .changeset/bright-seals-smile.md`