### PR TITLE
fix: add resilient Starknet mainnet RPC fallbacks

### DIFF
--- a/.changeset/starknet-rpc-fallbacks.md
+++ b/.changeset/starknet-rpc-fallbacks.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Added resilient public RPC fallbacks for Starknet mainnet ahead of the discontinued Lava endpoint.

--- a/chains/metadata.yaml
+++ b/chains/metadata.yaml
@@ -8458,6 +8458,8 @@ starknet:
     symbol: STRK
   protocol: starknet
   rpcUrls:
+    - http: https://starknet-rpc.publicnode.com
+    - http: https://api.cartridge.gg/x/starknet/mainnet
     - http: https://rpc.starknet.lava.build:443/rpc/v0_9
   technicalStack: other
 starknetsepolia:

--- a/chains/starknet/metadata.yaml
+++ b/chains/starknet/metadata.yaml
@@ -24,5 +24,7 @@ nativeToken:
   symbol: STRK
 protocol: starknet
 rpcUrls:
+  - http: https://starknet-rpc.publicnode.com
+  - http: https://api.cartridge.gg/x/starknet/mainnet
   - http: https://rpc.starknet.lava.build:443/rpc/v0_9
 technicalStack: other


### PR DESCRIPTION
## Summary
- The sole configured Starknet **mainnet** RPC, `rpc.starknet.lava.build:443/rpc/v0_9`, has been **discontinued**. Direct probe returns `{"error":"This endpoint has been discontinued."}`.
- In production this manifests as intermittent `StarknetError(BlockNotFound)` (for already-advertised heads) and serde failures on malformed/non-JSON bodies (`expected value`, `data did not match any variant of untagged enum JsonRpcResponse`), which **wedge the relayer and validator contract-sync cursors**.
- Symptom: recurring low-urgency "No new blocks observed" PagerDuty alerts for `chain=starknet, mainnet3` (e.g. firing value `A=-1065` from a cursor regression). The scraper is excluded from that alert and keeps advancing, confirming the chain itself is healthy.

## Change
Added two healthy public fallbacks ahead of the discontinued Lava endpoint (both currently at chain head, JSON-RPC spec `0.10.2`):
- `https://starknet-rpc.publicnode.com` (publicnode is already used for starknet-sepolia in-org)
- `https://api.cartridge.gg/x/starknet/mainnet`

Lava is retained last as a soft fallback; it can be removed once the new endpoints are validated in production.

## Test plan
- [ ] Confirm mainnet3 relayer/validator pick up the new RPCs (redeploy/agent config refresh) and the starknet contract-sync cursor advances toward head
- [ ] Verify `hyperlane_contract_sync_block_height{chain="starknet",agent!="scraper"}` tracks the scraper again
- [ ] Confirm PagerDuty "No new blocks observed / starknet" stops recurring
- [ ] Optionally drop the discontinued Lava endpoint in a follow-up

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M21J5P3FKFAXFKGYNY2GVFAB