### PR TITLE
feat: preserve legacy nesa NES route as NES/legacy id

### DIFF
--- a/.changeset/nes-legacy-route-blacklist-id.md
+++ b/.changeset/nes-legacy-route-blacklist-id.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Re-added the original nesa-chain NES deployment as the `NES/legacy` warp route id. The `NES/bsc` id was cut over to the new nesachain deployment in #1673, so the legacy nesa (domain 41443) route was preserved under a dedicated id to keep it referenceable for relayer blacklisting while it remains paused.

--- a/deployments/warp_routes/NES/legacy-config.yaml
+++ b/deployments/warp_routes/NES/legacy-config.yaml
@@ -1,0 +1,104 @@
+# yaml-language-server: $schema=../schema.json
+tokens:
+  - addressOrDenom: "0xEf9295afCff293956E8B149b33449f246f6F107D"
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    chainName: arbitrum
+    connections:
+      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+    decimals: 18
+    name: Nesa
+    standard: EvmHypSynthetic
+    symbol: NES
+  - addressOrDenom: "0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C"
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    chainName: base
+    connections:
+      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+    decimals: 18
+    name: Nesa
+    standard: EvmHypSynthetic
+    symbol: NES
+  - addressOrDenom: "0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5"
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    chainName: bsc
+    connections:
+      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+    decimals: 18
+    name: Nesa
+    standard: EvmHypSynthetic
+    symbol: NES
+  - addressOrDenom: "0x230f1E241C621d5af670Dad83ebCdd18971E2995"
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    chainName: ethereum
+    connections:
+      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+    decimals: 18
+    name: Nesa
+    standard: EvmHypSynthetic
+    symbol: NES
+  - addressOrDenom: "0xD1B6443d49156B66E7bd8a37673511BE68BFa459"
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    chainName: hyperevm
+    connections:
+      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+    decimals: 18
+    name: Nesa
+    standard: EvmHypSynthetic
+    symbol: NES
+  - addressOrDenom: "0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886"
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    chainName: nesa
+    connections:
+      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+      - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+    decimals: 18
+    name: NES
+    standard: EvmHypNative
+    symbol: NES
+  - addressOrDenom: Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+    logoURI: /deployments/warp_routes/NES/logo.svg
+    collateralAddressOrDenom: DcozfBUx4qxNwfq3PU622qHvVtnMRtJEUjhmyiFRaG43
+    chainName: solanamainnet
+    scale:
+      denominator: 1
+      numerator: 1000000000
+    connections:
+      - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+      - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+      - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+      - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+      - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+      - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+    decimals: 9
+    name: Nesa
+    standard: SealevelHypSynthetic
+    symbol: NES

--- a/deployments/warp_routes/NES/legacy-deploy.yaml
+++ b/deployments/warp_routes/NES/legacy-deploy.yaml
@@ -1,0 +1,214 @@
+arbitrum:
+  decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+    type: fallbackRoutingHook
+  interchainSecurityModule:
+    modules:
+      - owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+        paused: true
+        type: pausableIsm
+      - domains: {}
+        owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+        type: defaultFallbackRoutingIsm
+    threshold: 2
+    type: staticAggregationIsm
+  mailbox: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
+  name: Nesa
+  owner: "0xAe04Fbe024FB2F807ee59CC14f101273665d2577"
+  symbol: NES
+  type: synthetic
+base:
+  decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+    type: fallbackRoutingHook
+  interchainSecurityModule:
+    modules:
+      - owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+        paused: true
+        type: pausableIsm
+      - domains: {}
+        owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+        type: defaultFallbackRoutingIsm
+    threshold: 2
+    type: staticAggregationIsm
+  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+  name: Nesa
+  owner: "0x755B06Ef10B8e1b1D834E18B66BEb97391A79faE"
+  symbol: NES
+  type: synthetic
+bsc:
+  decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+    type: fallbackRoutingHook
+  interchainSecurityModule:
+    modules:
+      - owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+        paused: true
+        type: pausableIsm
+      - domains: {}
+        owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+        type: defaultFallbackRoutingIsm
+    threshold: 2
+    type: staticAggregationIsm
+  mailbox: "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4"
+  name: Nesa
+  owner: "0x12C940009B062EB489acBcaFacCb018F44aB8526"
+  symbol: NES
+  type: synthetic
+ethereum:
+  decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+    type: fallbackRoutingHook
+  interchainSecurityModule:
+    modules:
+      - owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+        paused: true
+        type: pausableIsm
+      - domains: {}
+        owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+        type: defaultFallbackRoutingIsm
+    threshold: 2
+    type: staticAggregationIsm
+  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
+  name: Nesa
+  owner: "0x13a39383303aD4ce340C2f949D82394515418eCd"
+  symbol: NES
+  type: synthetic
+hyperevm:
+  decimals: 18
+  hook:
+    domains:
+      nesa:
+        hooks:
+          - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+      solanamainnet:
+        hooks:
+          - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+    type: fallbackRoutingHook
+  interchainSecurityModule:
+    modules:
+      - owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+        paused: true
+        type: pausableIsm
+      - domains: {}
+        owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+        type: defaultFallbackRoutingIsm
+    threshold: 2
+    type: staticAggregationIsm
+  mailbox: "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
+  name: Nesa
+  owner: "0x2900d3549716Cc3806A55173DF56DC11AD17f045"
+  symbol: NES
+  type: synthetic
+nesa:
+  decimals: 18
+  hook:
+    domains:
+      solanamainnet:
+        hooks:
+          - owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
+            paused: true
+            type: pausableHook
+          - type: defaultHook
+        type: aggregationHook
+    fallback:
+      type: defaultHook
+    owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
+    type: fallbackRoutingHook
+  mailbox: "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7"
+  owner: "0xD0C88AF1AA3353fC24078545d8d7D7e7c7BE6fca"
+  type: native
+solanamainnet:
+  decimals: 9
+  gas: 300000
+  hook: BhNcatUDC2D5JTyeaqrdSukiVFsEHK7e3hVmKMztwefv
+  mailbox: E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi
+  metadataUri: https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/deployments/warp_routes/NES/metadata.json
+  name: Nesa
+  owner: 8iU79nHDGm8ZXeGu3gL9G5axteBWJszbu1DZTUzABQzg
+  scale: 1000000000
+  symbol: NES
+  type: synthetic

--- a/deployments/warp_routes/warpRouteConfigs.yaml
+++ b/deployments/warp_routes/warpRouteConfigs.yaml
@@ -5576,6 +5576,110 @@ NES/bsc:
       standard: EvmHypNative
       symbol: NES
       tokenType: native
+NES/legacy:
+  tokens:
+    - addressOrDenom: "0xEf9295afCff293956E8B149b33449f246f6F107D"
+      chainName: arbitrum
+      connections:
+        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      decimals: 18
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: Nesa
+      standard: EvmHypSynthetic
+      symbol: NES
+    - addressOrDenom: "0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C"
+      chainName: base
+      connections:
+        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      decimals: 18
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: Nesa
+      standard: EvmHypSynthetic
+      symbol: NES
+    - addressOrDenom: "0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5"
+      chainName: bsc
+      connections:
+        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      decimals: 18
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: Nesa
+      standard: EvmHypSynthetic
+      symbol: NES
+    - addressOrDenom: "0x230f1E241C621d5af670Dad83ebCdd18971E2995"
+      chainName: ethereum
+      connections:
+        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      decimals: 18
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: Nesa
+      standard: EvmHypSynthetic
+      symbol: NES
+    - addressOrDenom: "0xD1B6443d49156B66E7bd8a37673511BE68BFa459"
+      chainName: hyperevm
+      connections:
+        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      decimals: 18
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: Nesa
+      standard: EvmHypSynthetic
+      symbol: NES
+    - addressOrDenom: "0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886"
+      chainName: nesa
+      connections:
+        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+        - token: sealevel|solanamainnet|Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      decimals: 18
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: NES
+      standard: EvmHypNative
+      symbol: NES
+    - addressOrDenom: Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp
+      chainName: solanamainnet
+      collateralAddressOrDenom: DcozfBUx4qxNwfq3PU622qHvVtnMRtJEUjhmyiFRaG43
+      connections:
+        - token: ethereum|arbitrum|0xEf9295afCff293956E8B149b33449f246f6F107D
+        - token: ethereum|base|0x87ea09Fe8d9dC6115086F5E0A30CA6750a997f1C
+        - token: ethereum|bsc|0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5
+        - token: ethereum|ethereum|0x230f1E241C621d5af670Dad83ebCdd18971E2995
+        - token: ethereum|hyperevm|0xD1B6443d49156B66E7bd8a37673511BE68BFa459
+        - token: ethereum|nesa|0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886
+      decimals: 9
+      logoURI: /deployments/warp_routes/NES/logo.svg
+      name: Nesa
+      scale:
+        denominator: 1
+        numerator: 1000000000
+      standard: SealevelHypSynthetic
+      symbol: NES
 NEX/bsc:
   tokens:
     - addressOrDenom: "0x365DE036A1F7dcCb621530d517133521debB2013"


### PR DESCRIPTION
## Summary
- Re-adds the original nesa deployment (domain 41443) under `NES/legacy`.
- `NES/bsc` now refers to the live nesachain deployment (domain 41444) after #1673.

## Why
The mainnet3 relayer blacklist resolves a warp-route id into router matchers. Keeping the legacy deployment under `NES/legacy` lets the relayer blacklist the old paused route without blocking the new route.

## On-chain state
- Legacy nesa Ethereum pausable ISM `0x142aA41c…`: paused.
- New nesachain Ethereum pausable ISM `0x9603c437…`: unpaused.

Companion fix: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9462