### PR TITLE
fix(warp-routes): rotate USDT/eni nested fee owners to Turnkey

### DIFF
--- a/.changeset/usdt-eni-fee-owner-turnkey.md
+++ b/.changeset/usdt-eni-fee-owner-turnkey.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+The USDT/eni warp route nested OffchainQuotedLinearFee owners on the arbitrum, base, bsc, ethereum, optimism, and polygon collateral legs were set to the WarpFees Turnkey treasury key so a warp apply transfers fee-contract ownership to Turnkey. The tron leg keeps its WarpFees ICA.

--- a/deployments/warp_routes/USDT/eni-deploy.yaml
+++ b/deployments/warp_routes/USDT/eni-deploy.yaml
@@ -10,37 +10,37 @@ arbitrum:
     feeContracts:
       base:
         bps: 5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       bsc:
         bps: 5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       ethereum:
         bps: 5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       optimism:
         bps: 5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       polygon:
         bps: 5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       tron:
         bps: 5
-        owner: "0x6f0Cfe5fD2E4188AD68b7f8ceB135DD68DF629C7"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
@@ -59,37 +59,37 @@ base:
     feeContracts:
       arbitrum:
         bps: 5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       bsc:
         bps: 5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       ethereum:
         bps: 5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       optimism:
         bps: 5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       polygon:
         bps: 5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       tron:
         bps: 5
-        owner: "0x957019c916D05dDF70816Cad43ebF5D417bE81C8"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
@@ -107,37 +107,37 @@ bsc:
     feeContracts:
       arbitrum:
         bps: 5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       base:
         bps: 5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       ethereum:
         bps: 5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       optimism:
         bps: 5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       polygon:
         bps: 5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       tron:
         bps: 5
-        owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
@@ -196,37 +196,37 @@ ethereum:
     feeContracts:
       arbitrum:
         bps: 5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       base:
         bps: 5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       bsc:
         bps: 5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       optimism:
         bps: 5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       polygon:
         bps: 5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       tron:
         bps: 5
-        owner: "0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
@@ -245,37 +245,37 @@ optimism:
     feeContracts:
       arbitrum:
         bps: 5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       base:
         bps: 5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       bsc:
         bps: 5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       ethereum:
         bps: 5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       polygon:
         bps: 5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       tron:
         bps: 5
-        owner: "0xEB5745ce8dB26a5A93541F83db7d1F4223e13175"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
@@ -294,37 +294,37 @@ polygon:
     feeContracts:
       arbitrum:
         bps: 5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       base:
         bps: 5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       bsc:
         bps: 5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       ethereum:
         bps: 5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       optimism:
         bps: 5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee
       tron:
         bps: 5
-        owner: "0xdb1E550BcD5CDFF11ede39d042e38DD947dAAD0a"
+        owner: "0xe95C605096A1AD38BaC3E5210e145952Cbdc6998"
         quoteSigners:
           - "0xEd1829805De615eEFC7303766D395Ea0a1B2b04d"
         type: OffchainQuotedLinearFee


### PR DESCRIPTION
## Summary
- Set the 36 nested `OffchainQuotedLinearFee` owners on the USDT/eni collateral legs (arbitrum, base, bsc, ethereum, optimism, polygon) to the WarpFees Turnkey key `0xe95C605096A1AD38BaC3E5210e145952Cbdc6998`.
- Makes `hyperlane warp apply --id USDT/eni` diff on-chain (per-chain WarpFees ICA/Safe) vs desired (Turnkey) and issue `transferOwnership` on the fee contracts.
- Aligns the registry deploy config with the infra config getter intent (`getEniUsdtWarpConfig`, which already targets `WARP_FEES_TURNKEY_OWNER` via `getFixedRoutingFeeConfig`).
- tron leg unchanged (keeps its WarpFees ICA); route-level router owners and the eni synthetic leg unchanged.

## Authorization
The on-chain rotation was already executed and approved before this registry update. This PR records the same intent in the deploy config.
- Approved by Nam Chu Hoai in the #eng-guardian thread.
- WarpFees Safe (ethereum `0x8Ff4c563f26db00e65bD93d9f662A51c304C09b0`) batch nonce 18, SafeTxHash `0x37c5b063db86c45a481e2769e6dfe51a8c7f3e75d2aabad2208d2b8fa319301d`.
- Executed 2026-08-28T20:12:59Z, on-chain tx `0x4bc0c97a583e29cf53a9958d7170388a1aff1a753bd092bf7d8168fd5f3c0c29` (2/2). Ethereum legs via direct `transferOwnership`; base/optimism/bsc/arbitrum/polygon legs via ICA `callRemoteWithOverrides`.
- Verified all 36 fee contracts now `owner() == 0xe95C605096A1AD38BaC3E5210e145952Cbdc6998`.

## Context
The `check-warp-deploy-mainnet3` monitor flagged 36 `ConfigMismatch` series on `tokenFee.feeContracts.<chain>.owner` (PD Q1TZOS0IEK9GXC). Expected (getter) = Turnkey, actual (on-chain) = per-chain WarpFees ICA/Safe. This is real pending drift: the top-level RoutingFee owners were already rotated to Turnkey on-chain, the nested OQLF fee-contract owners were not.

## Apply note
The `transferOwnership` txs must be signed by the current fee-contract owners (each leg's WarpFees ICA/Safe), so the apply needs the WarpFees submitter/strategy for those accounts.

## Test plan
- [x] Review the 36 owner changes are nested `feeContracts.*.owner` only (no route-level owners).
- [x] `hyperlane warp apply --id USDT/eni` produces only fee-owner `transferOwnership` txs to `0xe95C60...6998`.
- [x] After apply, `check-warp-deploy-mainnet3` clears the USDT/eni owner mismatches.
