### PR TITLE
fix: add collateral metadata to CCTP v2 routes

### DIFF
--- a/.changeset/backfill-cctp-v2-collateral-metadata.md
+++ b/.changeset/backfill-cctp-v2-collateral-metadata.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added underlying USDC collateral addresses and CoinGecko metadata to the CCTP V2 fast and standard warp routes.

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml
@@ -1,6 +1,8 @@
 tokens:
   - addressOrDenom: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
     chainName: arbitrum
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
       - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -23,6 +25,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
     chainName: avalanche
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -45,6 +49,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
     chainName: base
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -67,6 +73,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
     chainName: ethereum
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -89,6 +97,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
     chainName: hyperevm
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -111,6 +121,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
     chainName: ink
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -133,6 +145,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
     chainName: linea
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -155,6 +169,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
     chainName: optimism
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -177,6 +193,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x890CB8Dd7b6817b2Ab45b484264386ee48000F21"
     chainName: plume
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -199,6 +217,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
     chainName: polygon
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -221,6 +241,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x3Ce3585d2Fa9AfB4101Fd6007b0839ddCb5b9599"
     chainName: sei
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -243,6 +265,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x45935ea31cF8fd877122DB8D9c47065Bbc095135"
     chainName: sonic
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -265,6 +289,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
     chainName: unichain
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -287,6 +313,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
     chainName: worldchain
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
     connections:
       - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
       - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09

--- a/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml
+++ b/deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml
@@ -1,6 +1,8 @@
 tokens:
   - addressOrDenom: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
     chainName: arbitrum
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
     connections:
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
       - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -23,6 +25,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: avalanche
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -45,6 +49,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: base
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -67,6 +73,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
     chainName: ethereum
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -89,6 +97,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
     chainName: hyperevm
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -111,6 +121,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
     chainName: ink
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -133,6 +145,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: linea
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -155,6 +169,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: optimism
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -177,6 +193,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
     chainName: plume
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -199,6 +217,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: polygon
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -221,6 +241,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x346961e35b9a2ea5511AA5FC44DBF61Ab0f293F6"
     chainName: sei
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -243,6 +265,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: sonic
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -265,6 +289,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: unichain
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -287,6 +313,8 @@ tokens:
     symbol: USDC
   - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
     chainName: worldchain
+    coinGeckoId: usd-coin
+    collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
     connections:
       - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
       - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -9625,6 +9625,8 @@ USDC/mainnet-cctp-v2-fast:
   tokens:
     - addressOrDenom: "0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f"
       chainName: arbitrum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
       connections:
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
         - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -9647,6 +9649,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
       chainName: avalanche
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|base|0x31169ee5A8C0D680de74461d7B5394fFc7C3576B
@@ -9669,6 +9673,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x31169ee5A8C0D680de74461d7B5394fFc7C3576B"
       chainName: base
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9691,6 +9697,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07"
       chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9713,6 +9721,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0xe10b7b030C75C80359841CB0ec892E233F03f145"
       chainName: hyperevm
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9735,6 +9745,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x70CF23d09784fCA62be304c928BCA9F1801B1F21"
       chainName: ink
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9757,6 +9769,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
       chainName: linea
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9779,6 +9793,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30"
       chainName: optimism
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9801,6 +9817,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x890CB8Dd7b6817b2Ab45b484264386ee48000F21"
       chainName: plume
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9823,6 +9841,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872"
       chainName: polygon
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9845,6 +9865,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x3Ce3585d2Fa9AfB4101Fd6007b0839ddCb5b9599"
       chainName: sei
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9867,6 +9889,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x45935ea31cF8fd877122DB8D9c47065Bbc095135"
       chainName: sonic
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9889,6 +9913,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0xCB35d7730843F770625bE36A0E4228c17fDcBC09"
       chainName: unichain
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9911,6 +9937,8 @@ USDC/mainnet-cctp-v2-fast:
       tokenType: collateralCctp
     - addressOrDenom: "0x89aAa89D36F995b41d929f2D29b8Ee7C9c8e54cA"
       chainName: worldchain
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
       connections:
         - token: ethereum|arbitrum|0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f
         - token: ethereum|avalanche|0xCB35d7730843F770625bE36A0E4228c17fDcBC09
@@ -9935,6 +9963,8 @@ USDC/mainnet-cctp-v2-standard:
   tokens:
     - addressOrDenom: "0x4c19c653a8419A475d9B6735511cB81C15b8d9b2"
       chainName: arbitrum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
       connections:
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
         - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9957,6 +9987,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: avalanche
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|base|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -9979,6 +10011,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: base
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10001,6 +10035,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23"
       chainName: ethereum
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10023,6 +10059,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0xDdf252a063f8c5C399B9ccDBbaDBA55225F53Da1"
       chainName: hyperevm
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10045,6 +10083,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       chainName: ink
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x2D270e6886d130D724215A266106e6832161EAEd"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10067,6 +10107,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: linea
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x176211869cA2b568f2A7D4EE941E073a821EE1ff"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10089,6 +10131,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: optimism
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10111,6 +10155,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7"
       chainName: plume
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x222365EF19F7947e5484218551B56bb3965Aa7aF"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10133,6 +10179,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: polygon
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10155,6 +10203,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x346961e35b9a2ea5511AA5FC44DBF61Ab0f293F6"
       chainName: sei
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10177,6 +10227,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: sonic
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10199,6 +10251,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: unichain
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x078D782b760474a361dDA0AF3839290b0EF57AD6"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a
@@ -10221,6 +10275,8 @@ USDC/mainnet-cctp-v2-standard:
       tokenType: collateralCctp
     - addressOrDenom: "0x33e94B6D2ae697c16a750dB7c3d9443622C4405a"
       chainName: worldchain
+      coinGeckoId: usd-coin
+      collateralAddressOrDenom: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
       connections:
         - token: ethereum|arbitrum|0x4c19c653a8419A475d9B6735511cB81C15b8d9b2
         - token: ethereum|avalanche|0x33e94B6D2ae697c16a750dB7c3d9443622C4405a


### PR DESCRIPTION
### Description

- Backfill `collateralAddressOrDenom` from each chain's CCTP V2 deploy config for the fast and standard USDC routes.
- Add `coinGeckoId: usd-coin` to every route leg.
- Regenerate the combined warp route config.

### Backward compatibility

Yes. This adds missing token metadata without changing deployed route addresses or behavior.
