### PR TITLE
fix(sonicsvm): replace dead RPC with healthy quorum backends

### DIFF
--- a/.changeset/fix-sonicsvm-rpc.md
+++ b/.changeset/fix-sonicsvm-rpc.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/registry': patch
+---
+
+Replaced dead sonicsvm RPC with healthy quorum backends (official mainnet-alpha plus Helius fallback).

--- a/chains/sonicsvm/metadata.yaml
+++ b/chains/sonicsvm/metadata.yaml
@@ -23,5 +23,6 @@ nativeToken:
   symbol: SOL
 protocol: sealevel
 rpcUrls:
-  - http: https://api.mainnet-alpha.sonic.game
+  - http: https://rpc.mainnet-alpha.sonic.game
+  - http: https://sonic.helius-rpc.com
 technicalStack: other

--- a/chains/sonicsvm/metadata.yaml
+++ b/chains/sonicsvm/metadata.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../schema.json
 blockExplorers:
-  - apiUrl: https://explorer.sonic.game/?cluster=custom&customUrl=https%3A%2F%2Fapi.mainnet-alpha.sonic.game
+  - apiUrl: https://explorer.sonic.game/?cluster=custom&customUrl=https%3A%2F%2Frpc.mainnet-alpha.sonic.game
     family: other
     name: Sonic SVM Explorer
-    url: https://explorer.sonic.game/?cluster=custom&customUrl=https%3A%2F%2Fapi.mainnet-alpha.sonic.game
+    url: https://explorer.sonic.game/?cluster=custom&customUrl=https%3A%2F%2Frpc.mainnet-alpha.sonic.game
 blocks:
   confirmations: 1
   estimateBlockTime: 0.4


### PR DESCRIPTION
## Summary
`sonicsvm` had a single configured `rpcUrl` (`https://api.mainnet-alpha.sonic.game`) which is currently down — TLS handshake completes but HTTP requests hang and time out (HTTP 000, 0 bytes after 8s, consistent across retries). With one effective RPC that is also dead, the validator's QuorumProvider cannot form quorum, which fired the low-urgency **Validator RPC Quorum Risk** alert for `sonicsvm` (PagerDuty Q3PZHJVCIF897O).

The chain itself is healthy. This swaps the dead endpoint for two confirmed-healthy independent providers so the pool has durable quorum redundancy (addresses ENG-603 for this chain):

- `https://rpc.mainnet-alpha.sonic.game` — official Sonic mainnet-alpha (getHealth `ok`, solana-core 2.3.0, slot advancing)
- `https://sonic.helius-rpc.com` — Helius Sonic endpoint (getHealth `ok`)

Both return genesis hash `9qoRTAHGWBZHYzMJGkt62wBbFRASj6H7CvoNsNyRw2h4`, confirming the same network as the configured `mainnet-alpha` endpoint.

## Verification
- Dead: `api.mainnet-alpha.sonic.game` → HTTP 000 / 8s timeout, repeated.
- Healthy: `rpc.mainnet-alpha.sonic.game` + `sonic.helius-rpc.com` → `getHealth: ok`, matching genesis, slot 125,757,306 → 125,757,338 advancing.
- No delivery/signing impact observed; relayer-observed validator index flat (consistent with low sonicsvm traffic).

## Test plan
- [ ] Registry CI passes (schema + lint)
- [ ] After merge, confirm agents pick up the new RPCs and the quorum-risk alert clears

Relates to ENG-603 (chains with fallback capability should have >1 RPC).

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M29817X3CYP2D3TMV35JYTX8