### PR TITLE
chore: remove NES/bsc route from warp route allowlist

### DIFF
--- a/.changeset/remove-nes-bsc-allowlist.md
+++ b/.changeset/remove-nes-bsc-allowlist.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+the NES/bsc warp route was removed from the universal router engine allowlist to stop bridging the route

--- a/deployments/warp_routes/warpRouteAllowlist.yaml
+++ b/deployments/warp_routes/warpRouteAllowlist.yaml
@@ -422,9 +422,6 @@ warpRouteIds:
   # rise
   - RISE/bsc-ethereum
 
-  # Nesa routes
-  - NES/bsc
-
   # fluent
   - BLEND/fluent
   - USDnr/usdnr


### PR DESCRIPTION
Removes the `NES/bsc` warp route from the universal router engine allowlist (`deployments/warp_routes/warpRouteAllowlist.yaml`) so it is no longer offered as a bridge-only route in the router engine / Nexus UI.

Part of the NES route halt: the relayer already blacklists this route (monorepo #9326, merged) and a pausable-aggregation ISM is being set up on-chain (registry #1667).

Requested by @Xaroz  / @troykessler .

| Field | Value |
| ----- | ----- |
| **Route removed** | `NES/bsc` |