### PR TITLE
feat(chains): enable fallback RPC hedging on EVM mainnets

### DIFF
--- a/.changeset/enable-fallback-hedging.md
+++ b/.changeset/enable-fallback-hedging.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Enabled fallback RPC hedging on EVM mainnet chains with multiple RPC endpoints by setting fallback consensus and a hedge delay.

--- a/chains/alephzeroevmmainnet/metadata.yaml
+++ b/chains/alephzeroevmmainnet/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
 displayName: Aleph Zero EVM
 displayNameShort: Aleph Zero EVM
 domainId: 1000041455
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: aleph-zero
 index:
   from: 4243354
@@ -26,6 +27,7 @@ nativeToken:
   name: AZERO
   symbol: AZERO
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.alephzero.raas.gelato.cloud
   - http: https://alephzero.drpc.org

--- a/chains/arbitrum/metadata.yaml
+++ b/chains/arbitrum/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Arbitrum
 domainId: 42161
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/arb1
 index:
@@ -29,6 +30,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://arb1.arbitrum.io/rpc
   - http: https://arbitrum.drpc.org

--- a/chains/artela/metadata.yaml
+++ b/chains/artela/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Artela
 domainId: 11820
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: artela-network
 name: artela
 nativeToken:
@@ -24,6 +25,7 @@ nativeToken:
   name: Artela
   symbol: ART
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://node-euro.artela.network/rpc
   - http: https://node-hongkong.artela.network/rpc

--- a/chains/astarzkevm/metadata.yaml
+++ b/chains/astarzkevm/metadata.yaml
@@ -13,6 +13,7 @@ blocks:
 chainId: 3776
 displayName: Astar zkEVM
 domainId: 3776
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 name: astarzkevm
 nativeToken:
@@ -20,6 +21,7 @@ nativeToken:
   name: Ethereum
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.startale.com/astar-zkevm
   - http: https://astar-zkevm-rpc.dwellir.com

--- a/chains/aurora/metadata.yaml
+++ b/chains/aurora/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Aurora
 domainId: 1313161554
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 name: aurora
 nativeToken:
@@ -23,6 +24,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://mainnet.aurora.dev
   - http: https://aurora.drpc.org

--- a/chains/avalanche/metadata.yaml
+++ b/chains/avalanche/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Avalanche
 domainId: 43114
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: avalanche-2
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/avax
 name: avalanche
@@ -23,6 +24,7 @@ nativeToken:
   name: Avalanche
   symbol: AVAX
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://avalanche.drpc.org
   - http: https://1rpc.io/avax/c

--- a/chains/base/metadata.yaml
+++ b/chains/base/metadata.yaml
@@ -23,6 +23,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Base
 domainId: 8453
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/base
 name: base
@@ -31,6 +32,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://base-pokt.nodies.app
   - http: https://base.public.blockpi.network/v1/rpc/public

--- a/chains/bitlayer/metadata.yaml
+++ b/chains/bitlayer/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Bitlayer
 domainId: 200901
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: bitcoin
 gnosisSafeTransactionServiceUrl: https://multisign.bitlayer.org/txs/
 name: bitlayer
@@ -25,6 +26,7 @@ nativeToken:
   name: Bitcoin
   symbol: BTC
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.bitlayer.org
   - http: https://rpc.bitlayer-rpc.com

--- a/chains/blast/metadata.yaml
+++ b/chains/blast/metadata.yaml
@@ -23,6 +23,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Blast
 domainId: 81457
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://safe-transaction-blast.safe.global
 name: blast
@@ -31,6 +32,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.blast.io
   - http: https://blast-rpc.publicnode.com

--- a/chains/bsc/metadata.yaml
+++ b/chains/bsc/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
 displayName: Binance Smart Chain
 displayNameShort: Binance
 domainId: 56
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: binancecoin
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/bnb
 name: bsc
@@ -24,6 +25,7 @@ nativeToken:
   name: BNB
   symbol: BNB
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://bsc.drpc.org
   - http: https://bsc-rpc.publicnode.com

--- a/chains/bsquared/metadata.yaml
+++ b/chains/bsquared/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: B² Network
 domainId: 223
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: bitcoin
 gnosisSafeTransactionServiceUrl: https://safe-gateway.bsquared.network/txs/
 name: bsquared
@@ -24,6 +25,7 @@ nativeToken:
   name: Bitcoin
   symbol: BTC
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.bsquared.network
   - http: https://rpc.ankr.com/b2

--- a/chains/canto/metadata.yaml
+++ b/chains/canto/metadata.yaml
@@ -10,6 +10,7 @@ deployer:
   url: https://github.com/guy93354
 displayName: Canto
 domainId: 7700
+fallbackHedgeDelayMillis: 250
 isTestnet: false
 name: canto
 nativeToken:
@@ -17,6 +18,7 @@ nativeToken:
   name: Canto
   symbol: CANTO
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://canto-rpc.ansybl.io
   - http: https://mainnode.plexnode.org:8545

--- a/chains/celo/metadata.yaml
+++ b/chains/celo/metadata.yaml
@@ -19,6 +19,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Celo
 domainId: 42220
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: celo
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/celo
 name: celo
@@ -27,6 +28,7 @@ nativeToken:
   name: Celo
   symbol: CELO
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://forno.celo.org
   - http: https://rpc.ankr.com/celo

--- a/chains/chilizmainnet/metadata.yaml
+++ b/chains/chilizmainnet/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Chiliz
 domainId: 1000088888
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: chiliz
 name: chilizmainnet
 nativeToken:
@@ -24,6 +25,7 @@ nativeToken:
   name: Chiliz
   symbol: CHZ
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.ankr.com/chiliz
   - http: https://chiliz.publicnode.com

--- a/chains/conflux/metadata.yaml
+++ b/chains/conflux/metadata.yaml
@@ -13,6 +13,7 @@ blocks:
 chainId: 1030
 displayName: Conflux eSpace
 domainId: 1030
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: conflux-token
 name: conflux
 nativeToken:
@@ -20,6 +21,7 @@ nativeToken:
   name: Ethereum
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://evm.confluxrpc.com
   - http: https://conflux-espace-public.unifra.io

--- a/chains/coredao/metadata.yaml
+++ b/chains/coredao/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Core
 domainId: 1116
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: coredaoorg
 name: coredao
 nativeToken:
@@ -24,6 +25,7 @@ nativeToken:
   name: CoreDAO
   symbol: CORE
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.coredao.org
   - http: https://rpc.ankr.com/core

--- a/chains/corn/metadata.yaml
+++ b/chains/corn/metadata.yaml
@@ -14,6 +14,7 @@ blocks:
 chainId: 21000000
 displayName: Corn
 domainId: 21000000
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: bitcoin
 index:
   from: 55636
@@ -23,6 +24,7 @@ nativeToken:
   name: Bitcorn
   symbol: BTCN
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://mainnet.corn-rpc.com
   - http: https://maizenet-rpc.usecorn.com

--- a/chains/cyber/metadata.yaml
+++ b/chains/cyber/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Cyber
 domainId: 7560
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://transaction-cyber.safe.optimism.io
 name: cyber
@@ -24,6 +25,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.cyber.co
   - http: https://cyber.alt.technology

--- a/chains/duckchain/metadata.yaml
+++ b/chains/duckchain/metadata.yaml
@@ -14,6 +14,7 @@ blocks:
 chainId: 5545
 displayName: DuckChain
 domainId: 5545
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: the-open-network
 index:
   from: 1149918
@@ -23,6 +24,7 @@ nativeToken:
   name: Toncoin
   symbol: TON
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.duckchain.io
   - http: https://rpc-hk.duckchain.io

--- a/chains/ethereum/metadata.yaml
+++ b/chains/ethereum/metadata.yaml
@@ -23,6 +23,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Ethereum
 domainId: 1
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/eth
 name: ethereum
@@ -31,6 +32,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://ethereum.publicnode.com
   - http: https://eth.drpc.org

--- a/chains/evmos/metadata.yaml
+++ b/chains/evmos/metadata.yaml
@@ -14,6 +14,7 @@ blocks:
 chainId: 9001
 displayName: Evmos EVM
 domainId: 9001
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: evmos
 name: evmos
 nativeToken:
@@ -21,6 +22,7 @@ nativeToken:
   name: Evmos
   symbol: EVMOS
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://evmos.lava.build
   - http: https://evmos-json-rpc.stakely.io

--- a/chains/fantom/metadata.yaml
+++ b/chains/fantom/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Fantom Opera
 domainId: 250
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: fantom
 name: fantom
 nativeToken:
@@ -24,6 +25,7 @@ nativeToken:
   name: Fantom
   symbol: FTM
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpcapi.fantom.network
   - http: https://fantom-rpc.publicnode.com

--- a/chains/filecoin/metadata.yaml
+++ b/chains/filecoin/metadata.yaml
@@ -10,6 +10,7 @@ blocks:
 chainId: 314
 displayName: Filecoin
 domainId: 314
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: filecoin
 name: filecoin
 nativeToken:
@@ -17,6 +18,7 @@ nativeToken:
   name: Filecoin
   symbol: FIL
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://api.node.glif.io/rpc/v1
   - http: https://rpc.ankr.com/filecoin

--- a/chains/flare/metadata.yaml
+++ b/chains/flare/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Flare
 domainId: 14
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: flare-networks
 name: flare
 nativeToken:
@@ -24,6 +25,7 @@ nativeToken:
   name: Flare
   symbol: FLR
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://flare-api.flare.network/ext/C/rpc
     pagination:

--- a/chains/fraxtal/metadata.yaml
+++ b/chains/fraxtal/metadata.yaml
@@ -19,6 +19,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Fraxtal
 domainId: 252
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: frax-share
 gnosisSafeTransactionServiceUrl: https://safe.mainnet.frax.com/txs
 name: fraxtal
@@ -27,6 +28,7 @@ nativeToken:
   name: FRAX
   symbol: FRAX
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.frax.com
   - http: https://fraxtal.drpc.org

--- a/chains/fusemainnet/metadata.yaml
+++ b/chains/fusemainnet/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Fuse
 domainId: 122
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: fuse-network-token
 gnosisSafeTransactionServiceUrl: https://transaction-fuse.safe.fuse.io
 name: fusemainnet
@@ -25,6 +26,7 @@ nativeToken:
   name: FUSE
   symbol: FUSE
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.fuse.io
   - http: https://fuse.drpc.org

--- a/chains/harmony/metadata.yaml
+++ b/chains/harmony/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Harmony One
 domainId: 1666600000
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: harmony
 name: harmony
 nativeToken:
@@ -24,6 +25,7 @@ nativeToken:
   name: ONE
   symbol: ONE
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://api.harmony.one
   - http: https://api.s0.t.hmny.io

--- a/chains/immutablezkevmmainnet/metadata.yaml
+++ b/chains/immutablezkevmmainnet/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Immutable zkEVM
 domainId: 1000013371
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: immutable-x
 name: immutablezkevmmainnet
 nativeToken:
@@ -23,6 +24,7 @@ nativeToken:
   name: Immutable
   symbol: IMX
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.immutable.com
   - http: https://immutable.gateway.tenderly.co

--- a/chains/inevm/metadata.yaml
+++ b/chains/inevm/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
 displayName: Injective EVM
 displayNameShort: inEVM
 domainId: 2525
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: injective-protocol
 index:
   from: 37
@@ -27,6 +28,7 @@ nativeToken:
   name: Injective
   symbol: INJ
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://inevm.calderachain.xyz/http
   - http: https://mainnet.rpc.inevm.com/http

--- a/chains/kava/metadata.yaml
+++ b/chains/kava/metadata.yaml
@@ -11,6 +11,7 @@ blocks:
 chainId: 2222
 displayName: Kava
 domainId: 2222
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: kava
 name: kava
 nativeToken:
@@ -18,6 +19,7 @@ nativeToken:
   name: Kava
   symbol: KAVA
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://evm.kava-rpc.com
   - http: https://rpc.ankr.com/kava_evm

--- a/chains/kroma/metadata.yaml
+++ b/chains/kroma/metadata.yaml
@@ -13,6 +13,7 @@ blocks:
 chainId: 255
 displayName: Kroma
 domainId: 255
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 name: kroma
 nativeToken:
@@ -20,6 +21,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc-kroma.rockx.com
   - http: https://api.kroma.network

--- a/chains/linea/metadata.yaml
+++ b/chains/linea/metadata.yaml
@@ -19,6 +19,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Linea
 domainId: 59144
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/linea
 name: linea
@@ -27,6 +28,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.linea.build
   - http: https://1rpc.io/linea

--- a/chains/lukso/metadata.yaml
+++ b/chains/lukso/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: LUKSO
 domainId: 42
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: lukso-token-2
 name: lukso
 nativeToken:
@@ -21,6 +22,7 @@ nativeToken:
   name: LUKSO
   symbol: LYX
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.mainnet.lukso.network
   - http: https://42.rpc.thirdweb.com

--- a/chains/mantapacific/metadata.yaml
+++ b/chains/mantapacific/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
 displayName: Manta Pacific
 displayNameShort: Manta
 domainId: 169
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://transaction.safe.manta.network
 isTestnet: false
@@ -27,6 +28,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://pacific-rpc.manta.network/http
   - http: https://manta.nirvanalabs.xyz/mantapublic

--- a/chains/merlin/metadata.yaml
+++ b/chains/merlin/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Merlin
 domainId: 4200
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: merlin-chain-bridged-wrapped-btc-merlin
 name: merlin
 nativeToken:
@@ -23,6 +24,7 @@ nativeToken:
   name: Bitcoin
   symbol: BTC
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.merlinchain.io
   - http: https://merlin.blockpi.network/v1/rpc/public

--- a/chains/mode/metadata.yaml
+++ b/chains/mode/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Mode
 domainId: 34443
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://transaction-mode.safe.optimism.io
 name: mode
@@ -26,6 +27,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://mainnet.mode.network
   - http: https://mode.drpc.org

--- a/chains/moonriver/metadata.yaml
+++ b/chains/moonriver/metadata.yaml
@@ -10,6 +10,7 @@ deployer:
   url: https://github.com/guy93354
 displayName: Moonriver
 domainId: 1285
+fallbackHedgeDelayMillis: 250
 isTestnet: false
 name: moonriver
 nativeToken:
@@ -17,6 +18,7 @@ nativeToken:
   name: Moonriver
   symbol: MOVR
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://moonriver-rpc.dwellir.com
   - http: https://moonriver.api.onfinality.io/public

--- a/chains/opbnb/metadata.yaml
+++ b/chains/opbnb/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: opBNB
 domainId: 204
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: binancecoin
 name: opbnb
 nativeToken:
@@ -25,6 +26,7 @@ nativeToken:
   name: BNB
   symbol: BNB
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://opbnb-mainnet-rpc.bnbchain.org
   - http: https://opbnb-mainnet.nodereal.io/v1/64a9df0874fb4a93b9d0a3849de012d3

--- a/chains/optimism/metadata.yaml
+++ b/chains/optimism/metadata.yaml
@@ -23,6 +23,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Optimism
 domainId: 10
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/oeth
 name: optimism
@@ -31,6 +32,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://mainnet.optimism.io
   - http: https://optimism.drpc.org

--- a/chains/polygon/metadata.yaml
+++ b/chains/polygon/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Polygon
 domainId: 137
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: polygon-ecosystem-token
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/pol
 name: polygon
@@ -23,6 +24,7 @@ nativeToken:
   name: Polygon Ecosystem Token
   symbol: POL
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://polygon-bor.publicnode.com
   - http: https://polygon.drpc.org

--- a/chains/polygonzkevm/metadata.yaml
+++ b/chains/polygonzkevm/metadata.yaml
@@ -19,6 +19,7 @@ deployer:
 displayName: Polygon zkEVM
 displayNameShort: zkEVM
 domainId: 1101
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/zkevm
 name: polygonzkevm
@@ -27,6 +28,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://zkevm-rpc.com
   - http: https://rpc.ankr.com/polygon_zkevm

--- a/chains/pulsechain/metadata.yaml
+++ b/chains/pulsechain/metadata.yaml
@@ -22,6 +22,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: PulseChain
 domainId: 369
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: pulsechain
 name: pulsechain
 nativeToken:
@@ -29,6 +30,7 @@ nativeToken:
   name: PulseChain
   symbol: PLS
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.pulsechain.com
   - http: https://pulsechain-rpc.publicnode.com

--- a/chains/real/metadata.yaml
+++ b/chains/real/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
 displayName: re.al
 domainId: 111188
 # https://www.coingecko.com/en/coins/real-ether is in preview mode, so we use ethereum as a close proxy
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 index:
   from: 363159
@@ -27,6 +28,7 @@ nativeToken:
   name: Real Ether
   symbol: reETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.realforreal.gelato.digital
   - http: https://tangible-real.gateway.tenderly.co

--- a/chains/ronin/metadata.yaml
+++ b/chains/ronin/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Ronin
 domainId: 2020
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ronin
 gnosisSafeTransactionServiceUrl: https://safe-transaction-ronin.safe.onchainden.com
 name: ronin
@@ -25,6 +26,7 @@ nativeToken:
   name: Ronin
   symbol: RON
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://api.roninchain.com/rpc
   - http: https://ronin.drpc.org

--- a/chains/scroll/metadata.yaml
+++ b/chains/scroll/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Scroll
 domainId: 534352
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/scr
 name: scroll
@@ -26,6 +27,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.scroll.io
   - http: https://rpc.ankr.com/scroll

--- a/chains/sei/metadata.yaml
+++ b/chains/sei/metadata.yaml
@@ -18,6 +18,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Sei
 domainId: 1329
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: sei-network
 gnosisSafeTransactionServiceUrl: https://transaction.sei-safe.protofire.io
 name: sei
@@ -26,6 +27,7 @@ nativeToken:
   name: Sei
   symbol: SEI
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://evm-rpc.sei-apis.com
   - http: https://evm-rpc-sei.stingray.plus

--- a/chains/shibarium/metadata.yaml
+++ b/chains/shibarium/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Shibarium
 domainId: 109
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: bone-shibaswap
 name: shibarium
 nativeToken:
@@ -23,6 +24,7 @@ nativeToken:
   name: Bone ShibaSwap
   symbol: BONE
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://www.shibrpc.com
   - http: https://rpc.shibrpc.com

--- a/chains/smartbch/metadata.yaml
+++ b/chains/smartbch/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://goblins.cash
 displayName: Smartbch
 domainId: 10000
+fallbackHedgeDelayMillis: 250
 isTestnet: false
 name: smartbch
 nativeToken:
@@ -21,6 +22,7 @@ nativeToken:
   name: BCH
   symbol: BCH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://smartbch.greyh.at
   - http: https://rpc.smartbch.org

--- a/chains/sophon/metadata.yaml
+++ b/chains/sophon/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Sophon
 domainId: 50104
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: sophon
 gnosisSafeTransactionServiceUrl: https://transaction.safe.sophon.xyz
 name: sophon
@@ -25,6 +26,7 @@ nativeToken:
   name: sophon
   symbol: SOPH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.sophon.xyz
   - http: https://sophon-mainnet-public.unifra.io

--- a/chains/telos/metadata.yaml
+++ b/chains/telos/metadata.yaml
@@ -14,6 +14,7 @@ blocks:
 chainId: 40
 displayName: Telos EVM
 domainId: 40
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: telos
 name: telos
 nativeToken:
@@ -21,6 +22,7 @@ nativeToken:
   name: Telos
   symbol: TLOS
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.telos.net
   - http: https://telos.drpc.org

--- a/chains/tenet/metadata.yaml
+++ b/chains/tenet/metadata.yaml
@@ -10,6 +10,7 @@ blocks:
 chainId: 1559
 displayName: Tenet
 domainId: 1559
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: tenet-1b000f7b-59cb-4e06-89ce-d62b32d362b9
 name: tenet
 nativeToken:
@@ -17,6 +18,7 @@ nativeToken:
   name: Tenet
   symbol: TENET
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.tenet.org
   - http: https://tenet-evm.publicnode.com

--- a/chains/torus/metadata.yaml
+++ b/chains/torus/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Torus
 domainId: 21000
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: torus
 name: torus
 nativeToken:
@@ -24,6 +25,7 @@ nativeToken:
   name: Torus
   symbol: TORUS
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://api-hyperlane.nodes.torus.network
   - http: https://api.torus.network

--- a/chains/viction/metadata.yaml
+++ b/chains/viction/metadata.yaml
@@ -14,6 +14,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Viction
 domainId: 88
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: tomochain
 name: viction
 nativeToken:
@@ -21,6 +22,7 @@ nativeToken:
   name: Viction
   symbol: VIC
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.viction.xyz
   - http: https://viction.drpc.org

--- a/chains/worldchain/metadata.yaml
+++ b/chains/worldchain/metadata.yaml
@@ -19,6 +19,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: World Chain
 domainId: 480
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/wc
 name: worldchain
@@ -27,6 +28,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://worldchain.drpc.org
   - http: https://worldchain-mainnet.gateway.tenderly.co

--- a/chains/xlayer/metadata.yaml
+++ b/chains/xlayer/metadata.yaml
@@ -15,6 +15,7 @@ deployer:
 displayName: XLayer
 displayNameShort: XLayer
 domainId: 196
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: okb
 gnosisSafeTransactionServiceUrl: https://api.safe.global/tx-service/okb/
 name: xlayer
@@ -23,6 +24,7 @@ nativeToken:
   name: OKB
   symbol: OKB
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://xlayerrpc.okx.com
   - http: https://rpc.xlayer.tech

--- a/chains/zerogravity/metadata.yaml
+++ b/chains/zerogravity/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: 0G
 domainId: 16661
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: zero-gravity
 name: zerogravity
 nativeToken:
@@ -23,6 +24,7 @@ nativeToken:
   name: 0G
   symbol: 0G
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://0g.drpc.org
   - http: https://evmrpc.0g.ai

--- a/chains/zeronetwork/metadata.yaml
+++ b/chains/zeronetwork/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Zero Network
 domainId: 543210
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://prod.zeronet-mainnet.transaction.keypersafe.xyz
 name: zeronetwork
@@ -25,6 +26,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://rpc.zerion.io/v1/zero
   - http: https://zero.drpc.org

--- a/chains/zetachain/metadata.yaml
+++ b/chains/zetachain/metadata.yaml
@@ -17,6 +17,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: ZetaChain
 domainId: 7000
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: zetachain
 gnosisSafeTransactionServiceUrl: https://transaction.safe.zetachain.com
 name: zetachain
@@ -25,6 +26,7 @@ nativeToken:
   name: ZetaChain
   symbol: ZETA
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://zetachain-evm.blockpi.network/v1/rpc/public
   - http: https://zetachain-mainnet.g.allthatnode.com/archive/evm

--- a/chains/zircuit/metadata.yaml
+++ b/chains/zircuit/metadata.yaml
@@ -16,6 +16,7 @@ deployer:
   url: https://www.hyperlane.xyz
 displayName: Zircuit
 domainId: 48900
+fallbackHedgeDelayMillis: 250
 gasCurrencyCoinGeckoId: ethereum
 gnosisSafeTransactionServiceUrl: https://transaction.safe.zircuit.com
 name: zircuit
@@ -24,6 +25,7 @@ nativeToken:
   name: Ether
   symbol: ETH
 protocol: ethereum
+rpcConsensusType: fallback
 rpcUrls:
   - http: https://zircuit1-mainnet.p2pify.com
   - http: https://zircuit1-mainnet.liquify.com


### PR DESCRIPTION
Enables the #9395 fallback hedging path (monorepo) on 59 EVM mainnet chains with 2+ RPCs: `rpcConsensusType: fallback` (required by both SDK and Rust refinements) + `fallbackHedgeDelayMillis: 250`.

Notes for review:
- The consensus flip is the real behavior change here (quorum -> fallback for all reads); hedging only engages on allowlisted pinned reads slower than 250ms. Relayer/scraper roles already run fallback consensus in prod infra config.
- Timeout left at the 30s default.
- Excluded: testnets, deprecated chains, single-RPC chains.
- Follow-ups after merge: registry release -> monorepo registry bump -> agent restart (metadata is baked into helm values at deploy; no new image needed).
- Canary metrics (from #9395): p95 `fallback_hedge_duration_seconds`, `fallback_hedge_events_total{event="start"}` vs eligible completions for the extra-request ratio.