### PR TITLE
feat: add pausable aggregation ISM to KII warp route

### DIFF
--- a/deployments/warp_routes/KII/kiichain-deploy.yaml
+++ b/deployments/warp_routes/KII/kiichain-deploy.yaml
@@ -13,6 +13,8 @@ base:
   mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
   name: Kiichain
   owner: "0xaDa314c0177aD3BbBEff0D34707A15Ea0830dc14"
+  proxyAdmin:
+    owner: "0xf3739cE0bE7D3Ea9f9fA786dE5D2BD7A83aFA806"
   symbol: KII
   tokenFee:
     feeContracts:
@@ -39,6 +41,8 @@ bsc:
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: Kiichain
   owner: "0xB0C2698721Fa5F605a80E45beE81C33FE1a988b0"
+  proxyAdmin:
+    owner: "0x4a88c11B2a354CB924F3f6622216A74e30BcD9Ad"
   symbol: KII
   tokenFee:
     feeContracts:
@@ -65,6 +69,8 @@ ethereum:
   mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
   name: Kiichain
   owner: "0xB8e88116dAd2fE06045cC59bca7b63fFdbda2A52"
+  proxyAdmin:
+    owner: "0x7DF42bc2F3C8f94E1ed834deE49f6dC0d4Dc0Cdd"
   symbol: KII
   tokenFee:
     feeContracts:
@@ -97,6 +103,8 @@ mantle:
   mailbox: "0x398633D19f4371e1DB5a8EFE90468eB70B1176AA"
   name: Kiichain
   owner: "0xcBDbef893cadc6B44E89f18b5fb45EA5554DC389"
+  proxyAdmin:
+    owner: "0xef2489b56B0cF473883a20C1B552bA96aEf6BD71"
   symbol: KII
   tokenFee:
     feeContracts:
@@ -123,6 +131,8 @@ polygon:
   mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
   name: Kiichain
   owner: "0xDAfE64C14D71c7b9E1CED61658d77903C02C52De"
+  proxyAdmin:
+    owner: "0x7f34B47FF42e2D7c3E5A4862C8e083ad0850828A"
   symbol: KII
   tokenFee:
     feeContracts:

--- a/deployments/warp_routes/KII/kiichain-deploy.yaml
+++ b/deployments/warp_routes/KII/kiichain-deploy.yaml
@@ -1,5 +1,15 @@
 base:
   decimals: 18
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: pausableIsm
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: true
+      - type: defaultFallbackRoutingIsm
+        owner: "0xaDa314c0177aD3BbBEff0D34707A15Ea0830dc14"
+        domains: {}
   mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
   name: Kiichain
   owner: "0xaDa314c0177aD3BbBEff0D34707A15Ea0830dc14"
@@ -16,6 +26,16 @@ base:
 
 bsc:
   decimals: 18
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: pausableIsm
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: true
+      - type: defaultFallbackRoutingIsm
+        owner: "0xB0C2698721Fa5F605a80E45beE81C33FE1a988b0"
+        domains: {}
   mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
   name: Kiichain
   owner: "0xB0C2698721Fa5F605a80E45beE81C33FE1a988b0"
@@ -32,6 +52,16 @@ bsc:
 
 ethereum:
   decimals: 18
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: pausableIsm
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: true
+      - type: defaultFallbackRoutingIsm
+        owner: "0xB8e88116dAd2fE06045cC59bca7b63fFdbda2A52"
+        domains: {}
   mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
   name: Kiichain
   owner: "0xB8e88116dAd2fE06045cC59bca7b63fFdbda2A52"
@@ -54,6 +84,16 @@ kiichain:
 
 mantle:
   decimals: 18
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: pausableIsm
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: true
+      - type: defaultFallbackRoutingIsm
+        owner: "0xcBDbef893cadc6B44E89f18b5fb45EA5554DC389"
+        domains: {}
   mailbox: "0x398633D19f4371e1DB5a8EFE90468eB70B1176AA"
   name: Kiichain
   owner: "0xcBDbef893cadc6B44E89f18b5fb45EA5554DC389"
@@ -70,6 +110,16 @@ mantle:
 
 polygon:
   decimals: 18
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: pausableIsm
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: true
+      - type: defaultFallbackRoutingIsm
+        owner: "0xDAfE64C14D71c7b9E1CED61658d77903C02C52De"
+        domains: {}
   mailbox: "0x5d934f4e2f797775e53561bB72aca21ba36B96BB"
   name: Kiichain
   owner: "0xDAfE64C14D71c7b9E1CED61658d77903C02C52De"


### PR DESCRIPTION
## Summary

Adds a pauser-controlled kill switch to the **KII** warp route by setting each EVM leg's route ISM (currently `0x0` → mailbox default) to a **threshold-2 `staticAggregationIsm`** of:

- **`pausableIsm`** — owner = dedicated Turnkey pauser `0x60Cc386C85717CB51C2827A75e14826883dF5da4`, deployed `paused: true`
- **`defaultFallbackRoutingIsm`** — owner = that leg's route-owner ICA, `domains: {}` (delegates to the mailbox default ISM)

Legs changed: **base, bsc, ethereum, mantle, polygon**. Kiichain's own leg is omitted (native source leg, chain currently halted, undeployable).

## Why aggregation (not a bare PausableIsm)

A bare `PausableIsm` returns `true` on `verify` when unpaused → zero security → resuming would require a fresh ICA `setInterchainSecurityModule`. Threshold-2 aggregation fixes this:

- **Paused** → pausable submodule reverts → threshold unreachable → **all inbound KII blocked**.
- **Unpaused** → fallback routing delegates to the real mailbox-default multisig security.

So pause/resume is a **pauser-only toggle** — no owner/ICA action needed to turn messages back on. This is Hyperlane's standard default-ISM shape.

## Context

Response to an active exfiltration incident: an attacker-controlled flow is bridging large amounts of KII out of Kiichain (BSC is the active target). The bridge itself is fully collateralized — this is a customer-side compromise, not a Hyperlane protocol exploit — but this kill switch lets us halt inbound delivery on the destination legs while the situation is contained.

## Validation

- Config parses against `WarpRouteDeployConfigSchema` (all 5 EVM legs → `staticAggregationIsm[pausableIsm, defaultFallbackRoutingIsm]`, thr 2).
- BSC mainnet fork sim (real contracts via SDK ISM factory): deployed aggregation, pauser `pause()`, ICA `setInterchainSecurityModule` → inbound `verify` reverts `Pausable: paused` (blocked); pauser `unpause()` → security falls back to mailbox default (restored, no ICA re-set).

## Deployment (post-merge, two signers per leg)

1. Deploy agg ISM (permissionless) + Turnkey pauser `pause()` (`0x8456cb59`) on the pausable submodule.
2. Route-owner ICA `setInterchainSecurityModule(agg)` (`0x0e72cc06`) via ETH 4/7 Safe → ETH InterchainAccountRouter `callRemote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)