### PR TITLE
chore: deprecate 8 mainnet chains (aug 18 batch)

### DIFF
--- a/.changeset/deprecate-aug-18-2026-chains.md
+++ b/.changeset/deprecate-aug-18-2026-chains.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': minor
 ---
 
-Deprecated 8 mainnet chains that are ready for removal in H2 2026. Marked the following chains as disabled in their metadata: arcadia, bitlayer, hashkey, lumiaprism, matchain, oortmainnet, ronin, sonic.
+Deprecated 8 mainnet chains that are ready for removal in H2 2026. Arcadia was already disabled; marked bitlayer, hashkey, lumiaprism, matchain, oortmainnet, ronin, and sonic as disabled in their metadata.

--- a/.changeset/deprecate-aug-18-2026-chains.md
+++ b/.changeset/deprecate-aug-18-2026-chains.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': minor
+---
+
+Deprecated 8 mainnet chains that are ready for removal in H2 2026. Marked the following chains as disabled in their metadata: arcadia, bitlayer, hashkey, lumiaprism, matchain, oortmainnet, ronin, sonic.

--- a/chains/bitlayer/metadata.yaml
+++ b/chains/bitlayer/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api.btrscan.com/scan/api
     family: other

--- a/chains/hashkey/metadata.yaml
+++ b/chains/hashkey/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.hsk.xyz/api
     family: blockscout

--- a/chains/lumiaprism/metadata.yaml
+++ b/chains/lumiaprism/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.lumia.org/api/eth-rpc
     family: blockscout

--- a/chains/matchain/metadata.yaml
+++ b/chains/matchain/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://matchscan.io/api
     family: blockscout

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -988,6 +988,10 @@ berachain:
     - http: https://rpc.berachain.com
   technicalStack: other
 bitlayer:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api.btrscan.com/scan/api
       family: other
@@ -3857,6 +3861,10 @@ harmonytestnet:
   rpcUrls:
     - http: https://api.s0.b.hmny.io
 hashkey:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.hsk.xyz/api
       family: blockscout
@@ -4988,6 +4996,10 @@ lumia:
     - http: https://mainnet-rpc.lumia.org
   technicalStack: polygoncdk
 lumiaprism:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.lumia.org/api/eth-rpc
       family: blockscout
@@ -5147,6 +5159,10 @@ mantra:
     - http: https://evm.mantrachain.io
   technicalStack: other
 matchain:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://matchscan.io/api
       family: blockscout
@@ -6316,6 +6332,10 @@ ontology:
     - http: https://dappnode4.ont.io:10339
   technicalStack: other
 oortmainnet:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://mainnet-scan.oortech.com/api
       family: other
@@ -7361,6 +7381,10 @@ rometestnet2:
     - http: https://testnet-1.testnet.romeprotocol.xyz
   technicalStack: other
 ronin:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://app.roninchain.com/api
       family: other
@@ -8027,6 +8051,10 @@ soneiumtestnet:
   rpcUrls:
     - http: https://rpc.minato.soneium.org
 sonic:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
       apiUrl: https://api.etherscan.io/v2/api?chainid=146

--- a/chains/oortmainnet/metadata.yaml
+++ b/chains/oortmainnet/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://mainnet-scan.oortech.com/api
     family: other

--- a/chains/ronin/metadata.yaml
+++ b/chains/ronin/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://app.roninchain.com/api
     family: other

--- a/chains/sonic/metadata.yaml
+++ b/chains/sonic/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
     apiUrl: https://api.etherscan.io/v2/api?chainid=146


### PR DESCRIPTION
Marks the following chains as disabled (reason: deprecated) in chain metadata:

arcadia, bitlayer, hashkey, lumiaprism, matchain, oortmainnet, ronin, sonic

arcadia was already marked disabled on main.

Tracker: **H2 2026 Chain Removals - Mainnet** (Linear).

Companion monorepo PR disables agents/keyfunding and removes config references for the full set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only availability flags with no runtime or auth changes; consumers that respect disabled status may stop routing to these chains.
> 
> **Overview**
> Marks **seven mainnet chains** as registry-disabled with `availability.status: disabled` and `reasons: [deprecated]` in per-chain `metadata.yaml` and the consolidated `chains/metadata.yaml`: **bitlayer**, **hashkey**, **lumiaprism**, **matchain**, **oortmainnet**, **ronin**, and **sonic**. **arcadia** is listed in the changeset and PR scope but is not changed in this diff (already disabled on main).
> 
> Adds a **minor** `@hyperlane-xyz/registry` changeset documenting the Aug 18 batch ahead of planned H2 2026 removals; operational agent/config cutover is expected in the companion monorepo PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e314f129e621733f71c135a6f48e57d6ba0076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->