### PR TITLE
feat(warp-routes): record Eclipse USDC and USDT OQLF deployments

### DIFF
--- a/.changeset/update-eclipse-usdc-usdt-oqlf.md
+++ b/.changeset/update-eclipse-usdc-usdt-oqlf.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The Eclipse USDC and USDT EVM fee leaves were updated to use offchain-quoted linear fees.

--- a/.changeset/update-eclipse-usdc-usdt-oqlf.md
+++ b/.changeset/update-eclipse-usdc-usdt-oqlf.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/registry': patch
 ---
 
-The Eclipse USDC and USDT EVM fee leaves were updated to use offchain-quoted linear fees.
+The Eclipse USDC and USDT EVM fee leaves were updated to use offchain-quoted linear fees. The 13 Katana-origin USDC fallback fee targets were aligned from 1.5 bps to the live 10 bps configuration.

--- a/deployments/warp_routes/USDC/eclipsemainnet-deploy.yaml
+++ b/deployments/warp_routes/USDC/eclipsemainnet-deploy.yaml
@@ -46,57 +46,96 @@ arbitrum:
   tokenFee:
     feeContracts:
       avalanche:
+        address: "0xd7b2e2df3ee5a4e44b87b932d2a3029fcda27289"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x9f4e931cd45db7ac33e9156c99f4b326fc19c0cf"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x9f5ccdaaf460c50f7eb5053b4e45a55a9c233203"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x881936f95d37db4873770fe9fdd70517d1cf9063"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0xa27f838ed45abe57cac93cb6773c1bda66227c44"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0xfef6f2b93d790bb8b46425fc67a450fb7b318cdc"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0xca6e3647ff5a5c6b4b57e5526b3ae311413b91c6"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0x7d76d47fc53a959c0b3c60d5c10b5a2178c7c819"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0x29961a3c0164c4135796d82b2633cce1fea1b5d4"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0xcbe18e94b2571cd7cfcc8735d9ace81e6901f433"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x7d5f34dee3d60fae7f7a0d5a4a32c29ae96eeaa0"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x384b460e87f5075e6ec25f28ea0b612fd447dcc6"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xf7282606cb1e018e6d41926b0a06703e759e1353"
         bps: 1.5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -148,57 +187,96 @@ avalanche:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0xe56f68ce4cf9beb229644bc34aed7eaee1bffdc5"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0xc5c9a273f2155ebc3fc2e0ec93c7149de32842ba"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0xc36d6482857a224cceba3a1304a6cbf8e02b36c7"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x659f87e27bd6077a431b8cd67a6cd396e392c2fc"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0x0f9a3338ca44c41d6249a45bd30cf9d08e5aa3ee"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0xd225fa5c170591c9c5bb1b5f3e7900802a0a75ea"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0xa118a5310fc1cf3d03e561e7989d3e9a4ae9349e"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0x84fb7a7539f9e84518c5ca12c537cd13ff117bc6"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0xe53b32e3906adbb0091a3aa1dc087c5d696197cb"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0x587f4097f4d2551a71c12cb42aa885aa0916ce66"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0xa1be8c99e3104bed914ded6f1e33ff5055c71c11"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0xab8904aa0ee358db953a93466a3dd4513fb62127"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xa16e819e8ccbe39e81d6212aa4eb7b6aaab0448b"
         bps: 1.5
-        owner: "0xDE41E9C00B8aCb0e0013Bc197560e6bA5E7c3E67"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -250,57 +328,96 @@ base:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0xb39131c31fc707b22e494eb45bdc6e19f8ccc2aa"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0xe95a58be80357e4a9a976d1f2d77c4ababb8ffeb"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0xf0c8c5fc69fcc3fa49c319fdf422d8279756afe2"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x80ec25b6a65937f94d00b808b3f398b1d2ea76fc"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0x4735d7d700057a60be61151159999bf4d08c6221"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0xec5f5c15a0f083b185aad81f64e5242b16824f8d"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x16768c0cbe52c772e7af6b77cf04a2225299a89c"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0xf90a3d406c6f8321fe118861a357f4d7107760d7"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0xff9509808fbb87363fdc1bf0ec837245e87a703e"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0xb9125af8c297c13ddba4c19549675ba04827daab"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x314433d87cc59f5014e4891bc321871f70ac5e9d"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0xd219a59f3217cb667f623a9df0e75cf8f82a7433"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xf47216735f859b21cca076229f57bc52ad7b58a6"
         bps: 1.5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -319,57 +436,96 @@ bsc:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x09d416df7127823c19a1ae7e29a60719d3503e33"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0x8f3f27f71256da27d5b011e81104659e0a8a3458"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x282886328e2df188cdcc17e386b310710bfa68af"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0xcc4ffd9c2350064a3b5ee4701b44c0a9e5159cd8"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0xff3728a7c94c768004b4359f176a013447dc040e"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0x9cc9a7c749756f27d644ac846cf145fe4a05888c"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x68ddfb05f7cdaa7e28fca1d76c25218582061af4"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0xeb538d30c2ed7cc389a900e5e959cd116d332867"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0xdf0d9233d1fbe60f3c7d5936ceb038bf63d839a9"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0xdaefaf207fc1941242171cb91e6f4c45e0ec9c58"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x0416a8cf087db5a8eedef0186e3a9e011686aa75"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x70dcc5fe88ff94dae138b909c6c96354ba3d3315"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0x44648b80fe37f8db5620d419fb8578e03f253385"
         bps: 1.5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -427,57 +583,96 @@ ethereum:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x0a417d5afaf000b071fb6a15460f2dc9df0a5165"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0xf5f9cf6af895f1f3e0f4dd99f3827ba261651ba9"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x31e813444d0d7fcfbbbc8e91e66ea37ec2817666"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0xbe3b37604ce7f76025696ef5809f45c470e789a3"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0xc6ce686a5a5c7bad1f3f5bdefea466d9b67fc57c"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0x83b962f02714af324d542215233b8df7087aae4b"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x5a9644c4e0d594f9fbdfcb36a1137212e4c7a6af"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0x80f045a94c29176832a0923f9fb2537fd682ebd8"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0x78b0165aa8b8763d469a955d0b3149573cbe2052"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0xa322352d4498771e0f771e918630f7f057d61cda"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x09d61535440f52e045683f8b8bccc7bb0cb16b09"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x5edaae9c8eae595f01bab922b3df21651f8848e5"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0x33f3d8121ad5360a86787cddd53a7574d89db468"
         bps: 1.5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -529,57 +724,96 @@ hyperevm:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x5231dc31be50213fbd6e9a536cec37d8e06ca4a8"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0x324d0b921c03b1e42eefd198086a64bec3d736c2"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x6783dc9f1bf88dc554c8716c4c42c5bf640ddcc8"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x5e1a51c5654f55666e488c0d433bd180554548a7"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x13af971621321e42c009a7b9fee8f15e53a2a789"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0x9bde12a2496488feb5602047305f7904cb58a7b5"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x6c453d1234b19ad56c271bdfbc56f567f08e27b9"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0x7d11176446ba756cbedee6123cf8f825215f1b71"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0x004d9df774b1968989dcc9f2f389325ba61ba370"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0x609707355a53d2aab6366f48e2b607c599d26b29"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x855ee260ec267e9dcd47e86b1a8dea7213927f3f"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x421f92fe2360223cb057524a862d35310f4e3c9f"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0x521004d2c87f5129193b35f61fadc7ea1b937550"
         bps: 1.5
-        owner: "0x4831E1E44E907B5f12C660252f3B3b5483213C44"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -631,57 +865,96 @@ ink:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0xf0eb4487f134adfba4dd6e2e3335efa7072bad87"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0x065603eda09d395e015363df69a0d076edf24068"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x54f5bab7a95acac44947a62644e5b5f08a8b8de0"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x9f4a2d9f762faea363fff225b6518db07c8801de"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x297c766315be9d5add67dbaf80cfaaa097410284"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0x1ae0f9913b9277615a94eb78d4d438e708f67571"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x0bc8e181c04428301309dd1abff804c0ecf6b5a8"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0x03d6cc17d45e9ea27ed757a8214d1f07f7d901ad"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0x84c0ed8c9758a28afc923de50155cf0b4da4c1f9"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0x3647c108c1e011e376e086bf924c297ec875d519"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0xfc8f5272d690cf19732a7ed6f246adf5fb8708db"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0xebb66ab041d00ddadaaf051632101f49650d5dc0"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xa88ffcfc08553a68d0bf6dfd14a43d3aa5ffe567"
         bps: 1.5
-        owner: "0x77B326B3AE95973e875b2cb48C992e3F9B0A03d4"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -700,57 +973,96 @@ katana:
   tokenFee:
     feeContracts:
       arbitrum:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x1b947f6246ace28abaf073ff11c098f31ce4f899"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x855b4861d09c645ab38f56b476f1ed2f63c1e8ac"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x6fd7cfe005093ba658c1f294c20b229ceb5d4d97"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x977bea426b132a0fbb6f072f48520adb5eea4216"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0xdbace2d6a77558ff4c4db0a40a69e66d1e7226f8"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x34c76076248ab6caa626fed09d364c698347ab32"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x84289826bcd04b0a039b818039410563f8109309"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x04bd82ba84a165be5d555549ebb9890bb327336e"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x23d26a5fe6671b0c13e0970c15f595cf1e9a7785"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0xd9a9966e7da9a7f0032bf449fb12696a638e673c"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0xa87f683d055386e2b96ebd6f11e8da5e089a2527"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x1b101eff95d541590e955ce351a291148ae31835"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
-        bps: 1.5
-        owner: "0xB022F0D905ECa6e5272cE4ab0B0DEd9cD8441bF5"
-        type: LinearFee
+        address: "0x7712b534bf2b9fb7fa8d14ee83fdd077691a76c2"
+        bps: 10
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -802,57 +1114,96 @@ linea:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x17628b446a0fe13b495110c13fc41364e289ff7b"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0xcb203f48d9d4a0b95663ec15680b301634ce4104"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0xb41604b9cb92e1c5ae29646df8221468309c6499"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x32d4d8252ad91f55221ba0fca5edf22a8251b1e9"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0xba415982043d9affb488d36d6b2797a893025b53"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0x2754b3b4829b5ad5139f43aa428eeadaac154fe5"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0xf2e1129e97b32182358572cb093ff2dd54fc25fb"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x6c0952d074436382995af7f7daa466c513de2676"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0xf0d3f541c47ded11bb7cd6e31b58bab779e9a5d0"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0x2f3d24f1fa44c92c786f32255e0154e2947f594d"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0xe50dea401ed22abc75559d411b9cff819c324d3b"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x9374e2fd486356a3e16cb5ce8483a7f295628a9f"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xf4078eb7f881bcc321615a3cf96d6e35b31b1609"
         bps: 1.5
-        owner: "0x0085f0Cd2B9c7faadee696496E110687841628BD"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -871,57 +1222,96 @@ monad:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0xea1d1ac1d0709441a25e1746ae1c724ecdfb19f0"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0xc1c8760b7be3901a2fb6f8ecf2829552721d0fff"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x97e4682dbc4bfd432f1563a7fa9ac218bc48c861"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x094c609bfae070e07a465448491090edc796773e"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x9e4d5757890fa794d2c7af3bba533eee0150cd94"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0xa7e266a40927244d13981246d35b2419071881c8"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0xefad3f079048be2765b6bcfaa3e9d99e9a2c3df6"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0xcfe6dbad47c3b8cf4fecbb28b53df4617f8538a7"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0xf92c96f548931d4dbd733498b2b369c3cd27ee16"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0x850615df99fec6edffc77ff246f604a6f7df6a78"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x30494d0232acaf4d1ca7fa330c1228296e7f2e2c"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0xa4a0bb78658e91350f3f2a3028d404ab81dfe490"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xe7baaad9657ab13b01a208daa350bbac1feae51a"
         bps: 1.5
-        owner: "0x439d4a5b5F756d305354C41EB297B4d1f571ef56"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -973,57 +1363,96 @@ optimism:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0xb138fcd46b4d2ea94cd1bef06e70464df7282c22"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0x96a7a231d974b38064344c682d9a6e9986d62953"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x84dfe346f8f15e6814df1ea25cda968517862b11"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x2f0c66b5d4e268cdd8a63842054863957b41a3d1"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x8f4f46a59672dff36c168ebb3cf5871435815a14"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0x52d02e5ae467423e1a1d29dc1de2ac3e8e1df75b"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0x73c9627aedbce75247e1c8e05ed1a42b846a1d41"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x31b9d5f6cb835785b58c6279cb540be61d766b55"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0x4565cb98e10153372e2a5e0b7aed13afc32927b1"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0x4751aaf36aea381c28175423eee6efc992d03f05"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x821a707538e95a09a83788b304a09a5e47763e53"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x532b4327c4eb771ebeff74b93bdfc62d753a38ec"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xf1e57b85857118c203eab30743624397680be30d"
         bps: 1.5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -1075,57 +1504,96 @@ polygon:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x2295dd37b7f5a47ef2638eaa1c2316172aaa3c73"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0x5e166b108376d74911abb17d2918c7e6a5c1bff7"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0xfb1d7e6e4b999310a16374029f21350d2eb55b34"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0xad0b70cc608a662a59175245111f66d916c5c01f"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x113703331a439d49f11c567fc476826b80b31d3d"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0x3fc07dce3d66b5254c7d2361e9a2b8fa04adba03"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0xc57f04a6447e45f2643ddb11634cad308c7206a0"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0xfbec4f9e34928656053b3806101966a5ad732715"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0xfed1b602846417b65ec803c90cf9ff20ba9bacdb"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0x8f2fa118211f037a05c670e679c70a08179fc8cd"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0xf87618bb6cb772ed217b89ab535534a0a8a7f576"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x7f0f0afc26c670a71447ca5300fceae30abd2bac"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xa21ebe78a761890a8ca759a4a2cd625b113b977d"
         bps: 1.5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -1184,57 +1652,96 @@ unichain:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0xd69098235a74a16cdb76778368d2c3b05d532857"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0xbeeaff01197c7a4001b53e5fd384ae70be1a8399"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0xb824890e800c23693d6e2c7fdd5619752ad1f9df"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0xd6223d79f9850bc745912751f689509be92102fd"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x70683303cb16d5f3e8a7034486f87b2018116c75"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0xc54dc1dd81b5a4a17c3bbb126222f15ffa8e216b"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0x539060c14675bd2549877e429188f91e310a3195"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0xc671ad3298bbfb5bf73ac2f0c9ab7d88f2919358"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0xb04e72a0f46ae927677d826334ddaebf2a5ae8c8"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0xab2a08ec150d8c008ea715df6079bcc49e67be1a"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0xcfe5d156cf6882d90209dc2b6e4b2ef46c34167f"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x0408e8bb5936e295c3f40f53e622ff46b93a6704"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       worldchain:
+        address: "0xf222c902634860d84318298f9c47d06fb73c3641"
         bps: 1.5
-        owner: "0x7AAe345547E3DCf10d907F04202D454f82Ae3525"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -1286,57 +1793,96 @@ worldchain:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x3c330d4a2e2b8443afab8e326e64ab4251b7eae0"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       avalanche:
+        address: "0x84fcd67d2b723416e2afdd61484bd19bd9c32f27"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       base:
+        address: "0x10a4ce4dc3a14437e260808cc66a9cb544926e18"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x4fe98d56ea08f554c57035f7719670b7278ee941"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x02e4298a0d15410c4dfb36bb2de89c0e3641190f"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       hyperevm:
+        address: "0x4239ae3002e497b6f9e237a7d32f15924810c296"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ink:
+        address: "0x2022fde54271f5cf14c877ad486764dffec8ca20"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       katana:
+        address: "0x50008d8280c1c9465e9b88a6a97e666b8b598583"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       linea:
+        address: "0x06ca75aff13f2ad106b1880b43296d2f0cef140a"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       monad:
+        address: "0xa51d42185a426aac03c55705b72ef4efe839326e"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       optimism:
+        address: "0x5e8b4e6ff310c6919f3bb507747140fa5479f1f0"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       polygon:
+        address: "0x5f2edcb339c19ae0e13e1b98be11a5d8e583aa0a"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       unichain:
+        address: "0x43320f6b410322bf5ca326a0deaaa6a2fc5a021b"
         bps: 1.5
-        owner: "0xD9F36efa46100fB11AE6546CAb532e52974E4c18"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral

--- a/deployments/warp_routes/USDT/eclipsemainnet-deploy.yaml
+++ b/deployments/warp_routes/USDT/eclipsemainnet-deploy.yaml
@@ -23,21 +23,33 @@ arbitrum:
   tokenFee:
     feeContracts:
       bsc:
+        address: "0xB825843ef06D8f974894fF73aC0A4eaD1e27340C"
         bps: 15
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0xBDe3c4b03125B4B30b38164562c0efD6131Ee4e9"
         bps: 6.4
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       plasma:
+        address: "0xC814441c14CeCCEA55810097cc31CA9Ecf0b44A2"
         bps: 10
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
+        address: "0x1eFbBFa7f376264a921b835e79Cd65463e8252D1"
         bps: 15
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -56,21 +68,33 @@ bsc:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x679E79B772Df35396Cb644C09C387C294b6c4495"
         bps: 15
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x1403e4Da6a459162BBC5163FE79Bf1Dc28058168"
         bps: 15
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       plasma:
+        address: "0xBDbbCdFc69854f781e90548C7d9d48fc59584508"
         bps: 15
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
+        address: "0x06AE6e3Cc4cFf657323bC90b55A43e42C6a2D21E"
         bps: 15
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -109,21 +133,33 @@ ethereum:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x403651923E79C22C8d04a75ad8Ea92077c0c932b"
         bps: 3.1
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0x7aEA5Ecc2011B1F90bCDEf7d6faBb42E4e266c50"
         bps: 15
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       plasma:
+        address: "0xAA4aD2596D9C4390770600E7D93fcb08da867D7B"
         bps: 10
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
+        address: "0xb1C18875d674557776475f96441BD09D41Eed8dd"
         bps: 15
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral
@@ -149,21 +185,33 @@ plasma:
   tokenFee:
     feeContracts:
       arbitrum:
+        address: "0x4c50799aD95eF0DF91fF26dd406a068D0a28b4E8"
         bps: 10
-        owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       bsc:
+        address: "0xB504EA900302C7Faf24Cc4F155006d6c0357Dc35"
         bps: 15
-        owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       ethereum:
+        address: "0x6d93817FF18DFe745b8C268F8cf22CD9F5E2CDAb"
         bps: 10
-        owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
       tron:
+        address: "0x64D8b60C2d5F4FF35D61B3f039df327618FD0896"
         bps: 15
-        owner: "0x5BeF46e59b0D12C8C9806b05dA9cdcB7064a0Da9"
-        type: LinearFee
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
+        quoteSigners:
+          - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
+        type: OffchainQuotedLinearFee
     owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
     type: RoutingFee
   type: collateral


### PR DESCRIPTION
## Summary

- Records 182 deployed USDC and 16 deployed USDT `OffchainQuotedLinearFee` leaves.
- Sets each new leaf owner to the Warp Fees Turnkey signer and configures the shared quote signer.
- Records the now-live parent `RoutingFee` pointers.
- Preserves the intentional USDT Tron `LinearFee` configuration.
- Pins the 13 Katana-origin USDC lanes to their existing 10 bps target.

## Deployment and execution

The new leaves were deployed with the normal mainnet3 EVM deployer. After review, the dedicated Warp Fees Turnkey signer executed both reviewed file batches on 2026-08-21:

- USDC: 182/182 `RoutingFee.setFeeContract` calls confirmed across 14 parent contracts; source SHA-256 `3309d40afb6d14097ac849b87f95ea1e2c23e364c0ef1588d011a5c9a40eebf2`.
- USDT: 16/16 calls confirmed across 4 parent contracts; source SHA-256 `e8b0eaa4d36c9c4f13c71cae45cbdc3e37f5a658d84f53fc0f5b02b3999a3029`.
- Every receipt has status `1`; every call used selector `0x16068373`.
- Tron was not changed.

The USDC CLI run encountered confirmation timeouts on Ethereum and HyperEVM. Timed-out hashes were verified on chain before non-overlapping remainder batches were created. The USDT batch completed without interruption.

## Validation

- Read back all 198 leaves on chain: type, owner, token, quote signer, `maxFee`, and `halfAmount` match this config.
- Live USDC `warp check`: `No violations found` (exit 0).
- Live USDT `warp check`: `No violations found` (exit 0).
- Direct HyperEVM readback on Alchemy and Dwellir matches all 13 target pointers. Chainstack was excluded from the final check because its `eth_call(latest)` returned stale pre-update state despite correct canonical receipts and explicit-block reads.
- Explorer verification was skipped for Linea, Optimism, Unichain, and World Chain during the final config checks because the configured Etherscan key returned `Invalid API Key`; the preceding run showed no route differences beyond those verification errors.
- Loaded both configs through the local HTTP registry in write mode with private RPC metadata.
- `pnpm build`.
- `oxfmt --check` on both route configs.
- Changeset validation.

## Context

- CLI external-signer/Turnkey flow: [hyperlane-monorepo#9299](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9299) (merged).
- Infra getter/strategy changes: [hyperlane-monorepo#9143](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9143) (ready, intentionally not merged yet).

A prior partial deployment produced 99 unused USDC OQLFs. They were never linked by a parent RoutingFee and hold no user funds; this PR records the final 182-leaf USDC set.
