### PR TITLE
feat: switch Kiichain block explorer to Blockscout

### DIFF
--- a/.changeset/kiichain-blockscout-explorer.md
+++ b/.changeset/kiichain-blockscout-explorer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The Kiichain block explorer was switched to Blockscout (https://blockscout.kiichain.io).

--- a/chains/kiichain/metadata.yaml
+++ b/chains/kiichain/metadata.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://mainnet.explorer.kiichain.io/api
-    family: other
+  - apiUrl: https://blockscout.kiichain.io/api
+    family: blockscout
     name: KiiChain Explorer
-    url: https://mainnet.explorer.kiichain.io
+    url: https://blockscout.kiichain.io
 blocks:
   confirmations: 1
   estimateBlockTime: 2

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -4524,10 +4524,10 @@ kava:
     - http: https://kava.drpc.org
 kiichain:
   blockExplorers:
-    - apiUrl: https://mainnet.explorer.kiichain.io/api
-      family: other
+    - apiUrl: https://blockscout.kiichain.io/api
+      family: blockscout
       name: KiiChain Explorer
-      url: https://mainnet.explorer.kiichain.io
+      url: https://blockscout.kiichain.io
   blocks:
     confirmations: 1
     estimateBlockTime: 2


### PR DESCRIPTION
## Summary
- Switch the Kiichain block explorer to Blockscout at https://blockscout.kiichain.io
- Update `family` from `other` to `blockscout` and point `apiUrl`/`url` at the new host
- Regenerated the combined `chains/metadata.yaml` aggregate

## Verification
Blockscout endpoint is live (`v9.0.2`):
- `GET https://blockscout.kiichain.io/api/v2/config/backend-version` → `{"backend_version":"v9.0.2"}`
- `GET https://blockscout.kiichain.io/api?module=block&action=eth_block_number` → returns current block

🤖 Generated with [Claude Code](https://claude.com/claude-code)