### PR TITLE
chore(KII/kiichain): add rate-limit + pausable ISMs on kiichain leg

### DIFF
--- a/.changeset/kii-kiichain-leg-ratelimit-pausable-isms.md
+++ b/.changeset/kii-kiichain-leg-ratelimit-pausable-isms.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added a staticAggregationIsm (threshold = all) wrapping a rateLimitedIsm (1M KII/day), a pausableIsm, and a defaultFallbackRoutingIsm to the KII/kiichain warp route's kiichain leg. The rate-limit and fallback modules are owned by the kiichain leg's existing token owner; the pausable module is owned by the dedicated Turnkey pauser key. This matches the setup already declared for the EVM legs in the separate AW-752 PR.

--- a/deployments/warp_routes/KII/kiichain-deploy.yaml
+++ b/deployments/warp_routes/KII/kiichain-deploy.yaml
@@ -63,6 +63,19 @@ ethereum:
 
 kiichain:
   decimals: 18
+  interchainSecurityModule:
+    modules:
+      - maxCapacity: "999999999999999993600000"
+        owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
+        type: rateLimitedIsm
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
+        type: pausableIsm
+      - domains: {}
+        owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
+        type: defaultFallbackRoutingIsm
+    threshold: 3
+    type: staticAggregationIsm
   mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
   owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
   type: native


### PR DESCRIPTION
## Summary

Adds the `interchainSecurityModule` on the KII/kiichain warp route's **kiichain leg** only, mirroring the setup on the EVM legs in #1666.

`staticAggregationIsm` (threshold = all 3 modules):
- `rateLimitedIsm` — `maxCapacity` `999999999999999993600000` (1M KII/day), owner = kiichain leg token owner `0x30C48d3F3650C3f4A741588672CDc811Ed5303bd`
- `pausableIsm` — `paused: false`, owner = Turnkey pauser `0x60Cc386C85717CB51C2827A75e14826883dF5da4`
- `defaultFallbackRoutingIsm` — owner = kiichain leg token owner

Split out from #1666 because kiichain was halted when that PR was cut. kiichain resumes tonight; on-chain wiring lands via the deployer's `warp apply` after resume.

| Field | Value |
| ----- | ----- |
| Linear | https://linear.app/hyperlane-xyz/issue/AW-752 |
| Scope | kiichain leg only |

Requires the kiichain pauser `0x60Cc386C…` to be funded on kiichain (0 balance) before it can `pause()`, and the ICA owner txs (`kiichain-pausable.json`) to be signed after the chain resumes.