### PR TITLE
feat(aleo): add edge.provable.com RPC as primary with fallback

### DIFF
--- a/.changeset/update-aleo-edge-rpc.md
+++ b/.changeset/update-aleo-edge-rpc.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+added the edge.provable.com/api/v2 rpc as the primary aleo endpoint and kept api.explorer.provable.com/v2 as a fallback

--- a/chains/aleo/metadata.yaml
+++ b/chains/aleo/metadata.yaml
@@ -24,5 +24,6 @@ nativeToken:
   symbol: ALEO
 protocol: aleo
 rpcUrls:
+  - http: https://edge.provable.com/api/v2
   - http: https://api.explorer.provable.com/v2
 technicalStack: other


### PR DESCRIPTION
## Summary
- Added `https://edge.provable.com/api/v2` as the primary Aleo RPC endpoint, keeping the existing `https://api.explorer.provable.com/v2` as a second fallback.

## Context
Four Aleo→Ethereum/Solana messages (nonces 174–177) were stuck `pending` because 3 of the 4 Aleo validators (Enigma, Luganodes, Mitosis) stalled behind the message index while only Abacus Works' validator stayed at tip — the Aleo ISM is 3-of-4, so quorum was unreachable. This tracked back to Aleo RPC/indexing access. Per <@U08GTGH9ULA> (confirmed the new endpoint is not private), this adds the new Provable Edge API endpoint as primary with the current one retained as fallback so validators can resume indexing to tip.

## Test plan
- [ ] Registry CI passes (schema + changeset checks)