### PR TITLE
chore(radix routes): add pausable aggregation ISM to all EVM legs

### DIFF
--- a/.changeset/radix-routes-pausable-ism-all-legs.md
+++ b/.changeset/radix-routes-pausable-ism-all-legs.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+the EVM legs of all Radix warp routes (USDC/radix arbitrum+base, USDT/ethereum-radix ethereum, XRD/radix base+ethereum, WBTC/ethereum-radix ethereum, BNB/radix bsc, ETH/ethereum-radix ethereum) were set to a 2-of-2 aggregation ISM combining the default fallback ISM with a pausable ISM owned by the turnkey pauser, so every EVM leg can be paused in response to the radix incident wherever aggregation/pausing is supported

--- a/.changeset/update-usdc-radix-ethereum-pausable-ism.md
+++ b/.changeset/update-usdc-radix-ethereum-pausable-ism.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+the ethereum leg of the USDC/radix warp route was set to a 2-of-2 aggregation ISM combining the default fallback ISM with a pausable ISM owned by the turnkey pauser, enabling the route to be paused in response to the radix incident

--- a/deployments/warp_routes/BNB/radix-deploy.yaml
+++ b/deployments/warp_routes/BNB/radix-deploy.yaml
@@ -1,6 +1,16 @@
 bsc:
   decimals: 18
   gas: 300000
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/BNB/radix-deploy.yaml
+++ b/deployments/warp_routes/BNB/radix-deploy.yaml
@@ -1,16 +1,7 @@
 bsc:
   decimals: 18
   gas: 300000
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0x68DC857007C43E062Ced3E261DcA0772A30eD809"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/ETH/ethereum-radix-deploy.yaml
+++ b/deployments/warp_routes/ETH/ethereum-radix-deploy.yaml
@@ -1,16 +1,7 @@
 ethereum:
   decimals: 18
   gas: 68000
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0xf5aFE6E21cAAfD8390e76EE1c55DF9611FDc2c3e"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/ETH/ethereum-radix-deploy.yaml
+++ b/deployments/warp_routes/ETH/ethereum-radix-deploy.yaml
@@ -1,6 +1,16 @@
 ethereum:
   decimals: 18
   gas: 68000
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/USDC/radix-deploy.yaml
+++ b/deployments/warp_routes/USDC/radix-deploy.yaml
@@ -7,6 +7,16 @@ arbitrum:
     ethereum:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
   decimals: 6
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
@@ -21,6 +31,16 @@ base:
     ethereum:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
   decimals: 6
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/USDC/radix-deploy.yaml
+++ b/deployments/warp_routes/USDC/radix-deploy.yaml
@@ -7,16 +7,7 @@ arbitrum:
     ethereum:
       - bridge: "0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2"
   decimals: 6
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0x32F829dfA3aFF8bed84bCAd4Dc9EaBd884C4c34D"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
@@ -31,16 +22,7 @@ base:
     ethereum:
       - bridge: "0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975"
   decimals: 6
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0x0022D1aA03D603d8Fe34382c27FC3Ab3b12A028A"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/USDC/radix-deploy.yaml
+++ b/deployments/warp_routes/USDC/radix-deploy.yaml
@@ -35,6 +35,16 @@ ethereum:
     base:
       - bridge: "0xedCBAa585FD0F80f20073F9958246476466205b8"
   decimals: 6
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/USDT/ethereum-radix-deploy.yaml
+++ b/deployments/warp_routes/USDT/ethereum-radix-deploy.yaml
@@ -1,6 +1,16 @@
 ethereum:
   decimals: 6
   gas: 68000
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/USDT/ethereum-radix-deploy.yaml
+++ b/deployments/warp_routes/USDT/ethereum-radix-deploy.yaml
@@ -1,16 +1,7 @@
 ethereum:
   decimals: 6
   gas: 68000
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0xf5aFE6E21cAAfD8390e76EE1c55DF9611FDc2c3e"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/WBTC/ethereum-radix-deploy.yaml
+++ b/deployments/warp_routes/WBTC/ethereum-radix-deploy.yaml
@@ -1,16 +1,7 @@
 ethereum:
   decimals: 8
   gas: 68000
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0xf5aFE6E21cAAfD8390e76EE1c55DF9611FDc2c3e"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/WBTC/ethereum-radix-deploy.yaml
+++ b/deployments/warp_routes/WBTC/ethereum-radix-deploy.yaml
@@ -1,6 +1,16 @@
 ethereum:
   decimals: 8
   gas: 68000
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   proxyAdmin:
     owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"

--- a/deployments/warp_routes/XRD/radix-deploy.yaml
+++ b/deployments/warp_routes/XRD/radix-deploy.yaml
@@ -1,11 +1,31 @@
 base:
   decimals: 18
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   name: E-RADIX
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   symbol: eXRD
   type: synthetic
 ethereum:
   decimals: 18
+  interchainSecurityModule:
+    type: staticAggregationIsm
+    threshold: 2
+    modules:
+      - type: defaultFallbackRoutingIsm
+        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
+        domains: {}
+      - type: pausableIsm
+        paused: false
+        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   token: "0x6468e79A80C0eaB0F9A2B574c8d5bC374Af59414"
   type: collateralFiat

--- a/deployments/warp_routes/XRD/radix-deploy.yaml
+++ b/deployments/warp_routes/XRD/radix-deploy.yaml
@@ -1,31 +1,13 @@
 base:
   decimals: 18
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0x0022D1aA03D603d8Fe34382c27FC3Ab3b12A028A"
   name: E-RADIX
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   symbol: eXRD
   type: synthetic
 ethereum:
   decimals: 18
-  interchainSecurityModule:
-    type: staticAggregationIsm
-    threshold: 2
-    modules:
-      - type: defaultFallbackRoutingIsm
-        owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
-        domains: {}
-      - type: pausableIsm
-        paused: false
-        owner: "0x60Cc386C85717CB51C2827A75e14826883dF5da4"
+  interchainSecurityModule: "0xf5aFE6E21cAAfD8390e76EE1c55DF9611FDc2c3e"
   owner: "0xA365Bf3Da1f1B01E2a80f9261Ec717B305b2Eb8F"
   token: "0x6468e79A80C0eaB0F9A2B574c8d5bC374Af59414"
   type: collateralFiat


### PR DESCRIPTION
## Summary

Sets every EVM leg of every Radix warp route to a pausable ISM so the Radix route owner can pause inbound delivery on all supported legs in response to the Radix incident. (Started as the USDC/radix ethereum leg; extended here to all legs. #1688 consolidated in.)

Each EVM leg's `interchainSecurityModule` is a 2-of-2 `staticAggregationIsm` of:
- `defaultFallbackRoutingIsm` (owner = route owner `0xA365…EB8F`, empty domains → mailbox default)
- `pausableIsm` (`paused: false`, owner = turnkey pauser `0x60Cc386C85717CB51C2827A75e14826883dF5da4`)

Pausing the pausableIsm makes the aggregation fail closed → halts inbound releases on that leg.

### Legs
- USDC/radix: `arbitrum`, `base`, `ethereum`
- USDT/ethereum-radix: `ethereum`
- XRD/radix: `base`, `ethereum`
- WBTC/ethereum-radix: `ethereum`
- BNB/radix: `bsc`
- ETH/ethereum-radix: `ethereum`

### Not changed (aggregation/pausing not supported)
- All `radix` legs — Radix ISM impl supports only multisig/routing/noop.
- `solanamainnet` legs — pausable/aggregation only exist as nested composite-ISM nodes; pauser is an EVM key.

### Follow-up
Per-chain the routes will share a single aggregation ISM (config may be switched to reference the shared deployed ISM address per chain). Applying requires deploying the shared ISM per chain and the route owner `0xA365…EB8F` (an EOA we don't control) signing `setInterchainSecurityModule` on each router.

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M1CVBBP7EM6KQGCA418N8NPH