### PR TITLE
chore: deprecate remaining H2 2026 chain removals

### DIFF
--- a/.changeset/deprecate-remaining-chains-removals.md
+++ b/.changeset/deprecate-remaining-chains-removals.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Deprecate remaining H2 2026 chain removals: superseed, tac, carrchain, blast, sei, taiko, megaeth, berachain, lisk, forma.

--- a/chains/berachain/metadata.yaml
+++ b/chains/berachain/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/80094/etherscan/api
     family: routescan

--- a/chains/blast/metadata.yaml
+++ b/chains/blast/metadata.yaml
@@ -1,5 +1,8 @@
 ---
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
     apiUrl: https://api.etherscan.io/v2/api?chainid=81457

--- a/chains/carrchain/metadata.yaml
+++ b/chains/carrchain/metadata.yaml
@@ -1,3 +1,6 @@
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://carrscan.io/api/v1
     family: other

--- a/chains/forma/metadata.yaml
+++ b/chains/forma/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.forma.art/api
     family: blockscout

--- a/chains/lisk/metadata.yaml
+++ b/chains/lisk/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://blockscout.lisk.com/api/eth-rpc
     family: blockscout

--- a/chains/megaeth/metadata.yaml
+++ b/chains/megaeth/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://megaeth.blockscout.com/api
     family: blockscout

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -992,6 +992,10 @@ bepolia:
     - http: https://bepolia.rpc.berachain.com
   technicalStack: other
 berachain:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://api.routescan.io/v2/network/mainnet/evm/80094/etherscan/api
       family: routescan
@@ -1052,6 +1056,10 @@ bitlayer:
     - http: https://rpc.ankr.com/bitlayer
   technicalStack: other
 blast:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
       apiUrl: https://api.etherscan.io/v2/api?chainid=81457
@@ -1423,6 +1431,10 @@ carbon:
   rpcUrls:
     - http: https://evm-api.carbon.network
 carrchain:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://carrscan.io/api/v1
       family: other
@@ -3343,6 +3355,10 @@ form:
     - http: https://rpc.form.network/http
   technicalStack: opstack
 forma:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.forma.art/api
       family: blockscout
@@ -4864,6 +4880,10 @@ lineasepolia:
     - http: https://linea-sepolia-rpc.publicnode.com
     - http: https://linea-sepolia.drpc.org
 lisk:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://blockscout.lisk.com/api/eth-rpc
       family: blockscout
@@ -5231,6 +5251,10 @@ matchain:
         maxBlockRange: 1000
   technicalStack: opstack
 megaeth:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://megaeth.blockscout.com/api
       family: blockscout
@@ -7674,6 +7698,10 @@ scrollsepolia:
     - http: https://scroll-sepolia.chainstacklabs.com
     - http: https://scroll-public.scroll-testnet.quiknode.pro
 sei:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiKey: 487e1ac5-03f4-4473-9e73-cee721b782b5
       apiUrl: https://seitrace.com/pacific-1/api
@@ -8793,6 +8821,10 @@ superpositiontestnet:
     - http: https://testnet-rpc.superposition.so
   technicalStack: arbitrumnitro
 superseed:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.superseed.xyz/api
       family: blockscout
@@ -8958,6 +8990,10 @@ syscoin:
     - http: https://rpc.syscoin.org
   technicalStack: other
 tac:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiUrl: https://explorer.tac.build/api
       family: blockscout
@@ -8985,6 +9021,10 @@ tac:
     - http: https://rpc.ankr.com/tac
   technicalStack: other
 taiko:
+  availability:
+    reasons:
+      - deprecated
+    status: disabled
   blockExplorers:
     - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
       apiUrl: https://api.etherscan.io/v2/api?chainid=167000

--- a/chains/sei/metadata.yaml
+++ b/chains/sei/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiKey: 487e1ac5-03f4-4473-9e73-cee721b782b5
     apiUrl: https://seitrace.com/pacific-1/api

--- a/chains/superseed/metadata.yaml
+++ b/chains/superseed/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.superseed.xyz/api
     family: blockscout

--- a/chains/tac/metadata.yaml
+++ b/chains/tac/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiUrl: https://explorer.tac.build/api
     family: blockscout

--- a/chains/taiko/metadata.yaml
+++ b/chains/taiko/metadata.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../schema.json
+availability:
+  reasons: [deprecated]
+  status: disabled
 blockExplorers:
   - apiKey: GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN
     apiUrl: https://api.etherscan.io/v2/api?chainid=167000


### PR DESCRIPTION
Deprecates the following chains in registry metadata:

- superseed
- tac
- carrchain
- blast
- sei
- taiko
- megaeth
- berachain
- lisk
- forma

Each chain now has:\n```yaml\navailability:\n  reasons: [deprecated]\n  status: disabled\n```\n\nRelates to H2 2026 chain removal tickets.