### PR TITLE
chore: deprecate august 28 mainnet chains

### DIFF
--- a/.changeset/deprecate-aug-28-2026-chains.md
+++ b/.changeset/deprecate-aug-28-2026-chains.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+appchain, flowmainnet, and immutablezkevmmainnet were marked as deprecated

--- a/chains/appchain/metadata.yaml
+++ b/chains/appchain/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.appchain.xyz/api
     family: blockscout

--- a/chains/flowmainnet/metadata.yaml
+++ b/chains/flowmainnet/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://evm.flowscan.io/api
     family: blockscout

--- a/chains/immutablezkevmmainnet/metadata.yaml
+++ b/chains/immutablezkevmmainnet/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.immutable.com/api
     family: blockscout

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -326,6 +326,10 @@ apechain:
     - http: https://rpc.apechain.com/http
   technicalStack: arbitrumnitro
 appchain:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.appchain.xyz/api
       family: blockscout
@@ -3190,6 +3194,10 @@ flare:
     - http: https://rpc.ankr.com/flare
   technicalStack: other
 flowmainnet:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://evm.flowscan.io/api
       family: blockscout
@@ -4086,6 +4094,10 @@ igra:
   transactionOverrides:
     gasPrice: 1000000000000
 immutablezkevmmainnet:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.immutable.com/api
       family: blockscout


### PR DESCRIPTION
## Summary

- mark appchain, flowmainnet, and immutablezkevmmainnet disabled with the deprecated availability reason
- retain SOON as already deprecated in registry metadata
- regenerate combined chain metadata
- add a patch changeset

## Tracking

- AppChain: https://linear.app/hyperlane-xyz/issue/ENG-3932/appchain
- Flow: https://linear.app/hyperlane-xyz/issue/ENG-4006/flowmainnet
- Immutable zkEVM: https://linear.app/hyperlane-xyz/issue/ENG-4119/immutablezkevmmainnet
- SOON: https://linear.app/hyperlane-xyz/issue/ENG-3607/soon

## Validation

- Node 26.6.0: pnpm run build
- oxfmt check on changed metadata files
- changeset status parsed successfully