### PR TITLE
chore(KII/kiichain): record kiichain leg ISM in registry

### DIFF
--- a/.changeset/kii-kiichain-leg-ism-catchup.md
+++ b/.changeset/kii-kiichain-leg-ism-catchup.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Recorded the on-chain interchainSecurityModule for the KII/kiichain warp route's kiichain leg. The kiichain leg was left out of #1666 while the chain was halted, but the router has the same staticAggregationIsm (threshold = all) wrapping a rateLimitedIsm (1M KII/day), a pausableIsm, and a defaultFallbackRoutingIsm as the EVM legs. The rate-limit and fallback modules are owned by the kiichain token owner; the pausable module is owned by the dedicated Turnkey pauser key. This aligns the registry with on-chain state now that kiichain is live.

--- a/deployments/warp_routes/KII/kiichain-deploy.yaml
+++ b/deployments/warp_routes/KII/kiichain-deploy.yaml
@@ -102,6 +102,19 @@ ethereum:
 
 kiichain:
   decimals: 18
+  interchainSecurityModule:
+    modules:
+      - maxCapacity: "999999999999999993600000"
+        owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
+        type: rateLimitedIsm
+      - owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+        paused: false
+        type: pausableIsm
+      - domains: {}
+        owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
+        type: defaultFallbackRoutingIsm
+    threshold: 3
+    type: staticAggregationIsm
   mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
   owner: "0x30C48d3F3650C3f4A741588672CDc811Ed5303bd"
   type: native


### PR DESCRIPTION
## Summary
- PagerDuty Q3F3NBZJLZ8SXV: Warp Config Checker fires `ConfigMismatch` for `interchainSecurityModule` on KII/kiichain (`chain=kiichain`).
- Root cause: #1666 added the staticAggregationIsm to the EVM legs on-chain and in the registry but intentionally omitted the kiichain leg while that chain was halted. The kiichain router has the same ISM on-chain (`0x5dA16E7E42232496c9893cFD419bCd4a71Eb4723`), and kiichain is now live, so the checker flags the missing registry entry.
- Fix: record the on-chain ISM on the kiichain leg. Aggregation matches EVM legs: rateLimited (`maxCapacity=999999999999999993600000`, owner `0x30C48d3F...`), pausable (owner `0x60Cc386C...`, dedicated Turnkey pauser), defaultFallbackRouting (owner `0x30C48d3F...`), threshold 3.

Verified on-chain via `cast` against kiichain RPC: router `0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886` `interchainSecurityModule()` = aggregation ISM, `modulesAndThreshold` = 3 modules / threshold 3.

## Test plan
- [ ] Warp Config Checker clears the KII/kiichain `interchainSecurityModule` mismatch on next run.