### PR TITLE
fix(registry): dedupe chainId 41455 for deprecatedalephzeroevm (temporary rebalancer unblock)

### DIFF
--- a/chains/deprecatedalephzeroevm/metadata.yaml
+++ b/chains/deprecatedalephzeroevm/metadata.yaml
@@ -10,7 +10,7 @@ blocks:
   confirmations: 1
   estimateBlockTime: 3
   reorgPeriod: 5
-chainId: 41455
+chainId: 41455000
 displayName: DEPRECATED Aleph Zero EVM
 displayNameShort: DEPRECATED Aleph Zero EVM
 domainId: 41455


### PR DESCRIPTION
## Why
`deprecatedalephzeroevm` and `alephzeroevmmainnet` both declare `chainId: 41455`. Newer rebalancer images (e.g. `3329eda-20260828`) added a strict unique-chainId assertion in `DeBridgeBridge` (`buildExternalBridgeRegistry`), so the USDT/eclipsemainnet rebalancer crashloops on startup with `Duplicate chain metadata for chain ID 41455`.

## What
Give the disabled/deprecated chain a distinct `chainId` (`41455000`) so external-bridge registry init no longer collides. The chain is `availability: {status: disabled, reasons: [deprecated]}` and is never used for routing, so the value is inconsequential functionally.

## Status — DRAFT / do not merge
Temporary unblock only. The correct fix is rebalancer-side: dedupe duplicate chainIds before constructing the bridge provider. This branch exists so we can point the USDT/eclipsemainnet rebalancer redeploy at it and drain the plasma leg.

Source: Slack incident thread https://hyperlaneworkspace.slack.com/archives/C08GHFP3214/p1789007032564609