### PR TITLE
feat!: migrate registry schemas to Zod 4.5

### DIFF
--- a/.changeset/migrate-zod-4-5.md
+++ b/.changeset/migrate-zod-4-5.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': major
+---
+
+Zod was upgraded to 4.5.2, and the registry's exported schemas, SDK validation dependencies, and generated JSON schemas were migrated to Zod 4.

--- a/chains/schema.json
+++ b/chains/schema.json
@@ -1,422 +1,90 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/hyperlaneChainMetadata",
   "definitions": {
     "hyperlaneChainMetadata": {
       "type": "object",
       "properties": {
         "availability": {
-          "anyOf": [
-            {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "string",
-                  "const": "disabled",
-                  "description": "The status that represents the chain availability. See ChainStatus for valid values."
-                },
-                "reasons": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "badrpc",
-                      "deprecated",
-                      "private",
-                      "unavailable",
-                      "other"
-                    ]
-                  },
-                  "minItems": 1,
-                  "description": "List of reasons explaining why the chain is disabled."
-                }
-              },
-              "required": [
-                "status",
-                "reasons"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "string",
-                  "const": "live",
-                  "description": "The status that represents the chain availability. See ChainStatus for valid values."
-                }
-              },
-              "required": [
-                "status"
-              ],
-              "additionalProperties": false
-            }
-          ],
-          "description": "Specifies if the chain is available and the reasons why it is disabled."
+          "$ref": "#/definitions/__schema0"
         },
         "bech32Prefix": {
-          "type": "string",
-          "description": "The human readable address prefix for the chains using bech32."
+          "$ref": "#/definitions/__schema3"
         },
         "blockExplorers": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "A human readable name for the explorer."
-              },
-              "url": {
-                "type": "string",
-                "format": "uri",
-                "description": "The base URL for the explorer."
-              },
-              "apiUrl": {
-                "type": "string",
-                "format": "uri",
-                "description": "The base URL for requests to the explorer API."
-              },
-              "apiKey": {
-                "type": "string",
-                "description": "An API key for the explorer (recommended for better reliability)."
-              },
-              "family": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "enum": [
-                      "etherscan",
-                      "blockscout",
-                      "routescan",
-                      "voyager",
-                      "zksync",
-                      "radixdashboard",
-                      "tronscan",
-                      "other",
-                      "unknown"
-                    ]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ],
-                "description": "The type of the block explorer. See ExplorerFamily for valid values."
-              }
-            },
-            "required": [
-              "name",
-              "url",
-              "apiUrl"
-            ],
-            "additionalProperties": false
-          },
-          "description": "A list of block explorers with data for this chain"
+          "$ref": "#/definitions/__schema5"
         },
         "blocks": {
-          "type": "object",
-          "properties": {
-            "confirmations": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Number of blocks to wait before considering a transaction confirmed."
-            },
-            "reorgPeriod": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 0
-                },
-                {
-                  "type": "string"
-                }
-              ],
-              "description": "Number of blocks before a transaction has a near-zero chance of reverting or block tag."
-            },
-            "estimateBlockTime": {
-              "type": "number",
-              "exclusiveMinimum": 0,
-              "description": "Rough estimate of time per block in seconds."
-            }
-          },
-          "required": [
-            "confirmations"
-          ],
-          "additionalProperties": false,
-          "description": "Block settings for the chain/deployment."
+          "$ref": "#/definitions/__schema9"
         },
         "bypassBatchSimulation": {
-          "type": "boolean",
-          "description": "Whether to bypass batch simulation for this chain."
+          "$ref": "#/definitions/__schema14"
         },
         "chainId": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/hyperlaneChainMetadata/properties/blocks/properties/reorgPeriod/anyOf/0"
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "The chainId of the chain. Uses EIP-155 for EVM chains"
+          "$ref": "#/definitions/__schema16"
         },
         "customGrpcUrls": {
-          "type": "string",
-          "description": "Specify a comma separated list of custom GRPC URLs to use for this chain. If not specified, the default GRPC urls will be used."
+          "$ref": "#/definitions/__schema18"
         },
         "deployer": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "The name of the deployer."
-            },
-            "email": {
-              "type": "string",
-              "format": "email",
-              "description": "The email address of the deployer."
-            },
-            "url": {
-              "type": "string",
-              "format": "uri",
-              "description": "The URL of the deployer."
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "additionalProperties": false,
-          "description": "Identity information of the deployer of a Hyperlane instance to this chain"
+          "$ref": "#/definitions/__schema20"
         },
         "displayName": {
-          "type": "string",
-          "description": "Human-readable name of the chain."
+          "$ref": "#/definitions/__schema24"
         },
         "displayNameShort": {
-          "type": "string",
-          "description": "A shorter human-readable name of the chain for use in user interfaces."
+          "$ref": "#/definitions/__schema26"
         },
         "domainId": {
-          "type": "integer",
-          "exclusiveMinimum": 0,
-          "description": "The domainId of the chain, should generally default to `chainId`. Consumer of `ChainMetadata` should use this value or `name` as a unique identifier."
+          "$ref": "#/definitions/__schema28"
         },
         "gasCurrencyCoinGeckoId": {
-          "type": "string",
-          "description": "The ID on CoinGecko of the token used for gas payments."
+          "$ref": "#/definitions/__schema30"
         },
         "gnosisSafeTransactionServiceUrl": {
-          "type": "string",
-          "description": "The URL of the gnosis safe transaction service."
+          "$ref": "#/definitions/__schema32"
         },
         "gnosisSafeApiKey": {
-          "type": "string",
-          "description": "The API key for the gnosis safe transaction service."
+          "$ref": "#/definitions/__schema34"
         },
         "grpcUrls": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "http": {
-                "type": "string",
-                "format": "uri",
-                "description": "The HTTP URL of the RPC endpoint (preferably HTTPS)."
-              },
-              "concurrency": {
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "description": "Maximum number of concurrent RPC requests."
-              },
-              "webSocket": {
-                "type": "string",
-                "description": "The WSS URL if the endpoint also supports websockets."
-              },
-              "pagination": {
-                "type": "object",
-                "properties": {
-                  "maxBlockRange": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "description": "The maximum range between block numbers for which the RPC can query data"
-                  },
-                  "minBlockNumber": {
-                    "$ref": "#/definitions/hyperlaneChainMetadata/properties/blocks/properties/reorgPeriod/anyOf/0",
-                    "description": "The absolute minimum block number that this RPC supports."
-                  },
-                  "maxBlockAge": {
-                    "$ref": "#/definitions/hyperlaneChainMetadata/properties/grpcUrls/items/properties/pagination/properties/maxBlockRange",
-                    "description": "The relative different from latest block that this RPC supports."
-                  }
-                },
-                "additionalProperties": false,
-                "description": "Limitations on the block range/age that can be queried."
-              },
-              "retry": {
-                "type": "object",
-                "properties": {
-                  "maxRequests": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "description": "The maximum number of requests to attempt before failing."
-                  },
-                  "baseRetryMs": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "description": "The base retry delay in milliseconds."
-                  }
-                },
-                "required": [
-                  "maxRequests",
-                  "baseRetryMs"
-                ],
-                "additionalProperties": false,
-                "description": "Default retry settings to be used by a provider such as MultiProvider."
-              },
-              "public": {
-                "type": "boolean",
-                "description": "Flag if the RPC is publicly available."
-              }
-            },
-            "required": [
-              "http"
-            ],
-            "additionalProperties": false
-          },
-          "description": "For cosmos chains only, a list of gRPC API URLs"
+          "$ref": "#/definitions/__schema36"
         },
         "index": {
-          "type": "object",
-          "properties": {
-            "from": {
-              "type": "number",
-              "description": "The block to start any indexing from."
-            }
-          },
-          "additionalProperties": false,
-          "description": "Indexing settings for the chain."
+          "$ref": "#/definitions/__schema43"
         },
         "isTestnet": {
-          "type": "boolean",
-          "description": "Whether the chain is considered a testnet or a mainnet."
+          "$ref": "#/definitions/__schema46"
         },
         "logoURI": {
-          "type": "string",
-          "description": "A URI to a logo image for this chain for use in user interfaces."
+          "$ref": "#/definitions/__schema48"
         },
         "name": {
-          "type": "string",
-          "pattern": "^[a-z][a-z0-9]*$",
-          "description": "The unique string identifier of the chain, used as the key in ChainMap dictionaries."
+          "$ref": "#/definitions/__schema50"
         },
         "nativeToken": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "symbol": {
-              "type": "string"
-            },
-            "decimals": {
-              "type": "integer",
-              "minimum": 0,
-              "exclusiveMaximum": 256
-            },
-            "denom": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "symbol",
-            "decimals"
-          ],
-          "additionalProperties": false,
-          "description": "The metadata of the native token of the chain (e.g. ETH for Ethereum)."
+          "$ref": "#/definitions/__schema51"
         },
         "protocol": {
-          "anyOf": [
-            {
-              "type": "string",
-              "enum": [
-                "ethereum",
-                "sealevel",
-                "cosmos",
-                "cosmosnative",
-                "starknet",
-                "radix",
-                "aleo",
-                "tron",
-                "unknown"
-              ]
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "The type of protocol used by this chain. See ProtocolType for valid values."
+          "$ref": "#/definitions/__schema53"
         },
         "restUrls": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/hyperlaneChainMetadata/properties/grpcUrls/items"
-          },
-          "description": "For cosmos chains only, a list of Rest API URLs"
+          "$ref": "#/definitions/__schema55"
         },
         "rpcUrls": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/hyperlaneChainMetadata/properties/grpcUrls/items"
-          },
-          "minItems": 1,
-          "description": "The list of RPC endpoints for interacting with the chain."
+          "$ref": "#/definitions/__schema56"
         },
         "slip44": {
-          "type": "number",
-          "description": "The SLIP-0044 coin type."
+          "$ref": "#/definitions/__schema57"
         },
         "technicalStack": {
-          "anyOf": [
-            {
-              "type": "string",
-              "enum": [
-                "arbitrumnitro",
-                "opstack",
-                "polygoncdk",
-                "polkadotsubstrate",
-                "seismic",
-                "zksync",
-                "other",
-                "unknown"
-              ]
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "description": "The technical stack of the chain. See ChainTechnicalStack for valid values."
+          "$ref": "#/definitions/__schema59"
         },
         "transactionOverrides": {
-          "type": "object",
-          "additionalProperties": {},
-          "description": "Properties to include when forming transaction requests."
+          "$ref": "#/definitions/__schema61"
         },
         "gasPrice": {
-          "type": "object",
-          "properties": {
-            "denom": {
-              "type": "string"
-            },
-            "amount": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "denom",
-            "amount"
-          ],
-          "additionalProperties": false,
-          "description": "The gas price of Cosmos chains."
+          "$ref": "#/definitions/__schema63"
         }
       },
       "required": [
@@ -427,7 +95,700 @@
         "rpcUrls"
       ],
       "additionalProperties": false
+    },
+    "__schema0": {
+      "description": "Specifies if the chain is available and the reasons why it is disabled.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema1"
+        }
+      ]
+    },
+    "__schema1": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "const": "disabled",
+              "description": "The status that represents the chain availability. See ChainStatus for valid values."
+            },
+            "reasons": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/__schema2"
+              },
+              "description": "List of reasons explaining why the chain is disabled."
+            }
+          },
+          "required": [
+            "status",
+            "reasons"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "const": "live",
+              "description": "The status that represents the chain availability. See ChainStatus for valid values."
+            }
+          },
+          "required": [
+            "status"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "__schema2": {
+      "type": "string",
+      "enum": [
+        "badrpc",
+        "deprecated",
+        "private",
+        "unavailable",
+        "other"
+      ]
+    },
+    "__schema3": {
+      "description": "The human readable address prefix for the chains using bech32.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema4"
+        }
+      ]
+    },
+    "__schema4": {
+      "type": "string"
+    },
+    "__schema5": {
+      "description": "A list of block explorers with data for this chain",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema6"
+        }
+      ]
+    },
+    "__schema6": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A human readable name for the explorer."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The base URL for the explorer."
+          },
+          "apiUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "The base URL for requests to the explorer API."
+          },
+          "apiKey": {
+            "description": "An API key for the explorer (recommended for better reliability).",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema7"
+              }
+            ]
+          },
+          "family": {
+            "description": "The type of the block explorer. See ExplorerFamily for valid values.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema8"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "url",
+          "apiUrl"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "__schema7": {
+      "type": "string"
+    },
+    "__schema8": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "etherscan",
+            "blockscout",
+            "routescan",
+            "voyager",
+            "zksync",
+            "radixdashboard",
+            "tronscan",
+            "other",
+            "unknown"
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "__schema9": {
+      "description": "Block settings for the chain/deployment.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema10"
+        }
+      ]
+    },
+    "__schema10": {
+      "type": "object",
+      "properties": {
+        "confirmations": {
+          "description": "Number of blocks to wait before considering a transaction confirmed.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema11"
+            }
+          ]
+        },
+        "reorgPeriod": {
+          "description": "Number of blocks before a transaction has a near-zero chance of reverting or block tag.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema12"
+            }
+          ]
+        },
+        "estimateBlockTime": {
+          "description": "Rough estimate of time per block in seconds.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema13"
+            }
+          ]
+        }
+      },
+      "required": [
+        "confirmations"
+      ],
+      "additionalProperties": false
+    },
+    "__schema11": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "__schema12": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/__schema11"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "__schema13": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "__schema14": {
+      "description": "Whether to bypass batch simulation for this chain.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema15"
+        }
+      ]
+    },
+    "__schema15": {
+      "type": "boolean"
+    },
+    "__schema16": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/__schema11"
+        },
+        {
+          "$ref": "#/definitions/__schema17"
+        }
+      ],
+      "description": "The chainId of the chain. Uses EIP-155 for EVM chains"
+    },
+    "__schema17": {
+      "type": "string"
+    },
+    "__schema18": {
+      "description": "Specify a comma separated list of custom GRPC URLs to use for this chain. If not specified, the default GRPC urls will be used.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema19"
+        }
+      ]
+    },
+    "__schema19": {
+      "type": "string"
+    },
+    "__schema20": {
+      "description": "Identity information of the deployer of a Hyperlane instance to this chain",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema21"
+        }
+      ]
+    },
+    "__schema21": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the deployer."
+        },
+        "email": {
+          "description": "The email address of the deployer.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema22"
+            }
+          ]
+        },
+        "url": {
+          "description": "The URL of the deployer.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema23"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "__schema22": {
+      "type": "string",
+      "format": "email",
+      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+    },
+    "__schema23": {
+      "type": "string",
+      "format": "uri"
+    },
+    "__schema24": {
+      "description": "Human-readable name of the chain.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema25"
+        }
+      ]
+    },
+    "__schema25": {
+      "type": "string"
+    },
+    "__schema26": {
+      "description": "A shorter human-readable name of the chain for use in user interfaces.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema27"
+        }
+      ]
+    },
+    "__schema27": {
+      "type": "string"
+    },
+    "__schema28": {
+      "description": "The domainId of the chain, should generally default to `chainId`. Consumer of `ChainMetadata` should use this value or `name` as a unique identifier.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema29"
+        }
+      ]
+    },
+    "__schema29": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991
+    },
+    "__schema30": {
+      "description": "The ID on CoinGecko of the token used for gas payments.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema31"
+        }
+      ]
+    },
+    "__schema31": {
+      "type": "string"
+    },
+    "__schema32": {
+      "description": "The URL of the gnosis safe transaction service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema33"
+        }
+      ]
+    },
+    "__schema33": {
+      "type": "string"
+    },
+    "__schema34": {
+      "description": "The API key for the gnosis safe transaction service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema35"
+        }
+      ]
+    },
+    "__schema35": {
+      "type": "string"
+    },
+    "__schema36": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/__schema37"
+      },
+      "description": "For cosmos chains only, a list of gRPC API URLs"
+    },
+    "__schema37": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "type": "string",
+          "format": "uri",
+          "description": "The HTTP URL of the RPC endpoint (preferably HTTPS)."
+        },
+        "concurrency": {
+          "description": "Maximum number of concurrent RPC requests.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema38"
+            }
+          ]
+        },
+        "webSocket": {
+          "description": "The WSS URL if the endpoint also supports websockets.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema39"
+            }
+          ]
+        },
+        "pagination": {
+          "description": "Limitations on the block range/age that can be queried.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema40"
+            }
+          ]
+        },
+        "retry": {
+          "description": "Default retry settings to be used by a provider such as MultiProvider.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema41"
+            }
+          ]
+        },
+        "public": {
+          "description": "Flag if the RPC is publicly available.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema42"
+            }
+          ]
+        }
+      },
+      "required": [
+        "http"
+      ],
+      "additionalProperties": false
+    },
+    "__schema38": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991
+    },
+    "__schema39": {
+      "type": "string"
+    },
+    "__schema40": {
+      "type": "object",
+      "properties": {
+        "maxBlockRange": {
+          "description": "The maximum range between block numbers for which the RPC can query data",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema29"
+            }
+          ]
+        },
+        "minBlockNumber": {
+          "description": "The absolute minimum block number that this RPC supports.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema11"
+            }
+          ]
+        },
+        "maxBlockAge": {
+          "description": "The relative different from latest block that this RPC supports.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema29"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "__schema41": {
+      "type": "object",
+      "properties": {
+        "maxRequests": {
+          "description": "The maximum number of requests to attempt before failing.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema29"
+            }
+          ]
+        },
+        "baseRetryMs": {
+          "description": "The base retry delay in milliseconds.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema29"
+            }
+          ]
+        }
+      },
+      "required": [
+        "maxRequests",
+        "baseRetryMs"
+      ],
+      "additionalProperties": false
+    },
+    "__schema42": {
+      "type": "boolean"
+    },
+    "__schema43": {
+      "description": "Indexing settings for the chain.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema44"
+        }
+      ]
+    },
+    "__schema44": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "description": "The block to start any indexing from.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema45"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "__schema45": {
+      "type": "number"
+    },
+    "__schema46": {
+      "description": "Whether the chain is considered a testnet or a mainnet.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema47"
+        }
+      ]
+    },
+    "__schema47": {
+      "type": "boolean"
+    },
+    "__schema48": {
+      "description": "A URI to a logo image for this chain for use in user interfaces.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema49"
+        }
+      ]
+    },
+    "__schema49": {
+      "type": "string"
+    },
+    "__schema50": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*$",
+      "description": "The unique string identifier of the chain, used as the key in ChainMap dictionaries."
+    },
+    "__schema51": {
+      "description": "The metadata of the native token of the chain (e.g. ETH for Ethereum).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema52"
+        }
+      ]
+    },
+    "__schema52": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "symbol": {
+          "type": "string"
+        },
+        "decimals": {
+          "exclusiveMaximum": 256,
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema11"
+            }
+          ]
+        },
+        "denom": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "symbol",
+        "decimals"
+      ],
+      "additionalProperties": false
+    },
+    "__schema53": {
+      "description": "The type of protocol used by this chain. See ProtocolType for valid values.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema54"
+        }
+      ]
+    },
+    "__schema54": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "ethereum",
+            "sealevel",
+            "cosmos",
+            "cosmosnative",
+            "starknet",
+            "radix",
+            "aleo",
+            "tron",
+            "unknown"
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "__schema55": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/__schema37"
+      },
+      "description": "For cosmos chains only, a list of Rest API URLs"
+    },
+    "__schema56": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/__schema37"
+      },
+      "description": "The list of RPC endpoints for interacting with the chain."
+    },
+    "__schema57": {
+      "description": "The SLIP-0044 coin type.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema58"
+        }
+      ]
+    },
+    "__schema58": {
+      "type": "number"
+    },
+    "__schema59": {
+      "description": "The technical stack of the chain. See ChainTechnicalStack for valid values.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema60"
+        }
+      ]
+    },
+    "__schema60": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "arbitrumnitro",
+            "opstack",
+            "polygoncdk",
+            "polkadotsubstrate",
+            "seismic",
+            "zksync",
+            "other",
+            "unknown"
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "__schema61": {
+      "description": "Properties to include when forming transaction requests.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema62"
+        }
+      ]
+    },
+    "__schema62": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    },
+    "__schema63": {
+      "description": "The gas price of Cosmos chains.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema64"
+        }
+      ]
+    },
+    "__schema64": {
+      "type": "object",
+      "properties": {
+        "denom": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "denom",
+        "amount"
+      ],
+      "additionalProperties": false
     }
-  },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  }
 }

--- a/deployments/warp_routes/schema.json
+++ b/deployments/warp_routes/schema.json
@@ -1,437 +1,569 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/hyperlaneWarpCoreConfig",
   "definitions": {
     "hyperlaneWarpCoreConfig": {
       "type": "object",
       "properties": {
         "tokens": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "chainName": {
-                "type": "string",
-                "pattern": "^[a-z][a-z0-9]*$",
-                "description": "The name of the chain, must correspond to a chain in the multiProvider chainMetadata"
-              },
-              "standard": {
-                "type": "string",
-                "enum": [
-                  "ERC20",
-                  "ERC721",
-                  "EvmNative",
-                  "EvmHypNative",
-                  "EvmHypCollateral",
-                  "EvmHypOwnerCollateral",
-                  "EvmHypRebaseCollateral",
-                  "EvmHypCollateralFiat",
-                  "EvmHypSynthetic",
-                  "EvmHypSyntheticRebase",
-                  "EvmHypXERC20",
-                  "EvmHypXERC20Lockbox",
-                  "EvmHypVSXERC20",
-                  "EvmHypVSXERC20Lockbox",
-                  "EvmM0PortalLite",
-                  "EvmM0Portal",
-                  "EvmHypEverclearCollateral",
-                  "EvmHypEverclearEth",
-                  "EvmHypCrossCollateralRouter",
-                  "EvmAtomicLocalRebalancingBridge",
-                  "SealevelSpl",
-                  "SealevelSpl2022",
-                  "SealevelNative",
-                  "SealevelHypNative",
-                  "SealevelHypCollateral",
-                  "SealevelHypSynthetic",
-                  "SealevelHypCrossCollateral",
-                  "CosmosIcs20",
-                  "CosmosIcs721",
-                  "CosmosNative",
-                  "CosmosIbc",
-                  "CW20",
-                  "CWNative",
-                  "CW721",
-                  "CwHypNative",
-                  "CwHypCollateral",
-                  "CwHypSynthetic",
-                  "CosmosNativeHypCollateral",
-                  "CosmosNativeHypSynthetic",
-                  "StarknetNative",
-                  "StarknetHypNative",
-                  "StarknetHypCollateral",
-                  "StarknetHypSynthetic",
-                  "RadixNative",
-                  "RadixHypCollateral",
-                  "RadixHypSynthetic",
-                  "AleoNative",
-                  "AleoHypNative",
-                  "AleoHypCollateral",
-                  "AleoHypSynthetic",
-                  "TRC20",
-                  "TRC721",
-                  "TronNative",
-                  "TronHypNative",
-                  "TronHypCollateral",
-                  "TronHypOwnerCollateral",
-                  "TronHypRebaseCollateral",
-                  "TronHypCollateralFiat",
-                  "TronHypSynthetic",
-                  "TronHypSyntheticRebase",
-                  "TronHypXERC20",
-                  "TronHypXERC20Lockbox",
-                  "TronHypVSXERC20",
-                  "TronHypVSXERC20Lockbox",
-                  "TronM0PortalLite",
-                  "TronHypEverclearCollateral",
-                  "TronHypEverclearEth",
-                  "TronHypCrossCollateralRouter",
-                  "TronAtomicLocalRebalancingBridge"
-                ],
-                "description": "The type of token. See TokenStandard for valid values."
-              },
-              "tokenType": {
-                "type": "string",
-                "enum": [
-                  "synthetic",
-                  "syntheticRebase",
-                  "syntheticUri",
-                  "collateral",
-                  "collateralVault",
-                  "collateralVaultRebase",
-                  "xERC20",
-                  "xERC20Lockbox",
-                  "collateralFiat",
-                  "collateralUri",
-                  "collateralCctp",
-                  "collateralEverclear",
-                  "collateralDepositAddress",
-                  "collateralOft",
-                  "atomicLocalRebalancing",
-                  "native",
-                  "nativeOpL2",
-                  "nativeOpL1",
-                  "ethEverclear",
-                  "nativeScaled",
-                  "crossCollateral",
-                  "unknown"
-                ],
-                "description": "The warp route deploy token type. Used to preserve route implementation semantics when multiple deploy token types share the same token standard."
-              },
-              "decimals": {
-                "type": "integer",
-                "minimum": 0,
-                "exclusiveMaximum": 256,
-                "description": "The decimals value (e.g. 18 for Eth)"
-              },
-              "symbol": {
-                "type": "string",
-                "minLength": 1,
-                "description": "The symbol of the token"
-              },
-              "name": {
-                "type": "string",
-                "minLength": 1,
-                "description": "The name of the token"
-              },
-              "addressOrDenom": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "The address or denom; null config values are normalized to an empty string for native tokens"
-              },
-              "collateralAddressOrDenom": {
-                "type": "string",
-                "minLength": 1,
-                "description": "The address or denom of the collateralized token"
-              },
-              "igpTokenAddressOrDenom": {
-                "type": "string",
-                "minLength": 1,
-                "description": "The address or denom of the token for IGP payments"
-              },
-              "logoURI": {
-                "type": "string",
-                "description": "The URI of the token logo"
-              },
-              "connections": {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "const": "hyperlane"
-                            },
-                            "token": {
-                              "type": "string",
-                              "pattern": "^(.+)\\|(.+)\\|(.+)$"
-                            }
-                          },
-                          "required": [
-                            "token"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string",
-                              "const": "ibc"
-                            },
-                            "token": {
-                              "type": "string",
-                              "pattern": "^(.+)\\|(.+)\\|(.+)$"
-                            },
-                            "sourcePort": {
-                              "type": "string"
-                            },
-                            "sourceChannel": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "token",
-                            "sourcePort",
-                            "sourceChannel"
-                          ],
-                          "additionalProperties": false
-                        }
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "const": "ibc-hyperlane"
-                        },
-                        "token": {
-                          "type": "string",
-                          "pattern": "^(.+)\\|(.+)\\|(.+)$"
-                        },
-                        "sourcePort": {
-                          "type": "string"
-                        },
-                        "sourceChannel": {
-                          "type": "string"
-                        },
-                        "intermediateChainName": {
-                          "type": "string",
-                          "pattern": "^[a-z][a-z0-9]*$"
-                        },
-                        "intermediateIbcDenom": {
-                          "type": "string"
-                        },
-                        "intermediateRouterAddress": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "token",
-                        "sourcePort",
-                        "sourceChannel",
-                        "intermediateChainName",
-                        "intermediateIbcDenom",
-                        "intermediateRouterAddress"
-                      ],
-                      "additionalProperties": false
-                    }
-                  ]
-                },
-                "description": "The list of token connections (e.g. warp or IBC)"
-              },
-              "coinGeckoId": {
-                "type": "string",
-                "description": "The CoinGecko id of the token, used for price lookups"
-              },
-              "scale": {
-                "anyOf": [
-                  {
-                    "type": "integer",
-                    "exclusiveMinimum": 0
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "numerator": {
-                        "type": "integer",
-                        "exclusiveMinimum": 0
-                      },
-                      "denominator": {
-                        "type": "integer",
-                        "exclusiveMinimum": 0
-                      }
-                    },
-                    "required": [
-                      "numerator",
-                      "denominator"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "numerator": {
-                        "anyOf": [
-                          {
-                            "anyOf": [
-                              {
-                                "type": "integer",
-                                "format": "int64"
-                              },
-                              {
-                                "type": "integer",
-                                "minimum": 0
-                              }
-                            ]
-                          },
-                          {
-                            "type": "string",
-                            "pattern": "^[0-9]+$"
-                          }
-                        ]
-                      },
-                      "denominator": {
-                        "$ref": "#/definitions/hyperlaneWarpCoreConfig/properties/tokens/items/properties/scale/anyOf/2/properties/numerator"
-                      }
-                    },
-                    "required": [
-                      "numerator",
-                      "denominator"
-                    ],
-                    "additionalProperties": false
-                  }
-                ],
-                "description": "The scaling factor of the token"
-              },
-              "warpRouteId": {
-                "type": "string",
-                "minLength": 1,
-                "description": "Unique warp route identifier, used to disambiguate tokens that share the same addressOrDenom on the same chain (e.g. M0 Portal tokens)"
-              }
-            },
-            "required": [
-              "chainName",
-              "standard",
-              "decimals",
-              "symbol",
-              "name",
-              "addressOrDenom"
-            ],
-            "additionalProperties": false
-          }
+          "$ref": "#/definitions/__schema0"
         },
         "options": {
-          "type": "object",
-          "properties": {
-            "localFeeConstants": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "origin": {
-                    "$ref": "#/definitions/hyperlaneWarpCoreConfig/properties/tokens/items/properties/connections/items/anyOf/1/properties/intermediateChainName"
-                  },
-                  "destination": {
-                    "$ref": "#/definitions/hyperlaneWarpCoreConfig/properties/tokens/items/properties/connections/items/anyOf/1/properties/intermediateChainName"
-                  },
-                  "amount": {
-                    "type": [
-                      "string",
-                      "number",
-                      "integer"
-                    ]
-                  },
-                  "addressOrDenom": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "origin",
-                  "destination",
-                  "amount"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "interchainFeeConstants": {
-              "$ref": "#/definitions/hyperlaneWarpCoreConfig/properties/options/properties/localFeeConstants"
-            },
-            "routeBlacklist": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "origin": {
-                    "$ref": "#/definitions/hyperlaneWarpCoreConfig/properties/tokens/items/properties/connections/items/anyOf/1/properties/intermediateChainName"
-                  },
-                  "destination": {
-                    "$ref": "#/definitions/hyperlaneWarpCoreConfig/properties/tokens/items/properties/connections/items/anyOf/1/properties/intermediateChainName"
-                  }
-                },
-                "required": [
-                  "origin",
-                  "destination"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "sealevel": {
-              "type": "object",
-              "properties": {
-                "altAddresses": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "core": {
-                        "type": "string"
-                      },
-                      "warpSpecific": {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/hyperlaneWarpCoreConfig/properties/options/properties/sealevel/properties/altAddresses/additionalProperties/properties/core"
-                        },
-                        "minItems": 1
-                      }
-                    },
-                    "required": [
-                      "core",
-                      "warpSpecific"
-                    ],
-                    "additionalProperties": false
-                  },
-                  "propertyNames": {
-                    "pattern": "^[a-z][a-z0-9]*$"
-                  },
-                  "description": "Sealevel Address Lookup Table addresses per chain. `core` is the chain-shared ALT; `warpSpecific` lists the warp-route-specific ALTs."
-                }
-              },
-              "additionalProperties": false,
-              "description": "Sealevel-specific options for this warp route."
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/definitions/__schema14"
         }
       },
       "required": [
         "tokens"
       ],
       "additionalProperties": false
+    },
+    "__schema0": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "chainName": {
+            "description": "The name of the chain, must correspond to a chain in the multiProvider chainMetadata",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema1"
+              }
+            ]
+          },
+          "standard": {
+            "type": "string",
+            "enum": [
+              "ERC20",
+              "ERC721",
+              "EvmNative",
+              "EvmHypNative",
+              "EvmHypCollateral",
+              "EvmHypOwnerCollateral",
+              "EvmHypRebaseCollateral",
+              "EvmHypCollateralFiat",
+              "EvmHypSynthetic",
+              "EvmHypSyntheticRebase",
+              "EvmHypXERC20",
+              "EvmHypXERC20Lockbox",
+              "EvmHypVSXERC20",
+              "EvmHypVSXERC20Lockbox",
+              "EvmM0PortalLite",
+              "EvmM0Portal",
+              "EvmHypEverclearCollateral",
+              "EvmHypEverclearEth",
+              "EvmHypCrossCollateralRouter",
+              "EvmAtomicLocalRebalancingBridge",
+              "SealevelSpl",
+              "SealevelSpl2022",
+              "SealevelNative",
+              "SealevelHypNative",
+              "SealevelHypCollateral",
+              "SealevelHypSynthetic",
+              "SealevelHypCrossCollateral",
+              "CosmosIcs20",
+              "CosmosIcs721",
+              "CosmosNative",
+              "CosmosIbc",
+              "CW20",
+              "CWNative",
+              "CW721",
+              "CwHypNative",
+              "CwHypCollateral",
+              "CwHypSynthetic",
+              "CosmosNativeHypCollateral",
+              "CosmosNativeHypSynthetic",
+              "StarknetNative",
+              "StarknetHypNative",
+              "StarknetHypCollateral",
+              "StarknetHypSynthetic",
+              "RadixNative",
+              "RadixHypCollateral",
+              "RadixHypSynthetic",
+              "AleoNative",
+              "AleoHypNative",
+              "AleoHypCollateral",
+              "AleoHypSynthetic",
+              "TRC20",
+              "TRC721",
+              "TronNative",
+              "TronHypNative",
+              "TronHypCollateral",
+              "TronHypOwnerCollateral",
+              "TronHypRebaseCollateral",
+              "TronHypCollateralFiat",
+              "TronHypSynthetic",
+              "TronHypSyntheticRebase",
+              "TronHypXERC20",
+              "TronHypXERC20Lockbox",
+              "TronHypVSXERC20",
+              "TronHypVSXERC20Lockbox",
+              "TronM0PortalLite",
+              "TronHypEverclearCollateral",
+              "TronHypEverclearEth",
+              "TronHypCrossCollateralRouter",
+              "TronAtomicLocalRebalancingBridge"
+            ],
+            "description": "The type of token. See TokenStandard for valid values."
+          },
+          "tokenType": {
+            "description": "The warp route deploy token type. Used to preserve route implementation semantics when multiple deploy token types share the same token standard.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema2"
+              }
+            ]
+          },
+          "decimals": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMaximum": 256,
+            "description": "The decimals value (e.g. 18 for Eth)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema3"
+              }
+            ]
+          },
+          "symbol": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The symbol of the token"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the token"
+          },
+          "addressOrDenom": {
+            "description": "The address or denom; null config values are normalized to an empty string for native tokens",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema4"
+              }
+            ]
+          },
+          "collateralAddressOrDenom": {
+            "description": "The address or denom of the collateralized token",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema5"
+              }
+            ]
+          },
+          "igpTokenAddressOrDenom": {
+            "description": "The address or denom of the token for IGP payments",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema6"
+              }
+            ]
+          },
+          "logoURI": {
+            "description": "The URI of the token logo",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema7"
+              }
+            ]
+          },
+          "connections": {
+            "description": "The list of token connections (e.g. warp or IBC)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema8"
+              }
+            ]
+          },
+          "coinGeckoId": {
+            "description": "The CoinGecko id of the token, used for price lookups",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema9"
+              }
+            ]
+          },
+          "scale": {
+            "description": "The scaling factor of the token",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema10"
+              }
+            ]
+          },
+          "warpRouteId": {
+            "description": "Unique warp route identifier, used to disambiguate tokens that share the same addressOrDenom on the same chain (e.g. M0 Portal tokens)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/__schema13"
+              }
+            ]
+          }
+        },
+        "required": [
+          "chainName",
+          "standard",
+          "decimals",
+          "symbol",
+          "name",
+          "addressOrDenom"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "__schema1": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*$"
+    },
+    "__schema2": {
+      "type": "string",
+      "enum": [
+        "synthetic",
+        "syntheticRebase",
+        "syntheticUri",
+        "collateral",
+        "collateralVault",
+        "collateralVaultRebase",
+        "xERC20",
+        "xERC20Lockbox",
+        "collateralFiat",
+        "collateralUri",
+        "collateralCctp",
+        "collateralEverclear",
+        "collateralDepositAddress",
+        "collateralOft",
+        "atomicLocalRebalancing",
+        "native",
+        "nativeOpL2",
+        "nativeOpL1",
+        "ethEverclear",
+        "nativeScaled",
+        "crossCollateral",
+        "unknown"
+      ]
+    },
+    "__schema3": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "__schema4": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "__schema5": {
+      "type": "string",
+      "minLength": 1
+    },
+    "__schema6": {
+      "type": "string",
+      "minLength": 1
+    },
+    "__schema7": {
+      "type": "string"
+    },
+    "__schema8": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "hyperlane"
+                  },
+                  "token": {
+                    "type": "string",
+                    "pattern": "^(.+)\\|(.+)\\|(.+)$"
+                  }
+                },
+                "required": [
+                  "token"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "ibc"
+                  },
+                  "token": {
+                    "type": "string",
+                    "pattern": "^(.+)\\|(.+)\\|(.+)$"
+                  },
+                  "sourcePort": {
+                    "type": "string"
+                  },
+                  "sourceChannel": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "token",
+                  "sourcePort",
+                  "sourceChannel"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "ibc-hyperlane"
+              },
+              "token": {
+                "type": "string",
+                "pattern": "^(.+)\\|(.+)\\|(.+)$"
+              },
+              "sourcePort": {
+                "type": "string"
+              },
+              "sourceChannel": {
+                "type": "string"
+              },
+              "intermediateChainName": {
+                "$ref": "#/definitions/__schema1"
+              },
+              "intermediateIbcDenom": {
+                "type": "string"
+              },
+              "intermediateRouterAddress": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "token",
+              "sourcePort",
+              "sourceChannel",
+              "intermediateChainName",
+              "intermediateIbcDenom",
+              "intermediateRouterAddress"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "__schema9": {
+      "type": "string"
+    },
+    "__schema10": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "object",
+          "properties": {
+            "numerator": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "denominator": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": [
+            "numerator",
+            "denominator"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "numerator": {
+              "$ref": "#/definitions/__schema11"
+            },
+            "denominator": {
+              "$ref": "#/definitions/__schema11"
+            }
+          },
+          "required": [
+            "numerator",
+            "denominator"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "__schema11": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema12"
+        }
+      ]
+    },
+    "__schema12": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "integer",
+              "format": "int64"
+            },
+            {
+              "$ref": "#/definitions/__schema3"
+            }
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        }
+      ]
+    },
+    "__schema13": {
+      "type": "string",
+      "minLength": 1
+    },
+    "__schema14": {
+      "type": "object",
+      "properties": {
+        "localFeeConstants": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema15"
+            }
+          ]
+        },
+        "interchainFeeConstants": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema15"
+            }
+          ]
+        },
+        "routeBlacklist": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "origin": {
+                "$ref": "#/definitions/__schema1"
+              },
+              "destination": {
+                "$ref": "#/definitions/__schema1"
+              }
+            },
+            "required": [
+              "origin",
+              "destination"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "sealevel": {
+          "description": "Sealevel-specific options for this warp route.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema16"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "__schema15": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "origin": {
+            "$ref": "#/definitions/__schema1"
+          },
+          "destination": {
+            "$ref": "#/definitions/__schema1"
+          },
+          "amount": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer",
+                "format": "int64"
+              }
+            ]
+          },
+          "addressOrDenom": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "origin",
+          "destination",
+          "amount"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "__schema16": {
+      "type": "object",
+      "properties": {
+        "altAddresses": {
+          "description": "Sealevel Address Lookup Table addresses per chain. `core` is the chain-shared ALT; `warpSpecific` lists the warp-route-specific ALTs.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/__schema17"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "__schema17": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/definitions/__schema1"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "core": {
+            "$ref": "#/definitions/__schema18"
+          },
+          "warpSpecific": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/__schema18"
+            }
+          }
+        },
+        "required": [
+          "core",
+          "warpSpecific"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "__schema18": {
+      "type": "string"
     }
-  },
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
     "jszip": "^3.10.1",
     "pino": "^8.21.0",
     "yaml": "2.9.0",
-    "zod": "^3.25.76"
+    "zod": "^4.5.2"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
     "@faker-js/faker": "^10.5.0",
-    "@hyperlane-xyz/sdk": "41.3.0",
-    "@hyperlane-xyz/utils": "41.3.0",
+    "@hyperlane-xyz/sdk": "43.0.0",
+    "@hyperlane-xyz/utils": "43.0.0",
     "@types/chai-as-promised": "^8.0.2",
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.1.2",
@@ -71,8 +71,7 @@
     "sinon": "^22.1.0",
     "svgo": "4.0.2",
     "tsx": "^4.23.1",
-    "typescript": "7.0.2",
-    "zod-to-json-schema": "^3.25.2"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=24"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 2.9.0
         version: 2.9.0
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.5.2
+        version: 4.5.2
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
@@ -28,11 +28,11 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0
       '@hyperlane-xyz/sdk':
-        specifier: 41.3.0
-        version: 41.3.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
+        specifier: 43.0.0
+        version: 43.0.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/utils':
-        specifier: 41.3.0
-        version: 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+        specifier: 43.0.0
+        version: 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@types/chai-as-promised':
         specifier: ^8.0.2
         version: 8.0.2
@@ -81,9 +81,6 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
-      zod-to-json-schema:
-        specifier: ^3.25.2
-        version: 3.25.2(zod@3.25.76)
 
 packages:
 
@@ -621,8 +618,8 @@ packages:
     resolution: {integrity: sha512-xyR4SqS4MjDmQIrIQmqPWLNgwM6Ul6G8UWQsFKZw6PLv8pxVk1nYj2WJrdZ+Ecs9+qY/NYQItv8KVMXge3gFKQ==}
     engines: {node: '>=16.0.0'}
 
-  '@hyperlane-xyz/aleo-sdk@41.3.0':
-    resolution: {integrity: sha512-dzU7h0WMOzb+11a1kxgru2y5kkNiNtConyQRZiLArN3rZhr1XrUZkxtl8L/x3sh8sYn2Gqdea+775kqG/ZUy8w==}
+  '@hyperlane-xyz/aleo-sdk@43.0.0':
+    resolution: {integrity: sha512-uThKdlEhVc93kmO5P0VgMdJ1DlC2i/pIKfdPYKHuxiRFCCGZxnRkb6qC76lO63x9PbEviV9mjzqesaPHBRNr8Q==}
     peerDependencies:
       testcontainers: 11.12.0
     peerDependenciesMeta:
@@ -637,53 +634,53 @@ packages:
       '@ethersproject/providers': '*'
       '@types/sinon-chai': '*'
 
-  '@hyperlane-xyz/cosmos-sdk@41.3.0':
-    resolution: {integrity: sha512-QhXZY9NCxY65BYz1jEdEf4H9b86asvn/cGhAzlSiWhCXVIL6ceE8m1uZBCsxR9T72Ip1qYyikSFSxLNzhnui6Q==}
+  '@hyperlane-xyz/cosmos-sdk@43.0.0':
+    resolution: {integrity: sha512-hCDoYF/OFrylX2nfTneKo0+wrg0GNw4qxMvb94NrZBhkvPlH4gKGQEG6Zigho83EX/z8e1VOIhIe3YI1YLVUaA==}
 
-  '@hyperlane-xyz/cosmos-types@41.3.0':
-    resolution: {integrity: sha512-lzH5zlI08KPt1U5aj2EA4xBjUqY4bh7xAaV+bsZJjgCcvbiRd60twbKmcO2xvVFNfKdzzE6bptMDB31PcrPh4w==}
+  '@hyperlane-xyz/cosmos-types@43.0.0':
+    resolution: {integrity: sha512-kyDXrWVpYtCewc6/gsoJFlBa1E+vxK+v8XmwcE4YiQiq/ZBzLf8NDFDwsbIjIv78RY2LpmMWm9UwGgLR5c3trQ==}
 
-  '@hyperlane-xyz/deploy-sdk@8.1.1':
-    resolution: {integrity: sha512-MIDMKhZEEGN8f4F9C6qiEBRVePIQnVCCb4sEkH1ohrOeIL2yzyh2IRHjH6mF4vx5qJlBEsm3mPPUcLphBFplbA==}
+  '@hyperlane-xyz/deploy-sdk@9.0.0':
+    resolution: {integrity: sha512-wh8ImouTj6cpFlSeY9IWTW+qJbV12FS7RPqhozVq3/6lP9GHehWLjfs1AfccYrRnhMrxF5Zax/YMU815QbFOeA==}
 
-  '@hyperlane-xyz/forking-sdk@8.1.2':
-    resolution: {integrity: sha512-TKTxgf2UwOlk4i9dFjr2uspWaRC6T+mFp/y727HJycu+X7dOuMZzj0jU8XinSmYv9NuIWAnD0RVODtZmJXk9DA==}
+  '@hyperlane-xyz/forking-sdk@8.1.5':
+    resolution: {integrity: sha512-IZ3rB+NTJlaIcMbZJRb4q0nxmLvFu6tu14KNDyEvUN2AAcgv8mJ58VcZ4VL/AJYuZqd+eOUiL/7GiOxYDTwptA==}
 
-  '@hyperlane-xyz/provider-sdk@8.1.1':
-    resolution: {integrity: sha512-3jYTeVfMv3hFegn8yly0weDBIM+g7cvXfQpCwcaWW6kTyOcoANZrMPupSwhakKm2bwDYOpBoQT9VLB7ZF9XzKg==}
+  '@hyperlane-xyz/provider-sdk@9.0.0':
+    resolution: {integrity: sha512-rIpl5aOVUMo5KnM9tKuicNOFlfXVl4g8Vns5PEswOgZxFbspwrIne4k9a39xHF4YDbhQkyoJ/AzoPOTTL9vUXw==}
 
-  '@hyperlane-xyz/radix-sdk@41.3.0':
-    resolution: {integrity: sha512-XByhMQ7YHrM6A0y4RYi56qcToKkDJuyZasclo+MvQEmZruFRMYLXnnmoo33zfMMmSIdFt3yPmZhHUSyrhtjfLQ==}
+  '@hyperlane-xyz/radix-sdk@43.0.0':
+    resolution: {integrity: sha512-SoyDJ6UwTf/gmT3NG8+4bP9lGMwYeL2LpK0mY3EgWsIbVJ8Ybpikkojw2wncHEeXKbJTCSGveZaeeJ9vmRXFkw==}
 
   '@hyperlane-xyz/registry@25.3.0':
     resolution: {integrity: sha512-LkMxVYj30aoWDs8wLTV1KItBAiwhhlfJ6EYemh5WsQrFrI9Eo4g0Z0qKVMSBlt26Fq2uPRFpK2+2xdpTNSSQ0g==}
     engines: {node: '>=24'}
 
-  '@hyperlane-xyz/sdk@41.3.0':
-    resolution: {integrity: sha512-UH5qlcvrsYMmifburWZrQ1U3RtfwdpnS3esUlPKbCDZqtcfl8bl/ZH65kN5O50sv/pHmbTux8bxOa0xHkvJyMQ==}
+  '@hyperlane-xyz/sdk@43.0.0':
+    resolution: {integrity: sha512-ebNb6SER8M/w9QVpdOwRJQ0mzRHPKmttoxwH1eUVvU64yyOqWjWm5E57X0o2pKHsPC02PKB4eMPyS6F3/kw90A==}
     engines: {node: '>=16'}
     peerDependencies:
       '@ethersproject/abi': '*'
 
-  '@hyperlane-xyz/sealevel-sdk@41.3.0':
-    resolution: {integrity: sha512-uEuKKkOMm7Nsl5BOE3N6+gZoKB1wWOHH1huaEVzQI1wdnf9wdiejbXeRpcPBVu6iziDpi1im/blFqqc3aa4SKw==}
+  '@hyperlane-xyz/sealevel-sdk@43.0.0':
+    resolution: {integrity: sha512-X1qftgyqI+33+F0zS0bW41Uoz27ReSDDJ2xLPsprXGQYKU2iu4H8xZU5UbpXPYK+caRQc3HN7R3XqvuZfK2fUQ==}
     peerDependencies:
       testcontainers: 11.12.0
     peerDependenciesMeta:
       testcontainers:
         optional: true
 
-  '@hyperlane-xyz/starknet-core@41.3.0':
-    resolution: {integrity: sha512-C6+lx8OOAoZ0l3aDhHLM/oB4jvvMHw8JqVGmALEDGMJ09uZDSA5OkaKkNsVp/JQoM5lDaEi0rc9u8Sg1EH2YEw==}
+  '@hyperlane-xyz/starknet-core@43.0.0':
+    resolution: {integrity: sha512-4ksvdJMhq4aUJVMethtZ2YvhvPmTW/NnQaWtEHLb7Rk2MhT1KwbbT88x7yzevfOMSdvB9LPTS7N/YL8FXgd10A==}
 
-  '@hyperlane-xyz/starknet-sdk@29.1.5':
-    resolution: {integrity: sha512-zu34IiSMPyjm8TF8YhYT0CXWbwn7mdOIqxNZVq4rmzc0j9VAXseIRyf9YzKMGI9I/Fm++/gy7zvRP3Jdgtp7wg==}
+  '@hyperlane-xyz/starknet-sdk@29.1.8':
+    resolution: {integrity: sha512-VzGkBmDdhR1e5fY8+Q8tKLOf5moTTavGQQ2n5gtUcs6/OhX/qlMq8+i9IaLHdl2rL1F44NYJHelHvcOvEGmw6g==}
 
-  '@hyperlane-xyz/tron-sdk@24.1.4':
-    resolution: {integrity: sha512-xFPBPy55iIJRG+Dq1orvX28EhUy7M9PTki+hmiprbV+e4knl6JCWD4376Bqyz7hAFhKTMo9N0KwtB4T7cjORfA==}
+  '@hyperlane-xyz/tron-sdk@24.2.1':
+    resolution: {integrity: sha512-KXxoU+RxlBt7qdInHrFQUeIvpPSvEqsxiyGo6z6bO+WFBfeliT2semXrqeVkC44wzNUR9ZmNB7RjyGmQRtjWUg==}
 
-  '@hyperlane-xyz/utils@41.3.0':
-    resolution: {integrity: sha512-5v1eJJqj63vdZ1emmq25wQrMF0PMjc9QoKP5IwcZelWsDOLIy6gIaEp9U5XI4TzdSSa1V5I9bdolHushQJdmaA==}
+  '@hyperlane-xyz/utils@43.0.0':
+    resolution: {integrity: sha512-iHTwu237Y+zk9aZ6hiIqTc2DEnpAmDclS4hT3v5K+8AmFVOCBcQj+BFOv3TKjJhJzeOgP+VSS9J5vVDyfA7jwg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@google-cloud/pino-logging-gcp-config': ^1.3.5
@@ -3855,13 +3852,11 @@ packages:
     peerDependencies:
       ethers: ~5.7.0
 
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
 
 snapshots:
 
@@ -4953,10 +4948,10 @@ snapshots:
     dependencies:
       '@hpke/common': 1.8.1
 
-  '@hyperlane-xyz/aleo-sdk@41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/aleo-sdk@43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@provablehq/sdk': 0.11.3
       bignumber.js: 9.1.2
       unzipper: 0.12.3
@@ -4974,16 +4969,16 @@ snapshots:
       '@ethersproject/providers': 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@types/sinon-chai': 4.0.0
 
-  '@hyperlane-xyz/cosmos-sdk@41.3.0(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/cosmos-sdk@43.0.0(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@cosmjs/amino': 0.32.4
       '@cosmjs/math': 0.32.4
       '@cosmjs/proto-signing': 0.32.4
       '@cosmjs/stargate': 0.32.4(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(utf-8-validate@5.0.10)
       '@cosmjs/tendermint-rpc': 0.32.4(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/cosmos-types': 41.3.0
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/cosmos-types': 43.0.0
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -4993,22 +4988,22 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/cosmos-types@41.3.0':
+  '@hyperlane-xyz/cosmos-types@43.0.0':
     dependencies:
       long: 5.3.2
       protobufjs: 7.5.0
 
-  '@hyperlane-xyz/deploy-sdk@8.1.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/deploy-sdk@9.0.0(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/aleo-sdk': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/cosmos-sdk': 41.3.0(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/radix-sdk': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/sealevel-sdk': 41.3.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/starknet-sdk': 29.1.5(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/tron-sdk': 24.1.4(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      zod: 3.25.76
+      '@hyperlane-xyz/aleo-sdk': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/cosmos-sdk': 43.0.0(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/radix-sdk': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/sealevel-sdk': 43.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/starknet-sdk': 29.1.8(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/tron-sdk': 24.2.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      zod: 4.5.2
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - '@types/sinon-chai'
@@ -5021,10 +5016,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/forking-sdk@8.1.2(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/forking-sdk@8.1.5(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -5033,11 +5028,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/provider-sdk@8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/provider-sdk@9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       pino: 8.21.0
-      zod: 3.25.76
+      zod: 4.5.2
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -5046,10 +5041,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/radix-sdk@41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/radix-sdk@43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@radixdlt/babylon-core-api-sdk': 1.3.0
       '@radixdlt/babylon-gateway-api-sdk': 1.10.1
       '@radixdlt/radix-engine-toolkit': 1.0.5
@@ -5070,7 +5065,7 @@ snapshots:
       yaml: 2.4.5
       zod: 3.25.76
 
-  '@hyperlane-xyz/sdk@41.3.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/sdk@43.0.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@arbitrum/sdk': 4.0.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@aws-sdk/client-s3': 3.750.0
@@ -5084,25 +5079,25 @@ snapshots:
       '@cosmjs/stargate': 0.32.4(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(utf-8-validate@5.0.10)
       '@cosmjs/tendermint-rpc': 0.32.4(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(utf-8-validate@5.0.10)
       '@ethersproject/abi': 5.8.0
-      '@hyperlane-xyz/aleo-sdk': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/aleo-sdk': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/core': 12.1.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)
-      '@hyperlane-xyz/cosmos-sdk': 41.3.0(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/deploy-sdk': 8.1.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/radix-sdk': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/starknet-core': 41.3.0
-      '@hyperlane-xyz/tron-sdk': 24.1.4(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@safe-global/api-kit': 4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@hyperlane-xyz/cosmos-sdk': 43.0.0(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/deploy-sdk': 9.0.0(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/radix-sdk': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/starknet-core': 43.0.0
+      '@hyperlane-xyz/tron-sdk': 24.2.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@safe-global/api-kit': 4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       '@safe-global/safe-deployments': 1.37.60
-      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@3.25.76)
+      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.2)
       '@solana/spl-token': 0.4.9(@solana/web3.js@1.98.4(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@starknet-react/chains': 3.1.3
       '@turnkey/api-key-stamper': 0.5.0
-      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@turnkey/solana': 1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@turnkey/solana': 1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       bignumber.js: 9.1.2
       borsh: 0.7.0
       compare-versions: 6.1.1
@@ -5111,9 +5106,9 @@ snapshots:
       ethers: 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       pino: 8.21.0
       starknet: 7.6.2
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       zksync-ethers: 5.10.0(ethers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      zod: 3.25.76
+      zod: 4.5.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5149,11 +5144,11 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@hyperlane-xyz/sealevel-sdk@41.3.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/sealevel-sdk@43.0.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/forking-sdk': 8.1.2(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/forking-sdk': 8.1.5(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@solana-program/address-lookup-table': 0.11.0(@solana/kit@6.3.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10))
@@ -5162,7 +5157,7 @@ snapshots:
       '@solana/errors': 6.3.1(typescript@7.0.2)
       '@solana/kit': 6.3.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
       compare-versions: 6.1.1
-      zod: 3.25.76
+      zod: 4.5.2
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -5172,15 +5167,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/starknet-core@41.3.0':
+  '@hyperlane-xyz/starknet-core@43.0.0':
     dependencies:
       starknet: 7.6.2
 
-  '@hyperlane-xyz/starknet-sdk@29.1.5(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/starknet-sdk@29.1.8(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@hyperlane-xyz/starknet-core': 41.3.0
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/starknet-core': 43.0.0
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       starknet: 7.6.2
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
@@ -5190,14 +5185,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/tron-sdk@24.1.4(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/tron-sdk@24.2.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/providers': 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/core': 12.1.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@types/sinon-chai@4.0.0)
-      '@hyperlane-xyz/provider-sdk': 8.1.1(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/provider-sdk': 9.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/registry': 25.3.0
-      '@hyperlane-xyz/utils': 41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       bignumber.js: 9.1.2
       ethers: 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       tronweb: 6.2.0(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(utf-8-validate@5.0.10)
@@ -5211,7 +5206,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/utils@41.3.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@hyperlane-xyz/utils@43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@cosmjs/encoding': 0.32.4
       '@ethersproject/bytes': 5.8.0
@@ -5589,12 +5584,12 @@ snapshots:
       reflect-metadata: 0.1.13
       secp256k1: 5.0.0
 
-  '@safe-global/api-kit@4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/api-kit@4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
-      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@3.25.76)
+      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.2)
       node-fetch: 2.7.0
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -5602,14 +5597,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/protocol-kit@7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/protocol-kit@7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
       '@safe-global/safe-deployments': 1.37.60
       '@safe-global/safe-modules-deployments': 3.0.8
-      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@3.25.76)
-      abitype: 1.1.1(typescript@7.0.2)(zod@3.25.76)
+      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.2)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
       semver: 7.7.3
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
     optionalDependencies:
       '@noble/curves': 1.9.7
       '@peculiar/asn1-schema': 2.5.0
@@ -5625,9 +5620,9 @@ snapshots:
 
   '@safe-global/safe-modules-deployments@3.0.8': {}
 
-  '@safe-global/types-kit@3.1.0(typescript@7.0.2)(zod@3.25.76)':
+  '@safe-global/types-kit@3.1.0(typescript@7.0.2)(zod@4.5.2)':
     dependencies:
-      abitype: 1.1.1(typescript@7.0.2)(zod@3.25.76)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -6645,7 +6640,7 @@ snapshots:
       '@turnkey/encoding': 0.6.0
       sha256-uint8array: 0.10.7
 
-  '@turnkey/core@1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@turnkey/core@1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/crypto': 2.8.5
@@ -6655,13 +6650,13 @@ snapshots:
       '@turnkey/webauthn-stamper': 0.6.0
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
-      '@walletconnect/sign-client': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       '@walletconnect/types': 2.23.0
       cross-fetch: 3.1.8
       ethers: 6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       jwt-decode: 4.0.0
       uuid: 11.1.0
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6719,7 +6714,7 @@ snapshots:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/encoding': 0.6.0
 
-  '@turnkey/sdk-browser@5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@turnkey/sdk-browser@5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/crypto': 2.8.5
@@ -6728,7 +6723,7 @@ snapshots:
       '@turnkey/iframe-stamper': 2.7.0
       '@turnkey/indexed-db-stamper': 1.2.0
       '@turnkey/sdk-types': 0.8.0
-      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       '@turnkey/webauthn-stamper': 0.6.0
       buffer: 6.0.3
       cross-fetch: 3.1.8
@@ -6740,11 +6735,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@turnkey/sdk-server@4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@turnkey/sdk-server@4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/http': 3.15.0
-      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       buffer: 6.0.3
       cross-fetch: 3.1.8
     transitivePeerDependencies:
@@ -6756,13 +6751,13 @@ snapshots:
 
   '@turnkey/sdk-types@0.8.0': {}
 
-  '@turnkey/solana@1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@turnkey/solana@1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
       '@solana/web3.js': 1.98.4(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@turnkey/core': 1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@turnkey/core': 1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       '@turnkey/http': 3.15.0
-      '@turnkey/sdk-browser': 5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@turnkey/sdk-browser': 5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6791,12 +6786,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@turnkey/wallet-stamper@1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@turnkey/wallet-stamper@1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
       '@turnkey/crypto': 2.8.5
       '@turnkey/encoding': 0.6.0
     optionalDependencies:
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -6930,7 +6925,7 @@ snapshots:
 
   '@wallet-standard/base@1.1.0': {}
 
-  '@walletconnect/core@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -6944,7 +6939,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.0
-      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@3.25.76)
+      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@4.5.2)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.39.3
       events: 3.3.0
@@ -7062,16 +7057,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
     dependencies:
-      '@walletconnect/core': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.0
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.0
-      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@3.25.76)
+      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@4.5.2)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7131,7 +7126,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/utils@2.23.0(typescript@7.0.2)(zod@3.25.76)':
+  '@walletconnect/utils@2.23.0(typescript@7.0.2)(zod@4.5.2)':
     dependencies:
       '@msgpack/msgpack': 3.1.2
       '@noble/ciphers': 1.3.0
@@ -7151,7 +7146,7 @@ snapshots:
       blakejs: 1.2.1
       bs58: 6.0.0
       detect-browser: 5.3.0
-      ox: 0.9.3(typescript@7.0.2)(zod@3.25.76)
+      ox: 0.9.3(typescript@7.0.2)(zod@4.5.2)
       uint8arrays: 3.1.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7197,15 +7192,15 @@ snapshots:
       fs-extra: 10.1.0
       yargs: 17.7.2
 
-  abitype@1.1.0(typescript@7.0.2)(zod@3.25.76):
+  abitype@1.1.0(typescript@7.0.2)(zod@4.5.2):
     optionalDependencies:
       typescript: 7.0.2
-      zod: 3.25.76
+      zod: 4.5.2
 
-  abitype@1.1.1(typescript@7.0.2)(zod@3.25.76):
+  abitype@1.1.1(typescript@7.0.2)(zod@4.5.2):
     optionalDependencies:
       typescript: 7.0.2
-      zod: 3.25.76
+      zod: 4.5.2
 
   abort-controller@3.0.0:
     dependencies:
@@ -8194,7 +8189,7 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  ox@0.9.3(typescript@7.0.2)(zod@3.25.76):
+  ox@0.9.3(typescript@7.0.2)(zod@4.5.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -8202,14 +8197,14 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.1(typescript@7.0.2)(zod@3.25.76)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.6(typescript@7.0.2)(zod@3.25.76):
+  ox@0.9.6(typescript@7.0.2)(zod@4.5.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -8217,7 +8212,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.1(typescript@7.0.2)(zod@3.25.76)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 7.0.2
@@ -8804,15 +8799,15 @@ snapshots:
 
   validator@13.15.23: {}
 
-  viem@2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@3.25.76):
+  viem@2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@7.0.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@7.0.2)(zod@4.5.2)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      ox: 0.9.6(typescript@7.0.2)(zod@3.25.76)
+      ox: 0.9.6(typescript@7.0.2)(zod@4.5.2)
       ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 7.0.2
@@ -8909,8 +8904,6 @@ snapshots:
     dependencies:
       ethers: 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
   zod@3.25.76: {}
+
+  zod@4.5.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ minimumReleaseAgeExclude:
   - "@oxlint/*"
   - oxfmt
   - oxlint
+  - zod@4.5.2
 allowBuilds:
   bigint-buffer: true
   bufferutil: true

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,14 +1,32 @@
+import fs from 'fs';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ChainMetadataSchemaObject, WarpCoreConfigSchema } from '@hyperlane-xyz/sdk';
-import fs from 'fs';
 import { parse, stringify } from 'yaml';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { z } from 'zod/v4';
 
-import { BaseRegistry } from '../src/registry/BaseRegistry';
 import { WARP_ROUTE_ID_REGEX } from '../src/consts';
+import { BaseRegistry } from '../src/registry/BaseRegistry';
 const chainMetadata = {};
 const chainAddresses = {};
 const warpRouteConfigs = {};
+
+const JSON_SCHEMA_OPTIONS = {
+  target: 'draft-07',
+  io: 'input',
+  reused: 'ref',
+  unrepresentable: ({ zodSchema }) => {
+    if (zodSchema instanceof z.ZodBigInt) {
+      return { type: 'integer', format: 'int64' };
+    }
+    return 'throw';
+  },
+  override: ({ jsonSchema }) => {
+    if (jsonSchema.type === 'object' && !Object.hasOwn(jsonSchema, 'additionalProperties')) {
+      jsonSchema.additionalProperties = false;
+    }
+  },
+} satisfies z.core.ToJSONSchemaParams;
 
 function genJsExport(data, exportName) {
   return `export const ${exportName} = ${JSON.stringify(data, null, 2)}`;
@@ -196,16 +214,21 @@ function generateWarpConfigTsCode() {
 
 function updateJsonSchemas() {
   console.log('Updating & copying chain JSON schemas');
-  const chainSchema = zodToJsonSchema(ChainMetadataSchemaObject, 'hyperlaneChainMetadata');
+  const chainSchema = z.toJSONSchema(
+    ChainMetadataSchemaObject.meta({ id: 'hyperlaneChainMetadata' }),
+    JSON_SCHEMA_OPTIONS,
+  );
   fs.writeFileSync(`./chains/schema.json`, JSON.stringify(chainSchema, null, 2), 'utf8');
   fs.copyFileSync(`./chains/schema.json`, `./dist/chains/schema.json`);
-  const warpSchema = zodToJsonSchema(WarpCoreConfigSchema, 'hyperlaneWarpCoreConfig');
+  const warpSchema = z.toJSONSchema(
+    WarpCoreConfigSchema.meta({ id: 'hyperlaneWarpCoreConfig' }),
+    JSON_SCHEMA_OPTIONS,
+  );
   fs.writeFileSync(
     `./deployments/warp_routes/schema.json`,
     JSON.stringify(warpSchema, null, 2),
     'utf8',
   );
-  // Warp Deploy schema should not be attempted until this is resolved: https://github.com/StefanTerdell/zod-to-json-schema/issues/68
 }
 
 createTmpDir();

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,26 +2,24 @@ import { ChainMetadataSchema } from '@hyperlane-xyz/sdk/metadata/chainMetadataTy
 import type { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk/token/types';
 import type { ChainName } from '@hyperlane-xyz/sdk/types';
 import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import { WARP_ROUTE_ID_REGEX } from './consts.js';
 
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements
 export type MaybePromise<T> = T | Promise<T> | PromiseLike<T>;
 
-export const ChainAddressesSchema = z.record(z.string());
+export const ChainAddressesSchema = z.record(z.string(), z.string());
 export type ChainAddresses = z.infer<typeof ChainAddressesSchema>;
 
 /**
  * Schema for warp route filter parameters.
  * This serves as the single source of truth for both TypeScript types and validation.
  */
-export const WarpRouteFilterSchema = z
-  .object({
-    symbol: z.string().optional(),
-    label: z.string().optional(),
-  })
-  .strict();
+export const WarpRouteFilterSchema = z.strictObject({
+  symbol: z.string().optional(),
+  label: z.string().optional(),
+});
 
 /**
  * TypeScript type inferred from the schema.

--- a/test/unit/types.test.ts
+++ b/test/unit/types.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+
+import { expect } from 'chai';
+import { z } from 'zod/v4';
+
+import {
+  UpdateChainSchema,
+  WarpRouteFilterSchema,
+  chainMetadata,
+  warpRouteConfigs,
+} from '../../dist/index.js';
+
+const chainJsonSchema = z.fromJSONSchema(JSON.parse(fs.readFileSync('chains/schema.json', 'utf8')));
+const warpJsonSchema = z.fromJSONSchema(
+  JSON.parse(fs.readFileSync('deployments/warp_routes/schema.json', 'utf8')),
+);
+
+describe('Registry schemas', () => {
+  it('validates SDK-owned chain metadata', () => {
+    const result = UpdateChainSchema.safeParse({
+      metadata: chainMetadata.ethereum,
+    });
+
+    expect(result.success).to.equal(true);
+  });
+
+  it('preserves SDK metadata validation failures', () => {
+    const result = UpdateChainSchema.safeParse({
+      metadata: { name: 'invalid' },
+    });
+
+    expect(result.success).to.equal(false);
+    if (!result.success) {
+      expect(result.error.issues.length).to.be.greaterThan(0);
+    }
+  });
+
+  it('rejects unknown warp route filters', () => {
+    expect(WarpRouteFilterSchema.safeParse({ unknown: true }).success).to.equal(false);
+  });
+
+  it('generates a chain JSON schema that accepts valid metadata', () => {
+    expect(chainJsonSchema.safeParse(chainMetadata.ethereum).success).to.equal(true);
+  });
+
+  it('generates a warp JSON schema that accepts fee constants', () => {
+    expect(warpJsonSchema.safeParse(warpRouteConfigs['TIA/mantapacific']).success).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary

Migrates the registry schemas and public validation types to Zod 4.5.2, consuming the Zod 4-native `@hyperlane-xyz/sdk` and `@hyperlane-xyz/utils` 43.0.0 releases from [hyperlane-monorepo#9374](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9374).

This is stage 2 of the ecosystem migration and carries a major changeset because exported schemas and inferred/static types move to Zod 4.

## Changes

- Upgraded the registry direct Zod dependency to 4.5.2.
- Upgraded SDK and utils to 43.0.0.
- Composed the SDK Zod 4 `ChainMetadataSchema` directly, removing the temporary Zod 3 bridge and `preserveSymlinks` workaround.
- Migrated records to explicit key/value schemas and made warp-route filters strict.
- Replaced `zod-to-json-schema` with Zod 4 `z.toJSONSchema`.
- Preserved the published JSON Schema contract: Draft 7, named root references, input schemas, closed objects, and bigint `integer`/`int64` encoding.
- Regenerated chain and warp JSON schemas, fixing stale recursive references that rejected valid RPC URLs and fee-constant arrays.
- Added focused coverage for direct SDK schema composition, strict filters, metadata errors, and generated JSON schemas.

## Rollout sequence

1. ✅ Released Zod 4-native monorepo packages in [run 33443704079](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33443704079).
2. ✅ Updated this PR to the released packages and removed transitional compatibility code.
3. After this registry major is released, update the monorepo registry dependency and remove its temporary legacy registry-schema adapters.

## Verification

- `pnpm run build`
- `pnpm run lint`
- full unit suite: 8,267 passing; 1 pending
- format check
- `pnpm exec changeset status` (major)
- `git diff --check`
- rebased onto registry `main` at `dcc7c42726495b832f66a963c6e4e173f1c0b308`
