### PR TITLE
chore(USDT): disconnect plasma leg from Eclipse USD₮0 route

### DIFF
--- a/.changeset/disconnect-plasma-usdt-eclipse.md
+++ b/.changeset/disconnect-plasma-usdt-eclipse.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+disconnected the plasma leg from the USDT/eclipsemainnet warp route by emptying plasma's connections and removing plasma from every other token's connections.

--- a/deployments/warp_routes/USDT/eclipsemainnet-config.yaml
+++ b/deployments/warp_routes/USDT/eclipsemainnet-config.yaml
@@ -8,7 +8,6 @@ tokens:
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
       - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
-      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
@@ -27,7 +26,6 @@ tokens:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
       - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
-      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 18
@@ -45,7 +43,6 @@ tokens:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
-      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
@@ -61,7 +58,6 @@ tokens:
       - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
       - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
-      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
@@ -76,13 +72,7 @@ tokens:
     chainName: plasma
     coinGeckoId: tether
     collateralAddressOrDenom: "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb"
-    connections:
-      - token: ethereum|arbitrum|0x42B794FbF2Ae97d7E9001e21D36B0A5595B51B11
-      - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
-      - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
-      - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
-      - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
-      - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
+    connections: []
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
     name: USDT0
@@ -100,7 +90,6 @@ tokens:
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
       - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
-      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: tron|tron|0xbf8078818627110fD05827Ca0aa9E4518d3421ec
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg
@@ -116,7 +105,6 @@ tokens:
       - token: ethereum|bsc|0xc13d466B9E196AfdE472856923E857cc298EDf1b
       - token: sealevel|eclipsemainnet|5g5ujyYUNvdydwyDVCpZwPpgYRqH5RYJRi156cxyE3me
       - token: ethereum|ethereum|0x647C621CEb36853Ef6A907E397Adf18568E70543
-      - token: ethereum|plasma|0xa119087116aDC61ade063105644795cb7BC0009D
       - token: sealevel|solanamainnet|Bk79wMjvpPCh5iQcCEjPWFcG1V2TfgdwaBsWBEYFYSNU
     decimals: 6
     logoURI: /deployments/warp_routes/USDT/logo.svg


### PR DESCRIPTION
## Summary
First step of the Plasma chain deprecation for the Eclipse USD₮0 warp route (`USDT/eclipsemainnet`).

- Removes the `plasma` connection from every other USD₮0 leg (arbitrum, bsc, eclipsemainnet, ethereum, solanamainnet, tron).
- Empties the `plasma` leg's `connections` (`connections: []`) while **keeping** the plasma token entry in place.

The full removal of the plasma entry (config + deploy) and the monorepo config-getter change are handled in stacked follow-up PRs.

## Context
Plasma (chainId 9745) is slated for H2 2026 chain removal. The USD₮0 on Plasma is our own rebalanced collateral (no meaningful user traffic).