### PR TITLE
fix: refresh supported chain block-time estimates

### DIFF
--- a/.changeset/refresh-supported-block-times.md
+++ b/.changeset/refresh-supported-block-times.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+updated block-time estimates for fifteen supported chains using current block history and network documentation, including sub-second intervals

--- a/chains/arbitrumsepolia/metadata.yaml
+++ b/chains/arbitrumsepolia/metadata.yaml
@@ -7,7 +7,7 @@ blockExplorers:
     url: https://sepolia.arbiscan.io
 blocks:
   confirmations: 1
-  estimateBlockTime: 3
+  estimateBlockTime: 0.25
   reorgPeriod: 0
 chainId: 421614
 deployer:

--- a/chains/avalanche/metadata.yaml
+++ b/chains/avalanche/metadata.yaml
@@ -7,7 +7,7 @@ blockExplorers:
     url: https://snowtrace.io
 blocks:
   confirmations: 3
-  estimateBlockTime: 2
+  estimateBlockTime: 1
   reorgPeriod: 3
 chainId: 43114
 deployer:

--- a/chains/bsc/metadata.yaml
+++ b/chains/bsc/metadata.yaml
@@ -7,7 +7,7 @@ blockExplorers:
     url: https://bscscan.com
 blocks:
   confirmations: 1
-  estimateBlockTime: 3
+  estimateBlockTime: 0.45
   reorgPeriod: finalized
 chainId: 56
 deployer:

--- a/chains/bsctestnet/metadata.yaml
+++ b/chains/bsctestnet/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
     url: https://testnet.bscscan.com
 blocks:
   confirmations: 1
-  estimateBlockTime: 3
+  estimateBlockTime: 0.45
   reorgPeriod: 9
 chainId: 97
 deployer:

--- a/chains/hyperevm/metadata.yaml
+++ b/chains/hyperevm/metadata.yaml
@@ -11,7 +11,7 @@ blockExplorers:
     url: https://www.hyperscan.com
 blocks:
   confirmations: 1
-  estimateBlockTime: 2
+  estimateBlockTime: 1
   reorgPeriod: 5
 chainId: 999
 deployer:

--- a/chains/hyperliquidevmtestnet/metadata.yaml
+++ b/chains/hyperliquidevmtestnet/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
     url: https://explorer.hyperlend.finance
 blocks:
   confirmations: 1
-  estimateBlockTime: 2
+  estimateBlockTime: 1
   reorgPeriod: 1
 chainId: 998
 deployer:

--- a/chains/monad/metadata.yaml
+++ b/chains/monad/metadata.yaml
@@ -11,7 +11,7 @@ blockExplorers:
     url: https://mainnet-beta.monvision.io
 blocks:
   confirmations: 1
-  estimateBlockTime: 1
+  estimateBlockTime: 0.3
   reorgPeriod: 1
 chainId: 143
 deployer:

--- a/chains/polygon/metadata.yaml
+++ b/chains/polygon/metadata.yaml
@@ -7,7 +7,7 @@ blockExplorers:
     url: https://polygonscan.com
 blocks:
   confirmations: 3
-  estimateBlockTime: 2
+  estimateBlockTime: 1.5
   reorgPeriod: finalized
 chainId: 137
 deployer:

--- a/chains/polygonamoy/metadata.yaml
+++ b/chains/polygonamoy/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
     url: https://amoy.polygonscan.com
 blocks:
   confirmations: 5
-  estimateBlockTime: 2
+  estimateBlockTime: 1
   reorgPeriod: 10
 chainId: 80002
 deployer:

--- a/chains/robinhood/metadata.yaml
+++ b/chains/robinhood/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
     url: https://explorer.chain.robinhood.com
 blocks:
   confirmations: 1
-  estimateBlockTime: 1
+  estimateBlockTime: 0.1
   reorgPeriod: 5
 chainId: 4663
 deployer:

--- a/chains/sei/metadata.yaml
+++ b/chains/sei/metadata.yaml
@@ -10,7 +10,7 @@ blockExplorers:
     url: https://seitrace.com
 blocks:
   confirmations: 1
-  estimateBlockTime: 1
+  estimateBlockTime: 0.4
   reorgPeriod: 1
 chainId: 1329
 deployer:

--- a/chains/somnia/metadata.yaml
+++ b/chains/somnia/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
     url: https://explorer.somnia.network
 blocks:
   confirmations: 1
-  estimateBlockTime: 1
+  estimateBlockTime: 0.1
   reorgPeriod: 10
 chainId: 5031
 deployer:

--- a/chains/somniatestnet/metadata.yaml
+++ b/chains/somniatestnet/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
     url: https://shannon-explorer.somnia.network
 blocks:
   confirmations: 1
-  estimateBlockTime: 1
+  estimateBlockTime: 0.1
   reorgPeriod: 1
 chainId: 50312
 deployer:

--- a/chains/taiko/metadata.yaml
+++ b/chains/taiko/metadata.yaml
@@ -10,7 +10,7 @@ blockExplorers:
     url: https://taikoscan.io
 blocks:
   confirmations: 1
-  estimateBlockTime: 12
+  estimateBlockTime: 2
   reorgPeriod: 5
 chainId: 167000
 deployer:

--- a/chains/xlayer/metadata.yaml
+++ b/chains/xlayer/metadata.yaml
@@ -6,7 +6,7 @@ blockExplorers:
     url: https://www.oklink.com/xlayer
 blocks:
   confirmations: 1
-  estimateBlockTime: 10
+  estimateBlockTime: 1
   reorgPeriod: 5
 chainId: 196
 deployer:


### PR DESCRIPTION
Updated 15 supported-chain block-time estimates after auditing all 77 mainnets and 13 testnets against registry main. The schema already accepts fractional seconds. Related polling change: hyperlane-xyz/hyperlane-monorepo#9617.

| Chain | Before s | Proposed s | 100k-block mean s | Evidence |
| --- | ---: | ---: | ---: | --- |
| avalanche | 2 | 1 | 1.05412 | [Primary docs](https://build.avax.network/blog/granite-upgrade); RPC history |
| bsc | 3 | 0.45 | 0.45059 | [Primary docs](https://docs.bnbchain.org/announce/fermi-bsc/); RPC history |
| hyperevm | 2 | 1 | 0.9836 | [Primary docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture); RPC history |
| monad | 1 | 0.3 | 0.30198 | [Primary docs](https://docs.monad.xyz/developer-essentials/changelog/releases); RPC history |
| polygon | 2 | 1.5 | 1.5 | [Primary docs](https://polygon.technology/blog/polygon-chain-now-supports-5000-payments-per-second-hitting-the-speed-of-a-card-network-at-a-fraction-of-the-cost); RPC history |
| robinhood | 1 | 0.1 | 0.1008 | [Primary docs](https://research.arbitrum.io/t/the-power-of-faster-blocks/9609); RPC history; fixed-time history |
| sei | 1 | 0.4 | 0.46834 | [Primary docs](https://docs.sei.io/evm/differences-with-ethereum); RPC history |
| somnia | 1 | 0.1 | 0.10007 | [Primary docs](https://docs.somnia.network/concepts/tokenomics/gas-fees); RPC history |
| taiko | 12 | 2 | 2.02404 | RPC history |
| xlayer | 10 | 1 | 1 | [Primary docs](https://web3.okx.com/learn/flashblocks-on-x-layer); RPC history |
| arbitrumsepolia | 3 | 0.25 | 0.24944 | [Primary docs](https://research.arbitrum.io/t/the-power-of-faster-blocks/9609); RPC history; fixed-time history |
| bsctestnet | 3 | 0.45 | 0.45002 | [Primary docs](https://docs.bnbchain.org/announce/fermi-bsc/); RPC history |
| hyperliquidevmtestnet | 2 | 1 | 0.98361 | [Primary docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture); RPC history |
| polygonamoy | 2 | 1 | 1.001 | RPC history |
| somniatestnet | 1 | 0.1 | 0.10002 | [Primary docs](https://docs.somnia.network/concepts/tokenomics/gas-fees); RPC history |

Measured on 2026-09-10, around 15:34–15:37 UTC. RPC estimates use timestamp differences over 1k/10k/100k block intervals; Nitro also uses fixed wall-clock windows. Primary documentation supports nominal values where cited. Avalanche and Taiko use rounded longer-window observations, not fixed protocol guarantees. Testnet values were sampled independently.

Base remains 2s (200ms Flashblocks are preconfirmations); MegaETH remains 1s (10ms mini-blocks are distinct). Sparse Nitro networks retain their active-cadence estimates: idle-inclusive averages must not become polling targets. Confirmation counts and reorg periods are unchanged. This field also affects SDK timeout/retry calculations; this is not runtime rollout proof.

Validation: registry build and TypeScript compilation passed; all 15 changed metadata files passed the published SDK ChainMetadataSchema, and a synthetic Base 0.2s value also passed. Patch changeset included.

<details>
<summary>Full 90-chain audit and Nitro history</summary>

| Chain | Configured s | Last hour s/block (count) | Last 24h s/block (count) | Last 7d s/block (count) |
| --- | ---: | ---: | ---: | ---: |
| apechain | 0.2 | 0.89419 (4026) | 0.87959 (98228) | 0.8816 (686022) |
| arbitrum | 0.25 | 0.25207 (14282) | 0.25171 (343247) | 0.25317 (2388926) |
| carrchain | 1 | — (0) | 3927.27273 (22) | 2122.10526 (285) |
| galactica | 1 | 171.42857 (21) | 215.46135 (401) | 214.31609 (2822) |
| robinhood | 1 | 0.10092 (35671) | 0.10086 (856603) | 0.10098 (5989125) |
| arbitrumsepolia | 3 | 0.24929 (14441) | 0.24965 (346078) | 0.24873 (2431531) |

| Chain | Protocol | Registry s | Recent observed s | 10k-block mean s | 100k-block mean s | Proposed s | Notes |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| **mainnet3** | | | | | | | |
| [abstract](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/abstract/metadata.yaml) | ethereum | 1 | 0.55 | 0.5477 | 0.68994 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [adichain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/adichain/metadata.yaml) | ethereum | 1 | 6.857 | 3.0529 | 4.23725 | — | History varies ~3–7s vs configured 1s; defer nominal target correction. |
| [aleo](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/aleo/metadata.yaml) | aleo | 3 | 2.979 | — | — | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [apechain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/apechain/metadata.yaml) | ethereum | 0.2 | 1.074 | 0.8577 | 0.87909 | — | On demand: 0.2s configured minimum vs ~0.88s idle-inclusive recent mean; retain active estimate pending chain-specific sequencer config. |
| [arbitrum](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/arbitrum/metadata.yaml) | ethereum | 0.25 | 0.254 | 0.2523 | 0.25067 | — | Keep 0.25s active cadence; 1h/24h/7d corroborate. [Docs](https://research.arbitrum.io/t/the-power-of-faster-blocks/9609) |
| [arc](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/arc/metadata.yaml) | ethereum | 1 | 0.5059 | — | — | — | Public endpoints unavailable, but mainnet3 private RPC returned matching chain ID, fresh head, and 0.5059s over 10k blocks; confirm nominal target before editing. |
| [avalanche](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/avalanche/metadata.yaml) | ethereum | 2 | 1.062 | 1.0632 | 1.05412 | 1 | Set rounded 1s estimate from 1k/10k/100k history (~1.05s); Granite makes minimum cadence dynamic, not a fixed 1s guarantee. [Docs](https://build.avax.network/blog/granite-upgrade) |
| [base](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/base/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Keep 2s sealed blocks; 200ms Flashblocks are preconfirmations. [Docs](https://docs.base.org/base-chain/api-reference/rpc-overview) |
| [berachain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/berachain/metadata.yaml) | ethereum | 2 | 1.995 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [blast](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/blast/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [bob](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/bob/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [bsc](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/bsc/metadata.yaml) | ethereum | 3 | 0.45 | 0.45 | 0.45059 | 0.45 | Update supported by current history and cited documentation. [Docs](https://docs.bnbchain.org/announce/fermi-bsc/) |
| [carrchain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/carrchain/metadata.yaml) | ethereum | 1 | 1924.864 | 559.1172 | 81.84033 | — | On demand/sparse: zero blocks in last hour; do not turn an idle-inclusive mean into a polling interval. |
| [celestia](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/celestia/metadata.yaml) | cosmosnative | 6 | 2.84898 | — | — | — | Observed ~2.85s vs configured 6s; non-EVM target needs protocol-specific confirmation. |
| [celo](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/celo/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [citrea](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/citrea/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [coti](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/coti/metadata.yaml) | ethereum | 5 | 5 | 5 | 5 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [eclipsemainnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/eclipsemainnet/metadata.yaml) | sealevel | 0.4 | 0.35156 | — | — | — | Produced-block sample, not nominal slot duration; retain pending longer protocol-specific analysis. |
| [eden](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/eden/metadata.yaml) | ethereum | 1 | 0.103 | 0.102 | 0.10342 | — | Observed ~0.103s vs configured 1s; confirm chain-specific target before editing. |
| [electroneum](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/electroneum/metadata.yaml) | ethereum | 5 | 5 | 5 | 5 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [eni](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/eni/metadata.yaml) | ethereum | 1 | 1.03 | 1.023 | 1.02508 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [ethereum](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/ethereum/metadata.yaml) | ethereum | 13 | 12.048 | — | 12.04464 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [fluent](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/fluent/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [forma](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/forma/metadata.yaml) | ethereum | 3 | 2.108 | 2.1076 | 2.1071 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [fraxtal](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/fraxtal/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [galactica](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/galactica/metadata.yaml) | ethereum | 1 | 234.3 | 199.2963 | 182.97963 | — | On demand/sparse: retain estimate pending chain-specific active cadence; explorer confirms long idle-inclusive average. |
| [gnosis](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/gnosis/metadata.yaml) | ethereum | 5 | 5.065 | 5.094 | 5.08815 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [hyperevm](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/hyperevm/metadata.yaml) | ethereum | 2 | 0.984 | 0.9836 | 0.9836 | 1 | Set 1s fast blocks; interleaved 60s big blocks explain aggregate ~0.984s. This is not the inclusion wait for big-block transactions. [Docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture) |
| [igra](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/igra/metadata.yaml) | ethereum | 1 | 1.037 | 1.0367 | 1.04494 | — | Public and private RPC heads ~13 minutes old at sample time; cadence from historical blocks only, not a fresh liveness proof. |
| [ink](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/ink/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [katana](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/katana/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [kiichain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/kiichain/metadata.yaml) | ethereum | 2 | 2.356 | 2.3517 | 2.34962 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [krown](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/krown/metadata.yaml) | ethereum | 12 | 12.06 | 12.0252 | 12.00876 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [kyve](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/kyve/metadata.yaml) | cosmosnative | 6 | 5.60431 | — | — | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [lazai](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/lazai/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [linea](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/linea/metadata.yaml) | ethereum | 3 | 7.047 | 8.5799 | 8.60723 | — | History ~7–9s vs configured 3s; variable/load-sensitive, defer nominal target correction. |
| [lisk](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/lisk/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [lukso](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/lukso/metadata.yaml) | ethereum | 12 | 12.948 | 12.8472 | 13.07328 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [mantle](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/mantle/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [mantra](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/mantra/metadata.yaml) | ethereum | 3 | 3.284 | 3.2848 | 3.31187 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [megaeth](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/megaeth/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Keep 1s EVM blocks; ~10ms mini-blocks are a distinct RPC/streaming concept. [Docs](https://docs.megaeth.com/mini-block) |
| [metal](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/metal/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [metis](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/metis/metadata.yaml) | ethereum | 5 | 16.42 | 22.1381 | 25.84188 | — | History ~16–26s vs configured 5s; variable/load-sensitive, defer nominal target correction. |
| [mitosis](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/mitosis/metadata.yaml) | ethereum | 2 | 1.761 | 1.7563 | 1.7538 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [mocachain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/mocachain/metadata.yaml) | ethereum | 1 | 0.828 | 0.8258 | 0.8271 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [mode](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/mode/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [monad](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/monad/metadata.yaml) | ethereum | 1 | 0.302 | 0.3018 | 0.30198 | 0.3 | Set 0.3s. July 23 mainnet v0.15.1 activates MIP-12; older 400ms overview is outdated. [Docs](https://docs.monad.xyz/developer-essentials/changelog/releases) |
| [nesa](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/nesa/metadata.yaml) | ethereum | 2 | — | — | — | — | Retired per operator confirmation; public and mainnet3 private RPC attempts failed. Distinct from live nesachain, which was measured. Removal from supported inventory is outside this timing PR. |
| [nesachain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/nesachain/metadata.yaml) | ethereum | 2 | 5.319 | 5.3273 | 5.34877 | — | Observed ~5.35s vs configured 2s; verify target rather than pinning a short-term mean. |
| [nexus](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/nexus/metadata.yaml) | ethereum | 1 | 1.177 | 1.1762 | 1.17517 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [optimism](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/optimism/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [paradex](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/paradex/metadata.yaml) | starknet | 30 | 43.776 | — | — | — | Observed ~44s vs configured 30s; variable and non-EVM, not affected by ethers builder. |
| [plasma](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/plasma/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [polygon](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/polygon/metadata.yaml) | ethereum | 2 | 1.5 | 1.5 | 1.5 | 1.5 | Update supported by current history and cited documentation. [Docs](https://polygon.technology/blog/polygon-chain-now-supports-5000-payments-per-second-hitting-the-speed-of-a-card-network-at-a-fraction-of-the-cost) |
| [pulsechain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/pulsechain/metadata.yaml) | ethereum | 10 | 10.25 | 10.285 | 10.2906 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [radix](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/radix/metadata.yaml) | radix | 5 | — | — | — | — | Not a conventional block chain: Babylon exposes a committed transaction stream and state versions; do not estimate block time from state-version growth. [Docs](https://docs.radixdlt.com/docs/concepts-consensus-ledger-forks-blocks-and-trust-chains/) |
| [robinhood](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/robinhood/metadata.yaml) | ethereum | 1 | 0.102 | 0.101 | 0.1008 | 0.1 | Set 0.1s observed active cadence, corroborated over 1h/24h/7d. Do not generalize this value to other Nitro chains. [Docs](https://research.arbitrum.io/t/the-power-of-faster-blocks/9609) |
| [sei](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/sei/metadata.yaml) | ethereum | 1 | 0.466 | 0.4666 | 0.46834 | 0.4 | Set documented 0.4s target; observed ~0.47s includes consensus overhead. [Docs](https://docs.sei.io/evm/differences-with-ethereum) |
| [solanamainnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/solanamainnet/metadata.yaml) | sealevel | 0.4 | 0.31311 | — | — | — | Produced-block sample, not nominal slot duration; retain pending longer protocol-specific analysis. |
| [solaxy](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/solaxy/metadata.yaml) | sealevel | 1.2 | 2.84961 | — | — | — | Observed produced-block average ~2.85s vs configured 1.2s; separate slot and produced-block timing before editing. |
| [somnia](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/somnia/metadata.yaml) | ethereum | 1 | 0.101 | 0.1002 | 0.10007 | 0.1 | Update supported by current history and cited documentation. [Docs](https://docs.somnia.network/concepts/tokenomics/gas-fees) |
| [soneium](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/soneium/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [sonic](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/sonic/metadata.yaml) | ethereum | 2 | 1.774 | 1.4706 | 1.69601 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [sonicsvm](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/sonicsvm/metadata.yaml) | sealevel | 0.4 | 0.4043 | — | — | — | Produced-block sample, not nominal slot duration; retain pending longer protocol-specific analysis. |
| [stable](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/stable/metadata.yaml) | ethereum | 1 | 0.702 | 0.7014 | 0.70067 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [starknet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/starknet/metadata.yaml) | starknet | 30 | 1.715 | — | — | — | Observed ~1.7s vs configured 30s; non-EVM, not affected by ethers builder. Strong separate follow-up candidate; confirm current adaptive block target. |
| [subtensor](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/subtensor/metadata.yaml) | ethereum | 12 | 12.048 | 12.0204 | 12.0096 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [tac](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/tac/metadata.yaml) | ethereum | 1 | 1.58 | 1.5948 | 1.58938 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [taiko](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/taiko/metadata.yaml) | ethereum | 12 | 2.024 | 2.0248 | 2.02404 | 2 | Set rounded 2s estimate from consistent 1k/10k/100k history (~2.024s); empirical estimate, not a protocol guarantee. |
| [tea](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/tea/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [tron](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/tron/metadata.yaml) | tron | 3 | 3 | — | — | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [unichain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/unichain/metadata.yaml) | ethereum | 1 | 1 | 1 | 1 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [viction](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/viction/metadata.yaml) | ethereum | 2 | 2.034 | 2.0558 | 2.05366 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [worldchain](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/worldchain/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [xlayer](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/xlayer/metadata.yaml) | ethereum | 10 | 1 | 1 | 1 | 1 | Set 1s full blocks; 200ms Flashblocks are distinct. Registry technicalStack also appears stale (polygoncdk vs current OP Stack); not changed in this timing PR. [Docs](https://web3.okx.com/learn/flashblocks-on-x-layer) |
| [zerogravity](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/zerogravity/metadata.yaml) | ethereum | 0.4 | 1.046 | 1.0461 | 1.04829 | — | Observed ~1.048s vs configured 0.4s; confirm consensus target vs realized cadence. |
| [zksync](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/zksync/metadata.yaml) | ethereum | 1 | 7.18 | 7.2557 | 7.13134 | — | History ~7s vs configured 1s; investigate empty-block/traffic behavior before changing active target. |
| **testnet4** | | | | | | | |
| [aleotestnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/aleotestnet/metadata.yaml) | aleo | 3 | 2.941 | — | — | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [arbitrumsepolia](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/arbitrumsepolia/metadata.yaml) | ethereum | 3 | 0.25 | 0.2491 | 0.24944 | 0.25 | Set 0.25s; independently sampled testnet over 1h/24h/7d. [Docs](https://research.arbitrum.io/t/the-power-of-faster-blocks/9609) |
| [basesepolia](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/basesepolia/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Keep 2s sealed blocks; same Flashblocks distinction. |
| [bsctestnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/bsctestnet/metadata.yaml) | ethereum | 3 | 0.45 | 0.45 | 0.45002 | 0.45 | Update supported by current history and cited documentation. [Docs](https://docs.bnbchain.org/announce/fermi-bsc/) |
| [hyperliquidevmtestnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/hyperliquidevmtestnet/metadata.yaml) | ethereum | 2 | 0.984 | 0.9836 | 0.98361 | 1 | Set 1s fast blocks; independently sampled testnet agrees. [Docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture) |
| [optimismsepolia](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/optimismsepolia/metadata.yaml) | ethereum | 2 | 2 | 2 | 2 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [polygonamoy](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/polygonamoy/metadata.yaml) | ethereum | 2 | 1.002 | 1.0004 | 1.001 | 1 | Set 1s from independently sampled Amoy history; do not copy mainnet 1.5s. |
| [seismictestnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/seismictestnet/metadata.yaml) | ethereum | 1 | 0.22915 | 0.22858 | 0.22839 | — | Headers expose millisecond timestamps; normalized to seconds. ~0.228s observed, but defer nominal target until network-specific config is verified. [Docs](https://docs.seismic.systems/core/differences-from-ethereum) |
| [sepolia](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/sepolia/metadata.yaml) | ethereum | 13 | 12.372 | 12.3708 | 12.45744 | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |
| [solanadevnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/solanadevnet/metadata.yaml) | sealevel | 0.4 | 0.16602 | — | — | — | Produced-block sample, not nominal slot duration; retain pending longer protocol-specific analysis. |
| [solanatestnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/solanatestnet/metadata.yaml) | sealevel | 0.4 | 0.27476 | — | — | — | Endpoint returned finalized history roughly 53h old: historical sample only, not evidence of current network cadence. |
| [somniatestnet](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/somniatestnet/metadata.yaml) | ethereum | 1 | 0.101 | 0.1 | 0.10002 | 0.1 | Update supported by current history and cited documentation. [Docs](https://docs.somnia.network/concepts/tokenomics/gas-fees) |
| [tronshasta](https://github.com/hyperlane-xyz/hyperlane-registry/blob/d61a31f67ec2bc77a1fbefa7d138862e2e127b04/chains/tronshasta/metadata.yaml) | tron | 3 | 3.03 | — | — | — | Retain. Measured cadence recorded; no independently established nominal-target correction in this PR. |

Full evidence uses monorepo fbbb9329eab94610a404a106e31ac90a2f0b2dd0 and registry d61a31f67ec2bc77a1fbefa7d138862e2e127b04. Measurements are endpoint observations, not a multi-provider quorum. SVM figures describe produced blocks over a short finalized slot window; Solana testnet and Igra samples have stale heads. Arc was resolved using mainnet3 private RPC (fresh matching-chain head, 0.5059s over 10k blocks). Nesa yielded no sample; nesachain is a distinct live chain. No availability/deprecation metadata was changed. Private checks at 15:45 UTC corroborated Linea, zkSync, Metis and the stale Igra head. Radix state versions are transactions, not blocks. No fixed-target claim is made for deferred chains.

</details>
