### PR TITLE
feat: cut over NES warp route to Nesachain

### DIFF
--- a/.changeset/redeploy-nes-bsc-synthetics-composite-ism.md
+++ b/.changeset/redeploy-nes-bsc-synthetics-composite-ism.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+redeployed NES synthetics and moved the native leg to Nesachain

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -6102,7 +6102,7 @@ nesachain:
     symbol: NES
   protocol: ethereum
   rpcUrls:
-    - http: https://erpc.nesa.ai
+    - http: https://erpc.ns.onyxpro.ai
   technicalStack: other
 neuratestnet:
   availability:

--- a/chains/nesachain/metadata.yaml
+++ b/chains/nesachain/metadata.yaml
@@ -22,5 +22,5 @@ nativeToken:
   symbol: NES
 protocol: ethereum
 rpcUrls:
-  - http: https://erpc.nesa.ai
+  - http: https://erpc.ns.onyxpro.ai
 technicalStack: other

--- a/deployments/warp_routes/NES/bsc-config.yaml
+++ b/deployments/warp_routes/NES/bsc-config.yaml
@@ -1,104 +1,111 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0xEf9295afCff293956E8B149b33449f246f6F107D"
-    logoURI: /deployments/warp_routes/NES/logo.svg
+  - addressOrDenom: "0x8cAd676141FeadB6aCA5eF661E835d5957644033"
     chainName: arbitrum
     connections:
-      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+      - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+      - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+      - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+      - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+      - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
     decimals: 18
+    logoURI: /deployments/warp_routes/NES/logo.svg
     name: Nesa
     standard: EvmHypSynthetic
     symbol: NES
-  - addressOrDenom: "0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C"
-    logoURI: /deployments/warp_routes/NES/logo.svg
+    tokenType: synthetic
+  - addressOrDenom: "0x2E968fB88998a6303535Ac637C809119ECAd4a4b"
     chainName: base
     connections:
-      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+      - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+      - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+      - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+      - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+      - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
     decimals: 18
+    logoURI: /deployments/warp_routes/NES/logo.svg
     name: Nesa
     standard: EvmHypSynthetic
     symbol: NES
-  - addressOrDenom: "0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5"
-    logoURI: /deployments/warp_routes/NES/logo.svg
+    tokenType: synthetic
+  - addressOrDenom: "0x097acf27503753e77bCA940277806156C5925B81"
     chainName: bsc
     connections:
-      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+      - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+      - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+      - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+      - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+      - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
     decimals: 18
+    logoURI: /deployments/warp_routes/NES/logo.svg
     name: Nesa
     standard: EvmHypSynthetic
     symbol: NES
-  - addressOrDenom: "0x230f1E241C621d5af670Dad83ebCdd18971E2995"
-    logoURI: /deployments/warp_routes/NES/logo.svg
+    tokenType: synthetic
+  - addressOrDenom: "0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538"
     chainName: ethereum
     connections:
-      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+      - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+      - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+      - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+      - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+      - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
     decimals: 18
+    logoURI: /deployments/warp_routes/NES/logo.svg
     name: Nesa
     standard: EvmHypSynthetic
     symbol: NES
-  - addressOrDenom: "0xD1B6443d49156B66E7bd8a37673511BE68BFa459"
-    logoURI: /deployments/warp_routes/NES/logo.svg
+    tokenType: synthetic
+  - addressOrDenom: "0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af"
     chainName: hyperevm
     connections:
-      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+      - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+      - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+      - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+      - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+      - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
     decimals: 18
+    logoURI: /deployments/warp_routes/NES/logo.svg
     name: Nesa
     standard: EvmHypSynthetic
     symbol: NES
-  - addressOrDenom: "0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886"
-    logoURI: /deployments/warp_routes/NES/logo.svg
-    chainName: nesa
-    connections:
-      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
-    decimals: 18
-    name: NES
-    standard: EvmHypNative
-    symbol: NES
-  - addressOrDenom: Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
-    logoURI: /deployments/warp_routes/NES/logo.svg
-    collateralAddressOrDenom: DcozfBUx4qxNwfq3PU622qHvVtnMRtJEUjhmyiFRaG43
+    tokenType: synthetic
+  - addressOrDenom: EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
     chainName: solanamainnet
+    connections:
+      - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+      - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+      - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+      - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+      - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+      - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
+    decimals: 9
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    name: Nesa
     scale:
       denominator: 1
       numerator: 1000000000
-    connections:
-      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-    decimals: 9
-    name: Nesa
     standard: SealevelHypSynthetic
     symbol: NES
+    tokenType: synthetic
+  - addressOrDenom: "0xbb0AE51BCa526cF313b6a95BfaB020794af6C394"
+    chainName: nesachain
+    coinGeckoId: nesa
+    connections:
+      - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+      - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+      - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+      - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+      - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+      - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+    decimals: 18
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    name: NES
+    standard: EvmHypNative
+    symbol: NES
+    tokenType: native

--- a/deployments/warp_routes/NES/bsc-deploy.yaml
+++ b/deployments/warp_routes/NES/bsc-deploy.yaml
@@ -1,29 +1,9 @@
 arbitrum:
   decimals: 18
-  hook:
-    domains:
-      nesa:
-        hooks:
-          - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-      solanamainnet:
-        hooks:
-          - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-    fallback:
-      type: defaultHook
-    owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
-    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
-      - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
-        paused: true
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
         type: pausableIsm
       - domains: {}
         owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
@@ -37,30 +17,10 @@ arbitrum:
   type: synthetic
 base:
   decimals: 18
-  hook:
-    domains:
-      nesa:
-        hooks:
-          - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-      solanamainnet:
-        hooks:
-          - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-    fallback:
-      type: defaultHook
-    owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
-    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
-      - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
-        paused: true
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
         type: pausableIsm
       - domains: {}
         owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
@@ -74,30 +34,10 @@ base:
   type: synthetic
 bsc:
   decimals: 18
-  hook:
-    domains:
-      nesa:
-        hooks:
-          - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-      solanamainnet:
-        hooks:
-          - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-    fallback:
-      type: defaultHook
-    owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
-    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
-      - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
-        paused: true
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
         type: pausableIsm
       - domains: {}
         owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
@@ -111,30 +51,10 @@ bsc:
   type: synthetic
 ethereum:
   decimals: 18
-  hook:
-    domains:
-      nesa:
-        hooks:
-          - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-      solanamainnet:
-        hooks:
-          - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-    fallback:
-      type: defaultHook
-    owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
-    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
-      - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
-        paused: true
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
         type: pausableIsm
       - domains: {}
         owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
@@ -148,30 +68,10 @@ ethereum:
   type: synthetic
 hyperevm:
   decimals: 18
-  hook:
-    domains:
-      nesa:
-        hooks:
-          - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-      solanamainnet:
-        hooks:
-          - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-    fallback:
-      type: defaultHook
-    owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
-    type: fallbackRoutingHook
   interchainSecurityModule:
     modules:
-      - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
-        paused: true
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
         type: pausableIsm
       - domains: {}
         owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
@@ -183,23 +83,20 @@ hyperevm:
   owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
   symbol: NES
   type: synthetic
-nesa:
+nesachain:
   decimals: 18
-  hook:
-    domains:
-      solanamainnet:
-        hooks:
-          - owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
-            paused: true
-            type: pausableHook
-          - type: defaultHook
-        type: aggregationHook
-    fallback:
-      type: defaultHook
-    owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
-    type: fallbackRoutingHook
-  mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
-  owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
+  interchainSecurityModule:
+    modules:
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
+        type: pausableIsm
+      - domains: {}
+        owner: "0x80902abA042EFe99179FDC0Ba997028335A847E8"
+        type: defaultFallbackRoutingIsm
+    threshold: 2
+    type: staticAggregationIsm
+  mailbox: "0x7f50C5776722630a0024fAE05fDe8b47571D7B39"
+  owner: "0x80902abA042EFe99179FDC0Ba997028335A847E8"
   type: native
 solanamainnet:
   decimals: 9

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -5463,100 +5463,90 @@ MONEY/sonicsvm:
       symbol: MONEY
 NES/bsc:
   tokens:
-    - addressOrDenom: "0xEf9295afCff293956E8B149b33449f246f6F107D"
+    - addressOrDenom: "0x8cAd676141FeadB6aCA5eF661E835d5957644033"
       chainName: arbitrum
       connections:
-        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+        - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+        - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+        - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+        - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+        - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+        - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
       decimals: 18
       logoURI: /deployments/warp_routes/NES/logo.svg
       name: Nesa
       standard: EvmHypSynthetic
       symbol: NES
-    - addressOrDenom: "0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C"
+      tokenType: synthetic
+    - addressOrDenom: "0x2E968fB88998a6303535Ac637C809119ECAd4a4b"
       chainName: base
       connections:
-        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+        - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+        - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+        - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+        - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+        - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+        - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
       decimals: 18
       logoURI: /deployments/warp_routes/NES/logo.svg
       name: Nesa
       standard: EvmHypSynthetic
       symbol: NES
-    - addressOrDenom: "0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5"
+      tokenType: synthetic
+    - addressOrDenom: "0x097acf27503753e77bCA940277806156C5925B81"
       chainName: bsc
       connections:
-        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+        - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+        - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+        - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+        - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+        - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+        - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
       decimals: 18
       logoURI: /deployments/warp_routes/NES/logo.svg
       name: Nesa
       standard: EvmHypSynthetic
       symbol: NES
-    - addressOrDenom: "0x230f1E241C621d5af670Dad83ebCdd18971E2995"
+      tokenType: synthetic
+    - addressOrDenom: "0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538"
       chainName: ethereum
       connections:
-        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+        - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+        - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+        - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+        - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+        - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+        - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
       decimals: 18
       logoURI: /deployments/warp_routes/NES/logo.svg
       name: Nesa
       standard: EvmHypSynthetic
       symbol: NES
-    - addressOrDenom: "0xD1B6443d49156B66E7bd8a37673511BE68BFa459"
+      tokenType: synthetic
+    - addressOrDenom: "0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af"
       chainName: hyperevm
       connections:
-        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
-        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+        - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+        - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+        - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+        - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+        - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+        - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
       decimals: 18
       logoURI: /deployments/warp_routes/NES/logo.svg
       name: Nesa
       standard: EvmHypSynthetic
       symbol: NES
-    - addressOrDenom: "0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886"
-      chainName: nesa
-      connections:
-        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
-      decimals: 18
-      logoURI: /deployments/warp_routes/NES/logo.svg
-      name: NES
-      standard: EvmHypNative
-      symbol: NES
-    - addressOrDenom: Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      tokenType: synthetic
+    - addressOrDenom: EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
       chainName: solanamainnet
-      collateralAddressOrDenom: DcozfBUx4qxNwfq3PU622qHvVtnMRtJEUjhmyiFRaG43
       connections:
-        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
-        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
-        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
-        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
-        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
-        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+        - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+        - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+        - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+        - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+        - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+        - token: ethereum|nesachain|0xbb0AE51BCa526cF313b6a95BfaB020794af6C394
       decimals: 9
       logoURI: /deployments/warp_routes/NES/logo.svg
       name: Nesa
@@ -5565,6 +5555,23 @@ NES/bsc:
         numerator: 1000000000
       standard: SealevelHypSynthetic
       symbol: NES
+      tokenType: synthetic
+    - addressOrDenom: "0xbb0AE51BCa526cF313b6a95BfaB020794af6C394"
+      chainName: nesachain
+      coinGeckoId: nesa
+      connections:
+        - token: ethereum|arbitrum|0x8cAd676141FeadB6aCA5eF661E835d5957644033
+        - token: ethereum|base|0x2E968fB88998a6303535Ac637C809119ECAd4a4b
+        - token: ethereum|bsc|0x097acf27503753e77bCA940277806156C5925B81
+        - token: ethereum|ethereum|0x863F08A3d3B14fbD3D42fFD061D0e290F7dBC538
+        - token: ethereum|hyperevm|0xdFC12a5cF04Bc91BE4aF0E3Bc46A3CDADB1f86Af
+        - token: sealevel|solanamainnet|EFuxu8VZJJvWZohJgjsbgXvRifySusuMv7FmSEvzDRoz
+      decimals: 18
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: NES
+      standard: EvmHypNative
+      symbol: NES
+      tokenType: native
 NEX/bsc:
   tokens:
     - addressOrDenom: "0x365DE036A1F7dcCb621530d517133521debB2013"


### PR DESCRIPTION
## Summary

- cut the NES route over from `nesa` (`41443`) to `nesachain` (`41444`)
- add the live Nesachain native router `0xbb0AE51BCa526cF313b6a95BfaB020794af6C394`
- update the synthetic legs to the aggregation 2/2 ISM
- remove the old paused routing hooks

## Status

The Nesachain core deployment is on `main` via #1679, and the native leg is live and owned by the Ethereum ICA. Hyperlane enrollment multisig transactions are proposed and in progress. The existing EVM and Solana owner transactions can execute in parallel; transfers should wait until both sides are live.

`check-warp-deploy` is expected to reconcile after the existing-leg owner transactions execute.

## Validation

- registry build, lint, formatting, changeset, and focused `NES/bsc` tests
- live Nesachain router, mailbox, ISM, ownership, and zero-supply backing readback
- decoded EVM batch and replayed Solana transactions against the target config
