### PR TITLE
feat: add Kiichain leg rate limit and pausable ISM

### DIFF
--- a/.changeset/kii-kiichain-leg-ratelimit-pausable-isms.md
+++ b/.changeset/kii-kiichain-leg-ratelimit-pausable-isms.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added a staticAggregationIsm (threshold = all) wrapping a rateLimitedIsm (1M KII/day), a pausableIsm, and a defaultFallbackRoutingIsm to the KII/kiichain warp route on the kiichain leg.

--- a/deployments/warp_routes/KII/kiichain-deploy.yaml
+++ b/deployments/warp_routes/KII/kiichain-deploy.yaml
@@ -63,6 +63,19 @@ ethereum:
 
 kiichain:
   decimals: 18
+  interchainSecurityModule:
+    modules:
+      - maxCapacity: "999999999999999993600000"
+        owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
+        type: rateLimitedIsm
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
+        type: pausableIsm
+      - domains: {}
+        owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
+        type: defaultFallbackRoutingIsm
+    threshold: 3
+    type: staticAggregationIsm
   mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
   owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
   type: native


### PR DESCRIPTION
### Description

Add a static aggregation ISM to the KII/kiichain warp route's kiichain leg. It requires all three modules:

- rate limit: 1M KII/day
- pausable ISM, initially unpaused
- default fallback routing ISM

Includes a patch changeset.

### Backward compatibility

Yes. This adds security configuration to the existing route.

### Testing

- `pnpm exec oxfmt --check deployments/warp_routes/KII/kiichain-deploy.yaml .changeset/kii-kiichain-leg-ratelimit-pausable-isms.md`
- `pnpm run build`
