### PR TITLE
feat(warp-routes): NES pausable domain-routing hook (block nesa + solanamainnet)

### DIFF
--- a/.changeset/update-nes-pausable-domain-routing-hook.md
+++ b/.changeset/update-nes-pausable-domain-routing-hook.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+the NES warp route deploy config now sets a fallback routing hook on every EVM leg that routes transfers destined for nesa and solanamainnet through a 2/2 aggregation hook (pausable + default), with the pausable hook initially paused to block those transfers

--- a/deployments/warp_routes/NES/bsc-deploy.yaml
+++ b/deployments/warp_routes/NES/bsc-deploy.yaml
@@ -1,5 +1,25 @@
 arbitrum:
   decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
       - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
@@ -17,6 +37,26 @@ arbitrum:
   type: synthetic
 base:
   decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
       - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
@@ -34,6 +74,26 @@ base:
   type: synthetic
 bsc:
   decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
       - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
@@ -51,6 +111,26 @@ bsc:
   type: synthetic
 ethereum:
   decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
       - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
@@ -68,6 +148,26 @@ ethereum:
   type: synthetic
 hyperevm:
   decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
       - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
@@ -85,6 +185,19 @@ hyperevm:
   type: synthetic
 nesa:
   decimals: 18
+  hook:
+    domains:
+      solanamainnet:
+        hooks:
+          - owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
+    type: fallbackRoutingHook
   mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
   owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
   type: native


### PR DESCRIPTION
Adds a post-dispatch `hook` to every EVM leg of the `NES/bsc` route (arbitrum, base, bsc, ethereum, hyperevm, nesa) that blocks outbound transfers destined for **nesa** and **solanamainnet**, initially paused.

### Structure (per EVM leg)
```
hook:
  type: fallbackRoutingHook
  owner: <leg owner>
  domains:
    nesa:            # 2/2 aggregation hook
      type: aggregationHook
      hooks:
        - { type: pausableHook, paused: true, owner: <leg owner> }
        - { type: defaultHook }
    solanamainnet:   # 2/2 aggregation hook
      type: aggregationHook
      hooks:
        - { type: pausableHook, paused: true, owner: <leg owner> }
        - { type: defaultHook }
  fallback:
    type: defaultHook   # all other destinations: normal delivery
```

- **Pausable initially `paused: true`** → `postDispatch` reverts for nesa/solanamainnet destinations → those transfers are blocked at dispatch time.
- Unpausing (owner tx) restores normal delivery for those destinations (aggregation's `defaultHook` path).
- `nesa` leg routes only `solanamainnet` (nesa→nesa is impossible).
- `solanamainnet` leg is Sealevel — its `hook` remains the existing program address (EVM-style hook config not expressible there); the EVM legs already block sends *to* solanamainnet.

Complements the on-chain ISM halt (#1667) and the relayer blacklist (monorepo #9326) and allowlist removal (#1668).

Requested by @Troy. Owners per leg match the existing route/ISM owners.