### PR TITLE
feat: enable NES route in URE

### DIFF
--- a/.changeset/enable-nes-bsc-ure.md
+++ b/.changeset/enable-nes-bsc-ure.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+restored the NES/bsc Warp route to the Universal Router Engine allowlist after the Nesachain cutover

--- a/deployments/warp_routes/warpRouteAllowlist.yaml
+++ b/deployments/warp_routes/warpRouteAllowlist.yaml
@@ -419,6 +419,9 @@ warpRouteIds:
   # NEX routes
   - NEX/bsc
 
+  # Nesa routes
+  - NES/bsc
+
   # rise
   - RISE/bsc-ethereum
 


### PR DESCRIPTION
Restores NES/bsc to the Universal Router Engine allowlist now that Nesachain RPC support is deployed and Nexus hides the route.

Validation:
- `pnpm build`
- Focused Warp routes unit suite: 1,828 passing
- `pnpm exec changeset status`