### PR TITLE
fix(metal): rotate RPC to drpc primary

### DIFF
--- a/.changeset/fix-metal-rpc.md
+++ b/.changeset/fix-metal-rpc.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+metal's rpcUrls were rotated to make https://metall2.drpc.org the primary endpoint, with the previous https://rpc.metall2.com kept as a fallback, after rpc.metall2.com stalled while drpc served a fresh tip.

--- a/chains/metal/metadata.yaml
+++ b/chains/metal/metadata.yaml
@@ -24,5 +24,6 @@ nativeToken:
   symbol: ETH
 protocol: ethereum
 rpcUrls:
+  - http: https://metall2.drpc.org
   - http: https://rpc.metall2.com
 technicalStack: opstack


### PR DESCRIPTION
## Summary
- `rpc.metall2.com` (metal's sole registry RPC) stalled — served a frozen tip ~54 min stale — while `https://metall2.drpc.org` served a fresh tip, triggering the "No new blocks observed metal" PagerDuty alert.
- Rotated metal's `rpcUrls` to make `https://metall2.drpc.org` the primary endpoint and kept `https://rpc.metall2.com` as a fallback, restoring redundancy for a previously single-RPC chain.

## Evidence
- `metall2.drpc.org` block tip fresh (age ~0s); `rpc.metall2.com` frozen at 38657119 (~54 min stale).
- Not a chain halt — the chain kept producing blocks; the default RPC endpoint was stuck.

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M20RPVZ2NQTVWTD2YP89QZ4M