### PR TITLE
chore: restore flowmainnet leg to TRUMP warp route

### DIFF
--- a/.changeset/restore-trump-flowmainnet-leg.md
+++ b/.changeset/restore-trump-flowmainnet-leg.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The flowmainnet leg of the TRUMP warp route was restored in the registry config to match on-chain router enrollment, which was never removed. This re-surfaces the leg in tooling and the Nexus UI so holders can bridge their Flow TRUMP out ahead of the Flow agent shutdown.

--- a/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-config.yaml
+++ b/deployments/warp_routes/TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain-config.yaml
@@ -5,7 +5,7 @@ tokens:
     connections:
       - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
       - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-      # - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
@@ -19,7 +19,7 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
       - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-      # - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
@@ -33,7 +33,7 @@ tokens:
     connections:
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
       - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-      # - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
@@ -42,20 +42,20 @@ tokens:
     name: OFFICIAL TRUMP
     standard: EvmHypSynthetic
     symbol: TRUMP
-  # - addressOrDenom: "0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760"
-  #   chainName: flowmainnet
-  #   connections:
-  #     - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
-  #     - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
-  #     - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-  #     - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
-  #     - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
-  #     - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
-  #   decimals: 18
-  #   logoURI: /deployments/warp_routes/TRUMP/logo.png
-  #   name: OFFICIAL TRUMP
-  #   standard: EvmHypSynthetic
-  #   symbol: TRUMP
+  - addressOrDenom: "0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760"
+    chainName: flowmainnet
+    connections:
+      - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
+      - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
+      - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
+      - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
+      - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
+      - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
+    decimals: 18
+    logoURI: /deployments/warp_routes/TRUMP/logo.png
+    name: OFFICIAL TRUMP
+    standard: EvmHypSynthetic
+    symbol: TRUMP
   - addressOrDenom: "0x8528bAa7d1d386E7967603e480fa2B558a23644c"
     chainName: form
     decimals: 18
@@ -69,7 +69,7 @@ tokens:
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
       - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
       - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-      # - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
     decimals: 18
@@ -85,7 +85,7 @@ tokens:
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
       - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
       - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-      # - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: ethereum|worldchain|0x0fC7b3518C03BfA5e01995285b1eF3c4B55c8922
     decimals: 6
@@ -100,7 +100,7 @@ tokens:
       - token: ethereum|arbitrum|0x5155EB1bcD30189915cF84717550Acfa537068bF
       - token: ethereum|avalanche|0x0e2A546a53678ee8F8605748193a8c114fA0317F
       - token: ethereum|base|0x53c0499e7E4aBD3e7994ca161523FD50A12Bb8C8
-      # - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
+      - token: ethereum|flowmainnet|0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760
       - token: ethereum|optimism|0xe36c02471e708a9f16da58168da744b059a1c6fe
       - token: sealevel|solanamainnet|21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS
     decimals: 18


### PR DESCRIPTION
### Description

Restores the `flowmainnet` leg of the TRUMP warp route in the registry config. It was commented out in #1304 (Dec 27, 2025) as a precaution during Flow evaluation, but **the on-chain routers were never unenrolled** — the Flow router (`0xD3378b419feae4e3A4Bb4f3349DBa43a1B511760`) remains mutually enrolled with all seven counterparties, including the Solana collateral (domain `1399811149`), and the reverse enrollment holds (e.g. arbitrum still lists Flow domain `1000000747`).

The registry entry has therefore been stale: the bridge functions on-chain, but the leg is hidden from Nexus and warp tooling. There is still **~12,330.83 TRUMP (~$17.4k)** of fully-backed synthetic supply held by ~507 holders on Flow.

This change re-surfaces the leg so holders can find and bridge their Flow TRUMP out **before the Flow agents are shut down (~Aug 21)**, after which relaying stops and the funds would be stranded.

The diff is a pure revert of #1304's config edit (un-commenting the six connection references and the `flowmainnet` token block); it is byte-identical to the pre-removal state apart from the later-added `scale` field.

### Backward compatibility

Yes — additive (restores a previously present leg).

### Testing

Verified on-chain enrollment in both directions with `cast` before restoring.