### PR TITLE
fix(warp): record on-chain ISM for USDC/appchain-base base leg

### DIFF
--- a/.changeset/usdc-appchain-base-ism.md
+++ b/.changeset/usdc-appchain-base-ism.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The USDC/appchain-base deploy config was updated to record the appchain-team-operated MESSAGE_ID_MULTISIG ISM (0x049B9DEa8276856812129c7b146E514Dd46B6634) on the base collateral leg, replacing the placeholder mailbox-default zero address, to match the on-chain configuration set during appchain's self-host handover.

--- a/deployments/warp_routes/USDC/appchain-base-deploy.yaml
+++ b/deployments/warp_routes/USDC/appchain-base-deploy.yaml
@@ -3,7 +3,7 @@ appchain:
   owner: "0xe3436b3335fa6d4f1b58153079FB360c6Aa83Fd9"
   type: synthetic
 base:
-  interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+  interchainSecurityModule: "0x049B9DEa8276856812129c7b146E514Dd46B6634"
   owner: "0xE3b50a565fbcdb6CC67B30bEB112f9e7FC855359"
   token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   type: collateral


### PR DESCRIPTION
## Summary
- The USDC/appchain-base **base** collateral leg's on-chain `interchainSecurityModule` is a custom **MESSAGE_ID_MULTISIG** (`0x049B9DEa8276856812129c7b146E514Dd46B6634`, 2-of-3), set during appchain's **self-host handover** (per @nambrot).
- The deploy config still declared the mailbox-default zero address, so the Warp Config Checker fired `WarpRoute-ConfigMismatch` on `interchainSecurityModule` (PagerDuty Q0BW1H2Z3RJ0SJ).
- This records the actual on-chain ISM so expected == actual and the alert clears.

## Context
- Confirmed intentional by Nam (warp-config-checker L2): appchain team is taking over operations from AW's deprecation. The multisig validator set (`0x43dbc3f4…`, `0xb88d602e…`, `0xe80e982a…`) is the appchain team's self-hosted set (non-canonical vs the former AW appchain default).
- appchain is **Removal Planned** — Linear ENG-3932 (H2 2026 Chain Removals - Mainnet, `self-host`, due 2026-08-21). If chain removal lands first, this route gets removed anyway; either path clears the alert.
- Only the base leg drifted; the appchain synthetic leg already matches the registry (`0x0`).

## Test plan
- [ ] `hyperlane warp check` (or the daily check-warp-deploy job) reports no `interchainSecurityModule` violation for USDC/appchain-base after merge + monitor redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)