### PR TITLE
chore: update Zod to 4.5.4

### DIFF
--- a/.changeset/quiet-zebras-compile.md
+++ b/.changeset/quiet-zebras-compile.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Zod was updated to 4.5.4 to prevent function-valued default factories from running during schema cycle detection.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jszip": "^3.10.1",
     "pino": "^8.21.0",
     "yaml": "2.9.0",
-    "zod": "^4.5.2"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 2.9.0
         version: 2.9.0
       zod:
-        specifier: ^4.5.2
-        version: 4.5.2
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
@@ -3855,8 +3855,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.5.2:
-    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
 snapshots:
 
@@ -5003,7 +5003,7 @@ snapshots:
       '@hyperlane-xyz/starknet-sdk': 29.1.8(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/tron-sdk': 24.2.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      zod: 4.5.2
+      zod: 4.5.4
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - '@types/sinon-chai'
@@ -5032,7 +5032,7 @@ snapshots:
     dependencies:
       '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       pino: 8.21.0
-      zod: 4.5.2
+      zod: 4.5.4
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -5088,16 +5088,16 @@ snapshots:
       '@hyperlane-xyz/starknet-core': 43.0.0
       '@hyperlane-xyz/tron-sdk': 24.2.1(@types/sinon-chai@4.0.0)(bufferutil@4.0.8)(debug@4.4.3(supports-color@8.1.1))(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@hyperlane-xyz/utils': 43.0.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@safe-global/api-kit': 4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
-      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@safe-global/api-kit': 4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
+      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       '@safe-global/safe-deployments': 1.37.60
-      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.2)
+      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.4)
       '@solana/spl-token': 0.4.9(@solana/web3.js@1.98.4(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@starknet-react/chains': 3.1.3
       '@turnkey/api-key-stamper': 0.5.0
-      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
-      '@turnkey/solana': 1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
+      '@turnkey/solana': 1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       bignumber.js: 9.1.2
       borsh: 0.7.0
       compare-versions: 6.1.1
@@ -5106,9 +5106,9 @@ snapshots:
       ethers: 5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       pino: 8.21.0
       starknet: 7.6.2
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       zksync-ethers: 5.10.0(ethers@5.8.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      zod: 4.5.2
+      zod: 4.5.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5157,7 +5157,7 @@ snapshots:
       '@solana/errors': 6.3.1(typescript@7.0.2)
       '@solana/kit': 6.3.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@7.0.2)(utf-8-validate@5.0.10)
       compare-versions: 6.1.1
-      zod: 4.5.2
+      zod: 4.5.4
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -5584,12 +5584,12 @@ snapshots:
       reflect-metadata: 0.1.13
       secp256k1: 5.0.0
 
-  '@safe-global/api-kit@4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@safe-global/api-kit@4.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
-      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
-      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.2)
+      '@safe-global/protocol-kit': 7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
+      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.4)
       node-fetch: 2.7.0
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -5597,14 +5597,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/protocol-kit@7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@safe-global/protocol-kit@7.2.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
       '@safe-global/safe-deployments': 1.37.60
       '@safe-global/safe-modules-deployments': 3.0.8
-      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.2)
-      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
+      '@safe-global/types-kit': 3.1.0(typescript@7.0.2)(zod@4.5.4)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.4)
       semver: 7.7.3
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
     optionalDependencies:
       '@noble/curves': 1.9.7
       '@peculiar/asn1-schema': 2.5.0
@@ -5620,9 +5620,9 @@ snapshots:
 
   '@safe-global/safe-modules-deployments@3.0.8': {}
 
-  '@safe-global/types-kit@3.1.0(typescript@7.0.2)(zod@4.5.2)':
+  '@safe-global/types-kit@3.1.0(typescript@7.0.2)(zod@4.5.4)':
     dependencies:
-      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.4)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -6640,7 +6640,7 @@ snapshots:
       '@turnkey/encoding': 0.6.0
       sha256-uint8array: 0.10.7
 
-  '@turnkey/core@1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@turnkey/core@1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/crypto': 2.8.5
@@ -6650,13 +6650,13 @@ snapshots:
       '@turnkey/webauthn-stamper': 0.6.0
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
-      '@walletconnect/sign-client': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@walletconnect/sign-client': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       '@walletconnect/types': 2.23.0
       cross-fetch: 3.1.8
       ethers: 6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       jwt-decode: 4.0.0
       uuid: 11.1.0
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6714,7 +6714,7 @@ snapshots:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/encoding': 0.6.0
 
-  '@turnkey/sdk-browser@5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@turnkey/sdk-browser@5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/crypto': 2.8.5
@@ -6723,7 +6723,7 @@ snapshots:
       '@turnkey/iframe-stamper': 2.7.0
       '@turnkey/indexed-db-stamper': 1.2.0
       '@turnkey/sdk-types': 0.8.0
-      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       '@turnkey/webauthn-stamper': 0.6.0
       buffer: 6.0.3
       cross-fetch: 3.1.8
@@ -6735,11 +6735,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@turnkey/sdk-server@4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@turnkey/sdk-server@4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
       '@turnkey/api-key-stamper': 0.5.0
       '@turnkey/http': 3.15.0
-      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@turnkey/wallet-stamper': 1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       buffer: 6.0.3
       cross-fetch: 3.1.8
     transitivePeerDependencies:
@@ -6751,13 +6751,13 @@ snapshots:
 
   '@turnkey/sdk-types@0.8.0': {}
 
-  '@turnkey/solana@1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@turnkey/solana@1.1.12(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
       '@solana/web3.js': 1.98.4(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@turnkey/core': 1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@turnkey/core': 1.7.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       '@turnkey/http': 3.15.0
-      '@turnkey/sdk-browser': 5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
-      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@turnkey/sdk-browser': 5.13.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
+      '@turnkey/sdk-server': 4.12.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6786,12 +6786,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@turnkey/wallet-stamper@1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@turnkey/wallet-stamper@1.1.7(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
       '@turnkey/crypto': 2.8.5
       '@turnkey/encoding': 0.6.0
     optionalDependencies:
-      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      viem: 2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -6925,7 +6925,7 @@ snapshots:
 
   '@wallet-standard/base@1.1.0': {}
 
-  '@walletconnect/core@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@walletconnect/core@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -6939,7 +6939,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.0
-      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@4.5.2)
+      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@4.5.4)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.39.3
       events: 3.3.0
@@ -7057,16 +7057,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)':
+  '@walletconnect/sign-client@2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)':
     dependencies:
-      '@walletconnect/core': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2)
+      '@walletconnect/core': 2.23.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.0
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.0
-      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@4.5.2)
+      '@walletconnect/utils': 2.23.0(typescript@7.0.2)(zod@4.5.4)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7126,7 +7126,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/utils@2.23.0(typescript@7.0.2)(zod@4.5.2)':
+  '@walletconnect/utils@2.23.0(typescript@7.0.2)(zod@4.5.4)':
     dependencies:
       '@msgpack/msgpack': 3.1.2
       '@noble/ciphers': 1.3.0
@@ -7146,7 +7146,7 @@ snapshots:
       blakejs: 1.2.1
       bs58: 6.0.0
       detect-browser: 5.3.0
-      ox: 0.9.3(typescript@7.0.2)(zod@4.5.2)
+      ox: 0.9.3(typescript@7.0.2)(zod@4.5.4)
       uint8arrays: 3.1.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7192,15 +7192,15 @@ snapshots:
       fs-extra: 10.1.0
       yargs: 17.7.2
 
-  abitype@1.1.0(typescript@7.0.2)(zod@4.5.2):
+  abitype@1.1.0(typescript@7.0.2)(zod@4.5.4):
     optionalDependencies:
       typescript: 7.0.2
-      zod: 4.5.2
+      zod: 4.5.4
 
-  abitype@1.1.1(typescript@7.0.2)(zod@4.5.2):
+  abitype@1.1.1(typescript@7.0.2)(zod@4.5.4):
     optionalDependencies:
       typescript: 7.0.2
-      zod: 4.5.2
+      zod: 4.5.4
 
   abort-controller@3.0.0:
     dependencies:
@@ -8189,7 +8189,7 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  ox@0.9.3(typescript@7.0.2)(zod@4.5.2):
+  ox@0.9.3(typescript@7.0.2)(zod@4.5.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -8197,14 +8197,14 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.6(typescript@7.0.2)(zod@4.5.2):
+  ox@0.9.6(typescript@7.0.2)(zod@4.5.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -8212,7 +8212,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.2)
+      abitype: 1.1.1(typescript@7.0.2)(zod@4.5.4)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 7.0.2
@@ -8799,15 +8799,15 @@ snapshots:
 
   validator@13.15.23: {}
 
-  viem@2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.2):
+  viem@2.39.0(bufferutil@4.0.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.5.4):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@7.0.2)(zod@4.5.2)
+      abitype: 1.1.0(typescript@7.0.2)(zod@4.5.4)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      ox: 0.9.6(typescript@7.0.2)(zod@4.5.2)
+      ox: 0.9.6(typescript@7.0.2)(zod@4.5.4)
       ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 7.0.2
@@ -8906,4 +8906,4 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.5.2: {}
+  zod@4.5.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ minimumReleaseAgeExclude:
   - "@oxlint/*"
   - oxfmt
   - oxlint
-  - zod@4.5.2
+  - zod@4.5.4
 allowBuilds:
   bigint-buffer: true
   bufferutil: true


### PR DESCRIPTION
Bumps Zod from 4.5.2 to 4.5.4.

Upstream fix: https://github.com/colinhacks/zod/pull/6500

Zod 4.5.4 fixes function-valued `.default()`/`.prefault()` factories firing during schema cycle detection. This is a patch-only dependency update.

Changeset: patch bump for `@hyperlane-xyz/registry`.

Verification:
- Frozen lockfile-only install passed supply-chain policy.
- Full install completed successfully.
- Unit suite/build passed.
- Direct 4.5.4 regression script passed: `z.compile()` does not invoke a default factory; supplied values do not invoke it; absent value invokes it once.
- Changeset status passed.
