### PR TITLE
fix: update Starknet and Paradex RPC endpoints to spec v0.9

### DIFF
--- a/.changeset/starknet-paradex-rpc-v0-9.md
+++ b/.changeset/starknet-paradex-rpc-v0-9.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Updated Starknet and Paradex RPC endpoints to JSON-RPC spec version 0.9.

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -6609,9 +6609,9 @@ paradex:
     symbol: FUEL
   protocol: starknet
   rpcUrls:
-    - http: https://rpc.api.prod.paradex.trade/rpc/v0_8
-    - http: https://juno.api.prod.paradex.trade/rpc/v0_8
-    - http: https://pathfinder.api.prod.paradex.trade/rpc/v0_8
+    - http: https://rpc.api.prod.paradex.trade/rpc/v0_9
+    - http: https://juno.api.prod.paradex.trade/rpc/v0_9
+    - http: https://pathfinder.api.prod.paradex.trade/rpc/v0_9
   technicalStack: other
 paradexsepolia:
   blockExplorers:
@@ -8396,7 +8396,7 @@ starknet:
     symbol: STRK
   protocol: starknet
   rpcUrls:
-    - http: https://rpc.starknet.lava.build:443/
+    - http: https://rpc.starknet.lava.build:443/rpc/v0_9
   technicalStack: other
 starknetsepolia:
   blockExplorers:

--- a/chains/paradex/metadata.yaml
+++ b/chains/paradex/metadata.yaml
@@ -24,7 +24,7 @@ nativeToken:
   symbol: FUEL
 protocol: starknet
 rpcUrls:
-  - http: https://rpc.api.prod.paradex.trade/rpc/v0_8
-  - http: https://juno.api.prod.paradex.trade/rpc/v0_8
-  - http: https://pathfinder.api.prod.paradex.trade/rpc/v0_8
+  - http: https://rpc.api.prod.paradex.trade/rpc/v0_9
+  - http: https://juno.api.prod.paradex.trade/rpc/v0_9
+  - http: https://pathfinder.api.prod.paradex.trade/rpc/v0_9
 technicalStack: other

--- a/chains/starknet/metadata.yaml
+++ b/chains/starknet/metadata.yaml
@@ -24,5 +24,5 @@ nativeToken:
   symbol: STRK
 protocol: starknet
 rpcUrls:
-  - http: https://rpc.starknet.lava.build:443/
+  - http: https://rpc.starknet.lava.build:443/rpc/v0_9
 technicalStack: other


### PR DESCRIPTION
## Summary
- Updated Starknet mainnet Lava RPC endpoint to JSON-RPC spec **v0.9** (`https://rpc.starknet.lava.build:443/rpc/v0_9`). The bare endpoint currently serves 0.10.2.
- Updated all three Paradex mainnet RPC endpoints from `/rpc/v0_8` to `/rpc/v0_9`.
- Updated the aggregate `chains/metadata.yaml` accordingly and added a changeset.

## Verification
- `rpc.starknet.lava.build:443/rpc/v0_9` → `starknet_specVersion` returns `0.9.0`.
- `rpc.api.prod.paradex.trade/rpc/v0_9` → `starknet_specVersion` returns `0.9.0`.
- Paradex `juno`/`pathfinder` hosts return 403 to non-browser probes for both v0_8 and v0_9 (WAF/UA block), so the version path was updated to match the primary host.

Scope: mainnet `starknet` and `paradex` only (sepolia untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)