### PR TITLE
feat(oUSDT): convert bsc leg from synthetic to collateral

### DIFF
--- a/.changeset/ousdt-bsc-collateral.md
+++ b/.changeset/ousdt-bsc-collateral.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+the bsc leg of the oUSDT staging and production warp routes is converted from a synthetic xERC20 to a collateral route backed by BSC-USD (0x55d398326f99059fF775485246999027B3197955), replacing the previous synthetic routers with the newly deployed collateral ones on staging (0x54599E9872AfC75C6bF70825B636F021641fa3a3) and production (0xc283600F0A84162C0a062f7273ABB1F8F111b40C) and relinking every other leg to them. every leg of both routes also carries an explicit scale now: 1/1 on the six-decimal legs and 1/1000000000000 on bsc so its eighteen-decimal collateral matches the six-decimal message encoding. the staging deploy config is pinned to contractVersion 12.1.0

--- a/deployments/warp_routes/oUSDT/production-config.yaml
+++ b/deployments/warp_routes/oUSDT/production-config.yaml
@@ -17,7 +17,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -42,7 +41,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -68,7 +66,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
@@ -94,7 +91,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
@@ -119,7 +115,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -144,7 +139,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -169,7 +163,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -194,7 +187,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -219,7 +211,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -244,7 +235,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -269,7 +259,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -294,7 +283,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -319,7 +307,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
@@ -344,7 +331,6 @@ tokens:
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
@@ -352,31 +338,6 @@ tokens:
     standard: EvmHypCollateral
     symbol: USDT
     tokenType: collateral
-  - addressOrDenom: "0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c"
-    chainName: bsc
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
   - addressOrDenom: "0x58cc0cB6CcE9844221F7a425Aa04E12449955859"
     chainName: tea
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
@@ -404,7 +365,6 @@ tokens:
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|bsc|0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT

--- a/deployments/warp_routes/oUSDT/production-config.yaml
+++ b/deployments/warp_routes/oUSDT/production-config.yaml
@@ -15,19 +15,18 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USD₮0
+    name: Tether USDT
     scale:
       denominator: 1
       numerator: 1
     standard: EvmHypCollateral
-    symbol: USD₮0
+    symbol: USDT
     tokenType: collateral
   - addressOrDenom: "0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f"
     chainName: base
@@ -44,7 +43,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -55,7 +53,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x155332Fad14bdE126255E6Ab6A09Fe88D2864294"
@@ -73,7 +71,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -84,7 +81,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
@@ -103,19 +100,18 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: Tether USD
+    name: Tether USDT
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20Lockbox
-    symbol: USD₮
+    standard: EvmHypVSXERC20Lockbox
+    symbol: USDT
     tokenType: xERC20Lockbox
   - addressOrDenom: "0x88AC0fC430130983c0DDEB4C22574056D8340Ca8"
     chainName: ethereum
@@ -133,18 +129,17 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: Tether USD
+    name: Tether USDT
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20Lockbox
+    standard: EvmHypVSXERC20Lockbox
     symbol: USDT
     tokenType: xERC20Lockbox
   - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
@@ -162,7 +157,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -173,7 +167,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
@@ -191,7 +185,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -202,7 +195,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
@@ -220,7 +213,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -231,7 +223,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0"
@@ -249,7 +241,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -260,7 +251,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x324d0b921C03b1e42eeFD198086A64beC3d736c2"
@@ -278,7 +269,6 @@ tokens:
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -289,7 +279,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8"
@@ -307,7 +297,6 @@ tokens:
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -318,7 +307,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x2dC335bDF489f8e978477Ae53924324697e0f7BB"
@@ -336,7 +325,6 @@ tokens:
       - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
@@ -347,36 +335,20 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x58cc0cB6CcE9844221F7a425Aa04E12449955859"
     chainName: tea
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    connections: []
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
     name: OpenUSDT
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe"
@@ -395,13 +367,12 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: Tether USD
+    name: Tether USDT
     scale:
       denominator: 1
       numerator: 1
@@ -424,7 +395,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
       - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
@@ -434,7 +404,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74"
@@ -453,7 +423,6 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
@@ -463,7 +432,7 @@ tokens:
     scale:
       denominator: 1
       numerator: 1
-    standard: EvmHypXERC20
+    standard: EvmHypVSXERC20
     symbol: oUSDT
     tokenType: xERC20
   - addressOrDenom: "0xc283600F0A84162C0a062f7273ABB1F8F111b40C"
@@ -482,13 +451,12 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
       - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
     decimals: 18
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: Tether USD
+    name: Tether USDT
     scale:
       denominator: 1000000000000
       numerator: 1

--- a/deployments/warp_routes/oUSDT/production-config.yaml
+++ b/deployments/warp_routes/oUSDT/production-config.yaml
@@ -1,319 +1,5 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
-  - addressOrDenom: "0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f"
-    chainName: base
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x155332Fad14bdE126255E6Ab6A09Fe88D2864294"
-    chainName: bob
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
-    chainName: celo
-    coinGeckoId: tether
-    collateralAddressOrDenom: "0x5e5F4d6B03db16E7f00dE7C9AFAA53b92C8d1D42"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USDT
-    standard: EvmHypVSXERC20Lockbox
-    symbol: USD₮
-    tokenType: xERC20Lockbox
-  - addressOrDenom: "0x88AC0fC430130983c0DDEB4C22574056D8340Ca8"
-    chainName: ethereum
-    coinGeckoId: tether
-    collateralAddressOrDenom: "0x6D265C7dD8d76F25155F1a7687C693FDC1220D12"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USDT
-    standard: EvmHypVSXERC20Lockbox
-    symbol: USDT
-    tokenType: xERC20Lockbox
-  - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
-    chainName: fraxtal
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
-    chainName: ink
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
-    chainName: lisk
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0"
-    chainName: metal
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x324d0b921C03b1e42eeFD198086A64beC3d736c2"
-    chainName: mode
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8"
-    chainName: optimism
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x2dC335bDF489f8e978477Ae53924324697e0f7BB"
-    chainName: soneium
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f"
-    chainName: unichain
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
-  - addressOrDenom: "0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74"
-    chainName: zerogravity
-    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
-    connections:
-      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
-      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
-      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
-      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
-      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
-      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
-      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
-      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
-      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
-      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
-      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
-      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
-      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
-    decimals: 6
-    logoURI: /deployments/warp_routes/oUSDT/logo.svg
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDT
-    tokenType: xERC20
   - addressOrDenom: "0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a"
     chainName: arbitrum
     collateralAddressOrDenom: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
@@ -329,28 +15,346 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
-      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USDT
+    name: USD₮0
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypCollateral
-    symbol: USDT
+    symbol: USD₮0
     tokenType: collateral
-  - addressOrDenom: "0x58cc0cB6CcE9844221F7a425Aa04E12449955859"
-    chainName: tea
+  - addressOrDenom: "0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f"
+    chainName: base
     collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
     decimals: 6
     logoURI: /deployments/warp_routes/oUSDT/logo.svg
     name: OpenUSDT
-    standard: EvmHypVSXERC20
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
     symbol: oUSDT
     tokenType: xERC20
-  - addressOrDenom: "0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe"
-    chainName: tron
-    collateralAddressOrDenom: "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
+  - addressOrDenom: "0x155332Fad14bdE126255E6Ab6A09Fe88D2864294"
+    chainName: bob
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
     connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0xbBa1938ff861c77eA1687225B9C33554379Ef327"
+    chainName: celo
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0x5e5F4d6B03db16E7f00dE7C9AFAA53b92C8d1D42"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20Lockbox
+    symbol: USD₮
+    tokenType: xERC20Lockbox
+  - addressOrDenom: "0x88AC0fC430130983c0DDEB4C22574056D8340Ca8"
+    chainName: ethereum
+    coinGeckoId: tether
+    collateralAddressOrDenom: "0x6D265C7dD8d76F25155F1a7687C693FDC1220D12"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20Lockbox
+    symbol: USDT
+    tokenType: xERC20Lockbox
+  - addressOrDenom: "0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e"
+    chainName: fraxtal
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x69158d1A7325Ca547aF66C3bA599F8111f7AB519"
+    chainName: ink
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1"
+    chainName: lisk
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0"
+    chainName: metal
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x324d0b921C03b1e42eeFD198086A64beC3d736c2"
+    chainName: mode
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8"
+    chainName: optimism
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x2dC335bDF489f8e978477Ae53924324697e0f7BB"
+    chainName: soneium
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x58cc0cB6CcE9844221F7a425Aa04E12449955859"
+    chainName: tea
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
       - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
       - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
       - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
@@ -362,12 +366,132 @@ tokens:
       - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
       - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
       - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
       - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
       - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe"
+    chainName: tron
+    collateralAddressOrDenom: "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
+    connections:
       - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
-    name: USDT
+    name: Tether USD
+    scale:
+      denominator: 1
+      numerator: 1
     standard: TronHypCollateral
+    symbol: USDT
+    tokenType: collateral
+  - addressOrDenom: "0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f"
+    chainName: unichain
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74"
+    chainName: zerogravity
+    collateralAddressOrDenom: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|bsc|0xc283600F0A84162C0a062f7273ABB1F8F111b40C
+    decimals: 6
+    logoURI: /deployments/warp_routes/oUSDT/logo.svg
+    name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
+    standard: EvmHypXERC20
+    symbol: oUSDT
+    tokenType: xERC20
+  - addressOrDenom: "0xc283600F0A84162C0a062f7273ABB1F8F111b40C"
+    chainName: bsc
+    collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
+    connections:
+      - token: ethereum|arbitrum|0x98d4DD4220Aa0Fe9251ccF7978c9B355D1be276a
+      - token: ethereum|base|0x4F0654395d621De4d1101c0F98C1Dba73ca0a61f
+      - token: ethereum|bob|0x155332Fad14bdE126255E6Ab6A09Fe88D2864294
+      - token: ethereum|celo|0xbBa1938ff861c77eA1687225B9C33554379Ef327
+      - token: ethereum|ethereum|0x88AC0fC430130983c0DDEB4C22574056D8340Ca8
+      - token: ethereum|fraxtal|0xa0bD9e96556E27e6FfF0cC0F77496390d9844E1e
+      - token: ethereum|ink|0x69158d1A7325Ca547aF66C3bA599F8111f7AB519
+      - token: ethereum|lisk|0x910FF91a92c9141b8352Ad3e50cF13ef9F3169A1
+      - token: ethereum|metal|0x4FC916e83F59706Ba1Ccdd607be8cB64753Fe4f0
+      - token: ethereum|mode|0x324d0b921C03b1e42eeFD198086A64beC3d736c2
+      - token: ethereum|optimism|0x7bD2676c85cca9Fa2203ebA324fb8792fbd520b8
+      - token: ethereum|soneium|0x2dC335bDF489f8e978477Ae53924324697e0f7BB
+      - token: ethereum|tea|0x58cc0cB6CcE9844221F7a425Aa04E12449955859
+      - token: tron|tron|0x123ea3dC00a2799Ff04c6D0F8dcaFe56fA1cA9Fe
+      - token: ethereum|unichain|0x4A8149B1b9e0122941A69D01D23EaE6bD1441b4f
+      - token: ethereum|zerogravity|0xC34aD1fB13a9eE1A0C0AB75aD9B9ceeA0690Cc74
+    decimals: 18
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    scale:
+      denominator: 1000000000000
+      numerator: 1
+    standard: EvmHypCollateral
     symbol: USDT
     tokenType: collateral

--- a/deployments/warp_routes/oUSDT/production-deploy.yaml
+++ b/deployments/warp_routes/oUSDT/production-deploy.yaml
@@ -17,6 +17,9 @@ arbitrum:
     threshold: 2
     type: staticAggregationIsm
   owner: "0x8abE651230Ce65f546eb78C9Ed7fe54e15650224"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
   tokenFee:
     feeContracts:
@@ -183,6 +186,9 @@ base:
   ownerOverrides:
     collateralProxyAdmin: "0xe38714D00cAa906065D872D177C1374C847035fF"
     collateralToken: "0xe38714D00cAa906065D872D177C1374C847035fF"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -213,6 +219,9 @@ bob:
   ownerOverrides:
     collateralProxyAdmin: "0x790306c30eFeeAF3943ee3700C71D7B7812c85a1"
     collateralToken: "0x790306c30eFeeAF3943ee3700C71D7B7812c85a1"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -362,6 +371,9 @@ celo:
   ownerOverrides:
     collateralProxyAdmin: "0xb527ea7ff1B14fEb9FFF98b5Cd750Bd311cD598F"
     collateralToken: "0xb527ea7ff1B14fEb9FFF98b5Cd750Bd311cD598F"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x5e5F4d6B03db16E7f00dE7C9AFAA53b92C8d1D42"
   tokenFee:
     feeContracts:
@@ -492,6 +504,9 @@ ethereum:
   ownerOverrides:
     collateralProxyAdmin: "0x469f45d05F8C3B3cE40d1640ffE66b795B1d2d22"
     collateralToken: "0x469f45d05F8C3B3cE40d1640ffE66b795B1d2d22"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x6D265C7dD8d76F25155F1a7687C693FDC1220D12"
   tokenFee:
     feeContracts:
@@ -627,6 +642,9 @@ fraxtal:
   ownerOverrides:
     collateralProxyAdmin: "0x09F478e8dEB9Ef466025bf96d13cd9DC56881E18"
     collateralToken: "0x09F478e8dEB9Ef466025bf96d13cd9DC56881E18"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -651,6 +669,9 @@ ink:
   ownerOverrides:
     collateralProxyAdmin: "0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f"
     collateralToken: "0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -675,6 +696,9 @@ lisk:
   ownerOverrides:
     collateralProxyAdmin: "0xfA96BCb61C7CbD7839689E807CD6d7FC27754Af3"
     collateralToken: "0xfA96BCb61C7CbD7839689E807CD6d7FC27754Af3"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -699,6 +723,9 @@ metal:
   ownerOverrides:
     collateralProxyAdmin: "0xA312a8329bCDc2e5EA5dc2849326a45D40C58e8F"
     collateralToken: "0xA312a8329bCDc2e5EA5dc2849326a45D40C58e8F"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -770,6 +797,9 @@ mode:
   ownerOverrides:
     collateralProxyAdmin: "0x5CC74C639310B6865d2Ef2E92ed4B68fcd96Ff88"
     collateralToken: "0x5CC74C639310B6865d2Ef2E92ed4B68fcd96Ff88"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -841,6 +871,9 @@ optimism:
   ownerOverrides:
     collateralProxyAdmin: "0x1C9192aB4aDc226FF20121624590650b076492BE"
     collateralToken: "0x1C9192aB4aDc226FF20121624590650b076492BE"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -871,6 +904,9 @@ soneium:
   ownerOverrides:
     collateralProxyAdmin: "0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC"
     collateralToken: "0x39d3c2Cf646447ee302178EDBe5a15E13B6F33aC"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -895,6 +931,9 @@ tea:
   ownerOverrides:
     collateralProxyAdmin: "0x33AA12b4e8E79cA551Ca9D1F2eC7d2cE02129dd4"
     collateralToken: "0x33AA12b4e8E79cA551Ca9D1F2eC7d2cE02129dd4"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   tokenFee:
     feeContracts:
@@ -1021,6 +1060,9 @@ tron:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xf354dE0536da38537fe751B586eB5CCc81101741"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
   tokenFee:
     bps: 5
@@ -1046,6 +1088,9 @@ unichain:
   ownerOverrides:
     collateralProxyAdmin: "0x6291596339A6EDD6cD68aca1d1c08B1fa2115F8C"
     collateralToken: "0x6291596339A6EDD6cD68aca1d1c08B1fa2115F8C"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:
@@ -1070,6 +1115,9 @@ zerogravity:
   ownerOverrides:
     collateralProxyAdmin: "0x11EF91d17c5ad3330DbCa709a8841743d3Af6819"
     collateralToken: "0x11EF91d17c5ad3330DbCa709a8841743d3Af6819"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
   type: xERC20
   xERC20:

--- a/deployments/warp_routes/oUSDT/production-deploy.yaml
+++ b/deployments/warp_routes/oUSDT/production-deploy.yaml
@@ -240,10 +240,10 @@ bsc:
     threshold: 2
     type: staticAggregationIsm
   owner: "0x09F4D4e765A911B867263d4Ff5e73323281De80D"
-  ownerOverrides:
-    collateralProxyAdmin: "0x09F4D4e765A911B867263d4Ff5e73323281De80D"
-    collateralToken: "0x09F4D4e765A911B867263d4Ff5e73323281De80D"
-  token: "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"
+  scale:
+    denominator: 1000000000000
+    numerator: 1
+  token: "0x55d398326f99059fF775485246999027B3197955"
   tokenFee:
     feeContracts:
       arbitrum:
@@ -344,12 +344,7 @@ bsc:
         type: OffchainQuotedLinearFee
     owner: "0xA0e41Ab972294A8f7CD1599BB76AdDB6bAE24556"
     type: RoutingFee
-  type: xERC20
-  xERC20:
-    warpRouteLimits:
-      bufferCap: "20000000000000"
-      rateLimitPerSecond: "5000000000"
-      type: velo
+  type: collateral
 celo:
   contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"

--- a/deployments/warp_routes/oUSDT/staging-config.yaml
+++ b/deployments/warp_routes/oUSDT/staging-config.yaml
@@ -19,7 +19,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: USD₮0STAGE
     standard: EvmHypCollateral
@@ -44,7 +43,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -69,7 +67,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -95,7 +92,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: USDTSTAGE
     standard: EvmHypVSXERC20Lockbox
@@ -121,7 +117,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: USDTSTAGE
     standard: EvmHypVSXERC20Lockbox
@@ -146,7 +141,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -171,7 +165,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -196,7 +189,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -221,7 +213,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -246,7 +237,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -271,7 +261,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -296,7 +285,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -321,7 +309,6 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -346,7 +333,6 @@ tokens:
       - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: USDTSTAGE
     standard: TronHypCollateral
@@ -371,7 +357,6 @@ tokens:
       - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20
@@ -396,32 +381,6 @@ tokens:
       - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|bsc|0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133
-    decimals: 6
-    name: OpenUSDT
-    standard: EvmHypVSXERC20
-    symbol: oUSDTSTAGE
-    tokenType: xERC20
-  - addressOrDenom: "0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133"
-    chainName: bsc
-    collateralAddressOrDenom: "0x0290B74980C051EB46b84b1236645444e77da0E9"
-    connections:
-      - token: ethereum|arbitrum|0xf0f6e34FE0EF3EFF572A5D2f3a14d9e5f5cF34E8
-      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
-      - token: ethereum|bob|0x2cd196dae643794bfff70E8D8EaF8f3BA7fCe51D
-      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
-      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
-      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
-      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
-      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
-      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
-      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
-      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
-      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
-      - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
-      - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
-      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
-      - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
     decimals: 6
     name: OpenUSDT
     standard: EvmHypVSXERC20

--- a/deployments/warp_routes/oUSDT/staging-config.yaml
+++ b/deployments/warp_routes/oUSDT/staging-config.yaml
@@ -19,8 +19,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: USD₮0STAGE
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypCollateral
     symbol: USD₮0STAGE
     tokenType: collateral
@@ -43,8 +47,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -67,8 +75,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -92,8 +104,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: USDTSTAGE
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20Lockbox
     symbol: USD₮STAGE
     tokenType: xERC20Lockbox
@@ -117,8 +133,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: USDTSTAGE
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20Lockbox
     symbol: USDTSTAGE
     tokenType: xERC20Lockbox
@@ -141,8 +161,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -165,8 +189,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -189,8 +217,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -213,8 +245,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -237,8 +273,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -261,8 +301,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -285,8 +329,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -309,8 +357,12 @@ tokens:
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -333,8 +385,12 @@ tokens:
       - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: USDTSTAGE
+    scale:
+      denominator: 1
+      numerator: 1
     standard: TronHypCollateral
     symbol: USDTSTAGE
     tokenType: collateral
@@ -357,8 +413,12 @@ tokens:
       - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
@@ -381,8 +441,40 @@ tokens:
       - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
       - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
       - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|bsc|0x54599E9872AfC75C6bF70825B636F021641fa3a3
     decimals: 6
     name: OpenUSDT
+    scale:
+      denominator: 1
+      numerator: 1
     standard: EvmHypVSXERC20
     symbol: oUSDTSTAGE
     tokenType: xERC20
+  - addressOrDenom: "0x54599E9872AfC75C6bF70825B636F021641fa3a3"
+    chainName: bsc
+    collateralAddressOrDenom: "0x55d398326f99059fF775485246999027B3197955"
+    connections:
+      - token: ethereum|arbitrum|0xf0f6e34FE0EF3EFF572A5D2f3a14d9e5f5cF34E8
+      - token: ethereum|base|0xA46248347da3dE91def696689E7997997dA35864
+      - token: ethereum|bob|0x2cd196dae643794bfff70E8D8EaF8f3BA7fCe51D
+      - token: ethereum|celo|0x78a2D1891e7D1259695b4795e04285C478E068E6
+      - token: ethereum|ethereum|0x8a60E4aC11C2Fac40Dc936E048e05145547A4356
+      - token: ethereum|fraxtal|0x086dE790943c23c42176236c392Fa9C35e660cE5
+      - token: ethereum|ink|0xBb2eBD68b2FEEe450dce91509897F9AE02211421
+      - token: ethereum|lisk|0xCe3360b0ba136B734c4F296D95FAc11A7deF36e3
+      - token: ethereum|metal|0x978a80bC3E97AAD6F71acF9013A015690E77010a
+      - token: ethereum|mode|0x0071740Bf129b05C4684abfbBeD248D80971cce2
+      - token: ethereum|optimism|0x1D833D392379929f15d03d212DbF8c17001c27e3
+      - token: ethereum|soneium|0xA895A9e1D3A2269F57544A8F7E697300626F0900
+      - token: ethereum|tea|0x436024B756b140A6f4d739505172a0c0944c3557
+      - token: tron|tron|0x9c9C85d0aD0b8a62Bdcad5Ac057FdF43a70c7Cbb
+      - token: ethereum|unichain|0x7189A511D4312148cC0aEf79129417f714e3155E
+      - token: ethereum|zerogravity|0x21b5a2fA1f53e94cF4871201aeD30C6ad5E405f2
+    decimals: 18
+    name: USDTSTAGE
+    scale:
+      denominator: 1000000000000
+      numerator: 1
+    standard: EvmHypCollateral
+    symbol: USDTSTAGE
+    tokenType: collateral

--- a/deployments/warp_routes/oUSDT/staging-deploy.yaml
+++ b/deployments/warp_routes/oUSDT/staging-deploy.yaml
@@ -238,7 +238,10 @@ bsc:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
-  token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
+  scale:
+    denominator: 1000000000000
+    numerator: 1
+  token: "0x55d398326f99059fF775485246999027B3197955"
   tokenFee:
     feeContracts:
       arbitrum:
@@ -355,12 +358,7 @@ bsc:
         type: OffchainQuotedLinearFee
     owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
     type: RoutingFee
-  type: xERC20
-  xERC20:
-    warpRouteLimits:
-      bufferCap: "25000000000"
-      rateLimitPerSecond: "120000000"
-      type: velo
+  type: collateral
 celo:
   contractVersion: 12.0.0
   hook: "0x0000000000000000000000000000000000000000"

--- a/deployments/warp_routes/oUSDT/staging-deploy.yaml
+++ b/deployments/warp_routes/oUSDT/staging-deploy.yaml
@@ -17,6 +17,9 @@ arbitrum:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
   tokenFee:
     feeContracts:
@@ -196,6 +199,9 @@ base:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -217,6 +223,9 @@ bob:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -373,6 +382,9 @@ celo:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x9a3D8d7E931679374448FB2B661F664D42d05057"
   tokenFee:
     feeContracts:
@@ -510,6 +522,9 @@ ethereum:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x935EAaAb78B491Cd9281f438E413767893913983"
   tokenFee:
     feeContracts:
@@ -653,6 +668,9 @@ fraxtal:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -674,6 +692,9 @@ ink:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -695,6 +716,9 @@ lisk:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -716,6 +740,9 @@ metal:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -784,6 +811,9 @@ mode:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -852,6 +882,9 @@ optimism:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -873,6 +906,9 @@ soneium:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -894,6 +930,9 @@ tea:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   tokenFee:
     feeContracts:
@@ -1036,6 +1075,9 @@ tron:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0xa614f803b6fd780986a42c78ec9c7f77e6ded13c"
   tokenFee:
     bps: 5
@@ -1059,6 +1101,9 @@ unichain:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:
@@ -1080,6 +1125,9 @@ zerogravity:
     threshold: 2
     type: staticAggregationIsm
   owner: "0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
+  scale:
+    denominator: 1
+    numerator: 1
   token: "0x0290B74980C051EB46b84b1236645444e77da0E9"
   type: xERC20
   xERC20:

--- a/deployments/warp_routes/oUSDT/staging-deploy.yaml
+++ b/deployments/warp_routes/oUSDT/staging-deploy.yaml
@@ -4,7 +4,7 @@ arbitrum:
   allowedRebalancingBridges:
     tron:
       - bridge: "0x9323793FB9a071ce5fE839079925c0e39f37170F"
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -139,7 +139,7 @@ arbitrum:
     type: RoutingFee
   type: collateral
 base:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook:
     domains:
       mode:
@@ -210,7 +210,7 @@ base:
       rateLimitPerSecond: "120000000"
       type: velo
 bob:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -234,7 +234,7 @@ bob:
       rateLimitPerSecond: "120000000"
       type: velo
 bsc:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -369,7 +369,7 @@ bsc:
     type: RoutingFee
   type: collateral
 celo:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -509,7 +509,7 @@ celo:
       rateLimitPerSecond: "120000000"
       type: velo
 ethereum:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -655,7 +655,7 @@ ethereum:
       rateLimitPerSecond: "120000000"
       type: velo
 fraxtal:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -679,7 +679,7 @@ fraxtal:
       rateLimitPerSecond: "120000000"
       type: velo
 ink:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -703,7 +703,7 @@ ink:
       rateLimitPerSecond: "120000000"
       type: velo
 lisk:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -727,7 +727,7 @@ lisk:
       rateLimitPerSecond: "120000000"
       type: velo
 metal:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -751,7 +751,7 @@ metal:
       rateLimitPerSecond: "120000000"
       type: velo
 mode:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook:
     domains:
       base:
@@ -822,7 +822,7 @@ mode:
       rateLimitPerSecond: "120000000"
       type: velo
 optimism:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook:
     domains:
       base:
@@ -893,7 +893,7 @@ optimism:
       rateLimitPerSecond: "120000000"
       type: velo
 soneium:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -917,7 +917,7 @@ soneium:
       rateLimitPerSecond: "120000000"
       type: velo
 tea:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -1062,7 +1062,7 @@ tron:
   allowedRebalancingBridges:
     arbitrum:
       - bridge: "0x43Bb7C9C64a05af94d67B52883a60756950058D7"
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -1088,7 +1088,7 @@ tron:
     type: OffchainQuotedLinearFee
   type: collateral
 unichain:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:
@@ -1112,7 +1112,7 @@ unichain:
       rateLimitPerSecond: "120000000"
       type: velo
 zerogravity:
-  contractVersion: 12.0.0
+  contractVersion: 12.1.0
   hook: "0x0000000000000000000000000000000000000000"
   interchainSecurityModule:
     modules:


### PR DESCRIPTION
## Summary

Converts the oUSDT **BSC leg from synthetic xERC20 to collateral** (backed by BSC-USD), matching monorepo PR hyperlane-xyz/hyperlane-monorepo#9354. Motivation: USDT is already established on BSC and the synthetic leg had **zero traffic** ([traffic check](https://hyperlaneworkspace.slack.com/archives/C0B93776ACE/p1787856550203059)), so it was safe to replace.

**Both collateral routers are now deployed and enrolled**, and this PR carries the resulting registry state — it is no longer a "remove the leg so `warp apply` redeploys it" change.

## Deploy configs (`staging-deploy.yaml`, `production-deploy.yaml`)

bsc block:
- `type: xERC20` → `type: collateral`
- `token` → real BSC USDT `0x55d398326f99059fF775485246999027B3197955`
- Removed the `xERC20.warpRouteLimits` block and (prod) the `ownerOverrides`
- Kept the existing ISM, owner, and OQLF `tokenFee`

Every leg of both routes (not just bsc):
- Explicit `scale`: `1/1` on the six-decimal legs, `1/1000000000000` on bsc so its eighteen-decimal collateral matches the six-decimal message encoding
- Staging legs pinned to `contractVersion: 12.1.0` (production was already there)

## Core configs (`staging-config.yaml`, `production-config.yaml`)

- The synthetic bsc token entry is **replaced** by the deployed collateral router — staging `0xa5bEf0033BBc07133963ac325F0cc51CcEB4A133` → `0x54599E9872AfC75C6bF70825B636F021641fa3a3`, production `0x1A71B45cFd7F02BEc4ea03bA4566f54a6e6cae5c` → `0xc283600F0A84162C0a062f7273ABB1F8F111b40C` — now `EvmHypCollateral` / `tokenType: collateral`, `decimals: 18`, collateral `0x55d398…`, and every other leg is relinked to it
- `scale` mirrored from the deploy configs onto every token, so the deploy ↔ core scale consistency check passes
- Production bsc carries the USDT `logoURI` the other real-USDT legs already use, keeping logo presence consistent across the route
- The production core config was regenerated by the CLI after the apply, which also refreshed labels on the untouched legs: `EvmHypVSXERC20`/`EvmHypVSXERC20Lockbox` → `EvmHypXERC20`/`EvmHypXERC20Lockbox`, arbitrum `USDT` → `USD₮0`, and celo/ethereum/tron `name: USDT` → `Tether USD`. No addresses on those legs changed

## Provenance

Configuration authority is monorepo PR hyperlane-xyz/hyperlane-monorepo#9354 (the generator that emits these configs); the two bsc router addresses above come from the staging and production `warp apply` runs of this change. Merge #9354 before or with this PR so the generator stays authoritative.

## Test plan

- [x] `pnpm run build`, `pnpm run lint`, `pnpm run format` clean
- [x] Unit suite green (8,234 passing / 1 pending), including `Warp scale consistency` — every deploy leg with a `scale` matches its core-config token on both routes
- [x] `validate-file-path` / `validate-svg` / `validate-file-data` pass; changeset present
- [x] Cross-checked config against deploy for both routes: 17 legs each, complete 16-peer topology, every `collateralAddressOrDenom` matching the deploy `token`
- [x] Staging bsc collateral router deployed and enrolled (`0x54599E98…`)
- [x] Production bsc collateral router deployed and enrolled (`0xc283600F…`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
